### PR TITLE
16-way tagged cache to reduced mutex contention

### DIFF
--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -79,7 +79,7 @@ LedgerHistory::getLedgerHash(LedgerIndex index)
 
     if (it != mLedgersByIndex.end())
         return it->second;
-    
+
     return uint256();
 }
 
@@ -110,9 +110,10 @@ LedgerHistory::getLedgerBySeq(LedgerIndex index)
         {
             std::unique_lock sl(m_ledgers_by_hash.peekMutex(ret->info().hash));
             assert(ret->isImmutable());
-            m_ledgers_by_hash.canonicalize_replace_client(ret->info().hash, ret);
+            m_ledgers_by_hash.canonicalize_replace_client(
+                ret->info().hash, ret);
         }
-    
+
         {
             std::unique_lock<std::shared_mutex> lock(mLedgersByIndexMutex);
             mLedgersByIndex[ret->info().seq] = ret->info().hash;

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -27,6 +27,7 @@
 #include <ripple/protocol/RippleLedgerHash.h>
 
 #include <optional>
+#include <shared_mutex>
 
 namespace ripple {
 
@@ -150,6 +151,7 @@ private:
 
     // Maps ledger indexes to the corresponding hash.
     std::map<LedgerIndex, LedgerHash> mLedgersByIndex;  // validated ledgers
+    std::shared_mutex mLedgersByIndexMutex;
 
     beast::Journal j_;
 };

--- a/src/ripple/basics/TaggedCache.h
+++ b/src/ripple/basics/TaggedCache.h
@@ -981,12 +981,9 @@ public:
         return caches[getCacheIndex(key)]->retrieve(key, data);
     }
 
-    mutex_type& peekMutex()
+    mutex_type& peekMutex(key_type const& key)
     {
-        // This is tricky as we have multiple mutexes now.
-        // For simplicity, we'll return the mutex of the first cache,
-        // but this might not be the best approach in all scenarios.
-        return caches[0]->peekMutex();
+        return caches[getCacheIndex(key)]->peekMutex();
     }
 
     std::vector<key_type> getKeys() const


### PR DESCRIPTION
During profiling with mutrace I discovered one of the highest points of mutex contention in the codebase was in the TaggedCache mutex.

The solution to this is rather simple: build a wrapper for tagged cache that contains 16 tagged caches and routes based on the first nibble of the key. This should reduce lock contention in this code path by a factor of 16.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->