### PR TITLE
[DO NOT MERGE] Strict Building

### DIFF
--- a/src/ripple/app/hook/Enum.h
+++ b/src/ripple/app/hook/Enum.h
@@ -1,5 +1,7 @@
 #include <set>
 #include <string>
+#include <map>
+#include <vector>
 #ifndef HOOKENUM_INCLUDED
 #define HOOKENUM_INCLUDED 1
 namespace ripple

--- a/src/ripple/app/hook/impl/applyHook.cpp
+++ b/src/ripple/app/hook/impl/applyHook.cpp
@@ -1,22 +1,27 @@
 #include <ripple/app/hook/applyHook.h>
+#include <ripple/app/ledger/OpenLedger.h>
+#include <ripple/app/ledger/TransactionMaster.h>
+#include <ripple/app/misc/HashRouter.h>
+#include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/app/misc/Transaction.h>
+#include <ripple/app/misc/TxQ.h>
+#include <ripple/app/tx/impl/Import.h>
+#include <ripple/app/tx/impl/details/NFTokenUtils.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/Slice.h>
-#include <ripple/app/misc/Transaction.h>
 #include <ripple/protocol/ErrorCodes.h>
-#include <ripple/app/ledger/TransactionMaster.h>
-#include <ripple/app/ledger/OpenLedger.h>
-#include <ripple/app/misc/TxQ.h>
-#include <ripple/app/misc/NetworkOPs.h>
-#include <memory>
-#include <string>
-#include <optional>
-#include <any>
-#include <vector>
-#include <utility>
-#include <wasmedge/wasmedge.h>
+#include <ripple/protocol/TxFlags.h>
+#include <ripple/protocol/st.h>
 #include <ripple/protocol/tokens.h>
 #include <boost/multiprecision/cpp_dec_float.hpp>
+#include <any>
 #include <cfenv>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+#include <wasmedge/wasmedge.h>
 
 using namespace ripple;
 

--- a/src/ripple/app/misc/NegativeUNLVote.cpp
+++ b/src/ripple/app/misc/NegativeUNLVote.cpp
@@ -19,6 +19,7 @@
 
 #include <ripple/app/consensus/RCLValidations.h>
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/main/Application.h>
 #include <ripple/app/misc/NegativeUNLVote.h>
 
 namespace ripple {
@@ -150,7 +151,7 @@ NegativeUNLVote::addReportingTx(
             JLOG(j_.debug()) << "R-UNL: ledger seq=" << seq
                              << ", add a ttUNL_REPORT (active_val) Tx with txID: " << txID
                              << ", size=" << s.size()
-                             << ", " << repUnlTx.getJson(JsonOptions::none);
+                             << ", " << repUnlTx.getJson(JsonOptions::none).toStyledString();
         }
     }
 
@@ -185,7 +186,7 @@ NegativeUNLVote::addReportingTx(
             JLOG(j_.debug()) << "R-UNL: ledger seq=" << seq
                              << ", add a ttUNL_REPORT (import_vl) Tx with txID: " << txID
                              << ", size=" << s.size()
-                             << ", " << repUnlTx.getJson(JsonOptions::none);
+                             << ", " << repUnlTx.getJson(JsonOptions::none).toStyledString();
         }
     }
 

--- a/src/ripple/app/tx/impl/ClaimReward.cpp
+++ b/src/ripple/app/tx/impl/ClaimReward.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/tx/impl/ClaimReward.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>

