### PR TITLE
Nit: Fix formatting for codec gen

### DIFF
--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -174,10 +174,10 @@ enum LedgerEntryType : std::uint16_t
 
     /** A ledger object that reports on the active dUNL validators
      * that were validating for more than 240 of the last 256 ledgers
-     *
-     * \sa keylet::UNLReport
+
+        \sa keylet::UNLReport
      */
-    ltUNL_REPORT = 0x0052, 
+    ltUNL_REPORT = 0x0052,
 
     //---------------------------------------------------------------------------
     /** A special type, matching any ledger entry type.


### PR DESCRIPTION
There was bad formatting in the LedgerFormats.cpp file which was giving a bad definitions.json response from from [codec-gen](https://github.com/RichardAH/xrpl-codec-gen). I was using this to update the js and py repos.

`server_definitions` is giving the correct response so this is a minor nit. We should maybe deprecate/archive the codec-gen and force users to use the `server_definitions` endpoint as it didn't have any issues.