### PR TITLE
Build on most cores (nproc / 3 » nproc / 1.337)

### DIFF
--- a/release-builder.sh
+++ b/release-builder.sh
@@ -5,7 +5,7 @@ echo "START BUILDING (HOST)"
 echo "Cleaning previously built binary"
 rm -f release-build/xahaud
 
-BUILD_CORES=$(echo "scale=0 ; `nproc` / 3" | bc)
+BUILD_CORES=$(echo "scale=0 ; `nproc` / 1.337" | bc)
 
 if [[ "$GITHUB_REPOSITORY" == "" ]]; then
   #Default


### PR DESCRIPTION
Use those resources! 🎉🚀

Build was at nproc / 3, probably to keep some system resources available for other builds. But as we're not building in parallel on the same machine, let's just use those resources (minus a little bit for other system processes).