--- a/src/ripple/app/tx/impl/GenesisMint.cpp
+++ b/src/ripple/app/tx/impl/GenesisMint.cpp
@@ -23,6 +23,7 @@
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/app/tx/impl/Import.h>
+#include <ripple/protocol/st.h>
 
 namespace ripple {
 

--- a/src/ripple/app/tx/impl/Import.cpp
+++ b/src/ripple/app/tx/impl/Import.cpp
@@ -17,23 +17,24 @@
 */
 //==============================================================================
 
-#include <ripple/protocol/Import.h>
+#include <ripple/app/misc/Manifest.h>
 #include <ripple/app/tx/impl/Import.h>
+#include <ripple/app/tx/impl/SetSignerList.h>
 #include <ripple/basics/Log.h>
+#include <ripple/basics/base64.h>
+#include <ripple/json/json_reader.h>
+#include <ripple/json/json_value.h>
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Feature.h>
+#include <ripple/protocol/Import.h>
 #include <ripple/protocol/Indexes.h>
-#include <iostream>
-#include <algorithm>
-#include <vector>
-#include <charconv>
-#include <ripple/json/json_value.h>
-#include <ripple/json/json_reader.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/STTx.h>
-#include <ripple/basics/base64.h>
-#include <ripple/app/misc/Manifest.h>
-#include <ripple/app/tx/impl/SetSignerList.h>
+#include <ripple/protocol/st.h>
+#include <algorithm>
+#include <charconv>
+#include <iostream>
+#include <vector>
 
 namespace ripple {
 
@@ -63,11 +64,13 @@ Import::makeTxConsequences(PreflightContext const& ctx)
     return TxConsequences{ctx.tx, calculate(ctx)};
 }
 
-
 std::pair<
-    std::unique_ptr<STTx const>,            // txn
-    std::unique_ptr<STObject const>>        // meta
-Import::getInnerTxn(STTx const& outer, beast::Journal const& j,Json::Value const* xpop)
+    std::unique_ptr<STTx const>,      // txn
+    std::unique_ptr<STObject const>>  // meta
+Import::getInnerTxn(
+    STTx const& outer,
+    beast::Journal const& j,
+    Json::Value const* xpop)
 {
     // parse blob as json
 

--- a/src/ripple/app/tx/impl/Invoke.cpp
+++ b/src/ripple/app/tx/impl/Invoke.cpp
@@ -22,6 +22,7 @@
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/st.h>
 
 namespace ripple {
 

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -24,7 +24,6 @@
 #include <ripple/app/tx/impl/SignerEntries.h>
 #include <ripple/app/tx/impl/Transactor.h>
 #include <ripple/basics/Log.h>
-#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/Rules.h>
 #include <ripple/protocol/STArray.h>
@@ -71,6 +70,18 @@ public:
         ApplyView& view,
         AccountID const& account,
         beast::Journal j);
+
+    static TER
+    removeSignersFromLedger(
+        Application& app,
+        ApplyView& view,
+        Keylet const& accountKeylet,
+        Keylet const& ownerDirKeylet,
+        Keylet const& signerListKeylet,
+        beast::Journal j);
+
+    static int
+    signerCountBasedOwnerCountDelta(std::size_t entryCount, Rules const& rules);
 
 private:
     static

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -23,12 +23,16 @@
 #include <ripple/app/tx/impl/CancelOffer.h>
 #include <ripple/app/tx/impl/CashCheck.h>
 #include <ripple/app/tx/impl/Change.h>
+#include <ripple/app/tx/impl/ClaimReward.h>
 #include <ripple/app/tx/impl/CreateCheck.h>
 #include <ripple/app/tx/impl/CreateOffer.h>
 #include <ripple/app/tx/impl/CreateTicket.h>
 #include <ripple/app/tx/impl/DeleteAccount.h>
 #include <ripple/app/tx/impl/DepositPreauth.h>
 #include <ripple/app/tx/impl/Escrow.h>
+#include <ripple/app/tx/impl/GenesisMint.h>
+#include <ripple/app/tx/impl/Import.h>
+#include <ripple/app/tx/impl/Invoke.h>
 #include <ripple/app/tx/impl/NFTokenAcceptOffer.h>
 #include <ripple/app/tx/impl/NFTokenBurn.h>
 #include <ripple/app/tx/impl/NFTokenCancelOffer.h>
@@ -37,14 +41,12 @@
 #include <ripple/app/tx/impl/PayChan.h>
 #include <ripple/app/tx/impl/Payment.h>
 #include <ripple/app/tx/impl/SetAccount.h>
+#include <ripple/app/tx/impl/SetHook.h>
 #include <ripple/app/tx/impl/SetRegularKey.h>
 #include <ripple/app/tx/impl/SetSignerList.h>
 #include <ripple/app/tx/impl/SetTrust.h>
-#include <ripple/app/tx/impl/SetHook.h>
-#include <ripple/app/tx/impl/Import.h>
-#include <ripple/app/tx/impl/Invoke.h>
 #include <ripple/app/tx/impl/URIToken.h>
-#include <ripple/app/tx/impl/GenesisMint.h>
+#include <ripple/app/tx/impl/XahauGenesis.h>
 
 namespace ripple {
 

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -145,111 +145,78 @@ private:
     };
 
     // VFALCO TODO This should only be enabled for maps.
-    class pair_value_compare
-        : public beast::detail::empty_base_optimization<Compare>
-#ifdef _LIBCPP_VERSION
-        ,
-          public std::binary_function<value_type, value_type, bool>
-#endif
+    class pair_value_compare : public Compare
     {
     public:
-#ifndef _LIBCPP_VERSION
         using first_argument = value_type;
         using second_argument = value_type;
         using result_type = bool;
-#endif
 
         bool
         operator()(value_type const& lhs, value_type const& rhs) const
         {
-            return this->member()(lhs.first, rhs.first);
+            return Compare::operator()(lhs.first, rhs.first);
         }
 
         pair_value_compare()
         {
         }
 
-        pair_value_compare(pair_value_compare const& other)
-            : beast::detail::empty_base_optimization<Compare>(other)
+        pair_value_compare(pair_value_compare const& other) : Compare(other)
         {
         }
 
     private:
         friend aged_ordered_container;
 
-        pair_value_compare(Compare const& compare)
-            : beast::detail::empty_base_optimization<Compare>(compare)
+        pair_value_compare(Compare const& compare) : Compare(compare)
         {
         }
     };
 
     // Compares value_type against element, used in insert_check
     // VFALCO TODO hoist to remove template argument dependencies
-    class KeyValueCompare
-        : public beast::detail::empty_base_optimization<Compare>
-#ifdef _LIBCPP_VERSION
-        ,
-          public std::binary_function<Key, element, bool>
-#endif
+    class KeyValueCompare : public Compare
     {
     public:
-#ifndef _LIBCPP_VERSION
         using first_argument = Key;
         using second_argument = element;
         using result_type = bool;
-#endif
 
         KeyValueCompare() = default;
 
-        KeyValueCompare(Compare const& compare)
-            : beast::detail::empty_base_optimization<Compare>(compare)
+        KeyValueCompare(Compare const& compare) : Compare(compare)
         {
         }
-
-        // VFALCO NOTE WE might want only to enable these overloads
-        //                if Compare has is_transparent
-#if 0
-        template <class K>
-        bool operator() (K const& k, element const& e) const
-        {
-            return this->member() (k, extract (e.value));
-        }
-
-        template <class K>
-        bool operator() (element const& e, K const& k) const
-        {
-            return this->member() (extract (e.value), k);
-        }
-#endif
 
         bool
         operator()(Key const& k, element const& e) const
         {
-            return this->member()(k, extract(e.value));
+            return Compare::operator()(k, extract(e.value));
         }
 
         bool
         operator()(element const& e, Key const& k) const
         {
-            return this->member()(extract(e.value), k);
+            return Compare::operator()(extract(e.value), k);
         }
 
         bool
         operator()(element const& x, element const& y) const
         {
-            return this->member()(extract(x.value), extract(y.value));
+            return Compare::operator()(extract(x.value), extract(y.value));
         }
 
         Compare&
         compare()
         {
-            return beast::detail::empty_base_optimization<Compare>::member();
+            return *this;
         }
 
         Compare const&
         compare() const
         {
-            return beast::detail::empty_base_optimization<Compare>::member();
+            return *this;
         }
     };
 

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -148,115 +148,84 @@ private:
     };
 
     // VFALCO TODO hoist to remove template argument dependencies
-    class ValueHash : private beast::detail::empty_base_optimization<Hash>
-#ifdef _LIBCPP_VERSION
-        ,
-                      public std::unary_function<element, std::size_t>
-#endif
+    class ValueHash : public Hash
     {
     public:
-#ifndef _LIBCPP_VERSION
         using argument_type = element;
         using result_type = size_t;
-#endif
 
         ValueHash()
         {
         }
 
-        ValueHash(Hash const& h)
-            : beast::detail::empty_base_optimization<Hash>(h)
+        ValueHash(Hash const& h) : Hash(h)
         {
         }
 
         std::size_t
         operator()(element const& e) const
         {
-            return this->member()(extract(e.value));
+            return Hash::operator()(extract(e.value));
         }
 
         Hash&
         hash_function()
         {
-            return this->member();
+            return *this;
         }
 
         Hash const&
         hash_function() const
         {
-            return this->member();
+            return *this;
         }
     };
 
     // Compares value_type against element, used in find/insert_check
     // VFALCO TODO hoist to remove template argument dependencies
-    class KeyValueEqual
-        : private beast::detail::empty_base_optimization<KeyEqual>
-#ifdef _LIBCPP_VERSION
-        ,
-          public std::binary_function<Key, element, bool>
-#endif
+    class KeyValueEqual : public KeyEqual
     {
     public:
-#ifndef _LIBCPP_VERSION
         using first_argument_type = Key;
         using second_argument_type = element;
         using result_type = bool;
-#endif
 
         KeyValueEqual()
         {
         }
 
-        KeyValueEqual(KeyEqual const& keyEqual)
-            : beast::detail::empty_base_optimization<KeyEqual>(keyEqual)
+        KeyValueEqual(KeyEqual const& keyEqual) : KeyEqual(keyEqual)
         {
         }
-
-        // VFALCO NOTE WE might want only to enable these overloads
-        //                if KeyEqual has is_transparent
-#if 0
-        template <class K>
-        bool operator() (K const& k, element const& e) const
-        {
-            return this->member() (k, extract (e.value));
-        }
-
-        template <class K>
-        bool operator() (element const& e, K const& k) const
-        {
-            return this->member() (extract (e.value), k);
-        }
-#endif
 
         bool
         operator()(Key const& k, element const& e) const
         {
-            return this->member()(k, extract(e.value));
+            return KeyEqual::operator()(k, extract(e.value));
         }
 
         bool
         operator()(element const& e, Key const& k) const
         {
-            return this->member()(extract(e.value), k);
+            return KeyEqual::operator()(extract(e.value), k);
         }
 
         bool
         operator()(element const& lhs, element const& rhs) const
         {
-            return this->member()(extract(lhs.value), extract(rhs.value));
+            return KeyEqual::operator()(extract(lhs.value), extract(rhs.value));
         }
 
         KeyEqual&
         key_eq()
         {
-            return this->member();
+            return *this;
         }
 
         KeyEqual const&
         key_eq() const
         {
-            return this->member();
+            return *this;
         }
     };
 

--- a/src/ripple/ledger/impl/ApplyViewBase.cpp
+++ b/src/ripple/ledger/impl/ApplyViewBase.cpp
@@ -17,8 +17,13 @@
 */
 //==============================================================================
 
+#include <ripple/app/paths/impl/AmountSpec.h>
 #include <ripple/basics/contract.h>
+#include <ripple/ledger/View.h>
 #include <ripple/ledger/detail/ApplyViewBase.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/SField.h>
+#include <ripple/protocol/STAccount.h>
 
 namespace ripple {
 namespace detail {

--- a/src/ripple/peerfinder/impl/Bootcache.h
+++ b/src/ripple/peerfinder/impl/Bootcache.h
@@ -91,17 +91,10 @@ private:
     using value_type = map_type::value_type;
 
     struct Transform
-#ifdef _LIBCPP_VERSION
-        : std::unary_function<
-              map_type::right_map::const_iterator::value_type const&,
-              beast::IP::Endpoint const&>
-#endif
     {
-#ifndef _LIBCPP_VERSION
         using first_argument_type =
             map_type::right_map::const_iterator::value_type const&;
         using result_type = beast::IP::Endpoint const&;
-#endif
 
         explicit Transform() = default;
 

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -69,14 +69,9 @@ public:
     public:
         // Iterator transformation to extract the endpoint from Element
         struct Transform
-#ifdef _LIBCPP_VERSION
-            : public std::unary_function<Element, Endpoint>
-#endif
         {
-#ifndef _LIBCPP_VERSION
             using first_argument = Element;
             using result_type = Endpoint;
-#endif
 
             explicit Transform() = default;
 
@@ -239,15 +234,9 @@ public:
 
         template <bool IsConst>
         struct Transform
-#ifdef _LIBCPP_VERSION
-            : public std::
-                  unary_function<typename lists_type::value_type, Hop<IsConst>>
-#endif
         {
-#ifndef _LIBCPP_VERSION
             using first_argument = typename lists_type::value_type;
             using result_type = Hop<IsConst>;
-#endif
 
             explicit Transform() = default;
 

--- a/src/ripple/protocol/Import.h
+++ b/src/ripple/protocol/Import.h
@@ -20,12 +20,12 @@
 #ifndef RIPPLE_PROTOCOL_IMPORT_H_INCLUDED
 #define RIPPLE_PROTOCOL_IMPORT_H_INCLUDED
 
-// #include <ripple/basics/Log.h>
-#include <charconv>
 #include <ripple/app/misc/Manifest.h>
+#include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/base64.h>
 #include <ripple/json/json_reader.h>
+#include <charconv>
 
 namespace ripple {
 

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -171,8 +171,7 @@ STValidation::STValidation(
 {
     if (checkSignature && !isValid())
     {
-        JLOG(debugLog().error()) << "Invalid signature in validation: "
-                                 << getJson(JsonOptions::none);
+        JLOG(debugLog().error()) << "Invalid signature in validation";
         Throw<std::runtime_error>("Invalid signature in validation");
     }
 

--- a/src/ripple/shamap/impl/SHAMapInnerNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapInnerNode.cpp
@@ -398,7 +398,7 @@ SHAMapInnerNode::canonicalizeChild(
 void
 SHAMapInnerNode::invariants(bool is_root) const
 {
-    unsigned count = 0;
+    [[maybe_unused]] unsigned count = 0;
     auto [numAllocated, hashes, children] =
         hashesAndChildren_.getHashesAndChildren();
 

--- a/src/test/app/ClaimReward_test.cpp
+++ b/src/test/app/ClaimReward_test.cpp
@@ -17,7 +17,10 @@
 */
 //==============================================================================
 
+#include <ripple/app/ledger/LedgerMaster.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/protocol/Feature.h>
+#include <ripple/protocol/jss.h>
 #include <test/jtx.h>
 
 namespace ripple {

--- a/src/test/app/Invoke_test.cpp
+++ b/src/test/app/Invoke_test.cpp
@@ -17,7 +17,7 @@
 */
 //==============================================================================
 
-
+#include <ripple/protocol/jss.h>
 #include <test/jtx.h>
 
 namespace ripple {

--- a/src/test/app/NetworkID_test.cpp
+++ b/src/test/app/NetworkID_test.cpp
@@ -19,6 +19,7 @@
 
 #include <ripple/basics/BasicConfig.h>
 #include <ripple/core/ConfigSections.h>
+#include <ripple/protocol/jss.h>
 #include <test/jtx.h>
 #include <test/jtx/Env.h>
 

--- a/src/test/app/XahauGenesis_test.cpp
+++ b/src/test/app/XahauGenesis_test.cpp
@@ -15,15 +15,25 @@
 */
 //==============================================================================
 
-#include <ripple/app/tx/apply.h>
-#include <ripple/protocol/Feature.h>
-#include <ripple/protocol/STAccount.h>
-#include <ripple/protocol/Indexes.h>
+#include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/misc/HashRouter.h>
+#include <ripple/app/tx/apply.h>
 #include <ripple/app/tx/impl/XahauGenesis.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/STAccount.h>
+#include <ripple/protocol/digest.h>
+#include <ripple/protocol/jss.h>
 #include <string>
 #include <test/jtx.h>
 #include <vector>
+
+#define BEAST_REQUIRE(x)     \
+    {                        \
+        BEAST_EXPECT(!!(x)); \
+        if (!(x))            \
+            return;          \
+    }
 
 // Function to handle integer types
 template<typename T>


### PR DESCRIPTION
This PR cleans up the repo and using strict building. Needs a very good review.

```
mkdir build && cd build && \
cmake -DCMAKE_BUILD_TYPE=Release \
    -DLLVM_DIR=/opt/homebrew/opt/llvm@14/lib/cmake/llvm/ \
    -DLLVM_LIBRARY_DIR=/opt/homebrew/opt/llvm@14/lib/ \
    -DCMAKE_CXX_FLAGS=-DBOOST_ASIO_HAS_STD_INVOKE_RESULT \
    -Dassert=ON \
    -Dcoverage=OFF \
    -Dreporting=OFF \
    -Dunity=OFF \
    -Drocksdb=OFF ..
cmake --build . --target rippled --parallel 10
```

Currently the linker fails at:

```
Undefined symbols for architecture arm64:
  "ripple::SetSignerList::removeSignersFromLedger(ripple::Application&, ripple::ApplyView&, ripple::Keylet const&, ripple::Keylet const&, ripple::Keylet const&, beast::Journal)", referenced from:
      ripple::TERSubset<ripple::CanCvtToTER> ripple::SetSignerList::replaceSignersFromLedger<ripple::Sandbox>(ripple::Application&, ripple::Sandbox&, beast::Journal, ripple::base_uint<160ul, ripple::detail::AccountIDTag> const&, unsigned int, std::__1::vector<ripple::SignerEntries::SignerEntry, std::__1::allocator<ripple::SignerEntries::SignerEntry>> const&, ripple::XRPAmount) in Import.cpp.o
      ripple::SetSignerList::destroySignerList() in SetSignerList.cpp.o
      ripple::SetSignerList::removeFromLedger(ripple::Application&, ripple::ApplyView&, ripple::base_uint<160ul, ripple::detail::AccountIDTag> const&, beast::Journal) in SetSignerList.cpp.o
      ripple::TERSubset<ripple::CanCvtToTER> ripple::SetSignerList::replaceSignersFromLedger<ripple::ApplyView>(ripple::Application&, ripple::ApplyView&, beast::Journal, ripple::base_uint<160ul, ripple::detail::AccountIDTag> const&, unsigned int, std::__1::vector<ripple::SignerEntries::SignerEntry, std::__1::allocator<ripple::SignerEntries::SignerEntry>> const&, ripple::XRPAmount) in SetSignerList.cpp.o
  "ripple::SetSignerList::signerCountBasedOwnerCountDelta(unsigned long, ripple::Rules const&)", referenced from:
      ripple::TERSubset<ripple::CanCvtToTER> ripple::SetSignerList::replaceSignersFromLedger<ripple::Sandbox>(ripple::Application&, ripple::Sandbox&, beast::Journal, ripple::base_uint<160ul, ripple::detail::AccountIDTag> const&, unsigned int, std::__1::vector<ripple::SignerEntries::SignerEntry, std::__1::allocator<ripple::SignerEntries::SignerEntry>> const&, ripple::XRPAmount) in Import.cpp.o
      ripple::TERSubset<ripple::CanCvtToTER> ripple::SetSignerList::replaceSignersFromLedger<ripple::ApplyView>(ripple::Application&, ripple::ApplyView&, beast::Journal, ripple::base_uint<160ul, ripple::detail::AccountIDTag> const&, unsigned int, std::__1::vecto
```