### PR TITLE
Fix HookResult(ExitType) when accept() is not called

### DIFF
--- a/src/ripple/app/hook/impl/applyHook.cpp
+++ b/src/ripple/app/hook/impl/applyHook.cpp
@@ -1217,9 +1217,10 @@ hook::apply(
              .hookParamOverrides = hookParamOverrides,
              .hookParams = hookParams,
              .hookSkips = {},
-             .exitType =
-                 hook_api::ExitType::ROLLBACK,  // default is to rollback unless
-                                                // hook calls accept()
+             .exitType = applyCtx.view().rules().enabled(fixXahauV1)
+                 ? hook_api::ExitType::UNSET
+                 : hook_api::ExitType::ROLLBACK,  // default is to rollback
+                                                  // unless hook calls accept()
              .exitReason = std::string(""),
              .exitCode = -1,
              .hasCallback = hasCallback,

--- a/src/ripple/app/hook/impl/applyHook.cpp
+++ b/src/ripple/app/hook/impl/applyHook.cpp
@@ -1217,7 +1217,7 @@ hook::apply(
              .hookParamOverrides = hookParamOverrides,
              .hookParams = hookParams,
              .hookSkips = {},
-             .exitType = applyCtx.view().rules().enabled(fixXahauV1)
+             .exitType = applyCtx.view().rules().enabled(fixXahauV3)
                  ? hook_api::ExitType::UNSET
                  : hook_api::ExitType::ROLLBACK,  // default is to rollback
                                                   // unless hook calls accept()

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -1274,6 +1274,14 @@ Transactor::executeHookChain(
                                     << "]: Execution failure (graceful) "
                                     << "HookHash: " << hookHash;
                 }
+                if (results.back().exitType == hook_api::ExitType::UNSET)
+                {
+                    JLOG(j_.warn())
+                        << "HookError[" << account << "-"
+                        << ctx_.tx.getAccountID(sfAccount) << "]: "
+                        << "]: Execution failure (no exit type specified) "
+                        << "HookHash: " << hookHash;
+                }
                 return tecHOOK_REJECTED;
             }
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -1270,7 +1270,7 @@ Transactor::executeHookChain(
                 if (results.back().exitType == hook_api::ExitType::WASM_ERROR)
                 {
                     JLOG(j_.warn()) << "HookError[" << account << "-"
-                                    << ctx_.tx.getAccountID(sfAccount) << "]: "
+                                    << ctx_.tx.getAccountID(sfAccount)
                                     << "]: Execution failure (graceful) "
                                     << "HookHash: " << hookHash;
                 }
@@ -1278,7 +1278,7 @@ Transactor::executeHookChain(
                 {
                     JLOG(j_.warn())
                         << "HookError[" << account << "-"
-                        << ctx_.tx.getAccountID(sfAccount) << "]: "
+                        << ctx_.tx.getAccountID(sfAccount)
                         << "]: Execution failure (no exit type specified) "
                         << "HookHash: " << hookHash;
                 }
@@ -1306,7 +1306,7 @@ Transactor::executeHookChain(
         {
             JLOG(j_.warn())
                 << "HookError[" << account << "-"
-                << ctx_.tx.getAccountID(sfAccount) << "]: "
+                << ctx_.tx.getAccountID(sfAccount)
                 << "]: Execution failure (exceptional) "
                 << "Exception: " << e.what() << " HookHash: " << hookHash;
 
@@ -1434,13 +1434,13 @@ Transactor::doHookCallback(
                 finalizeHookResult(callbackResult, ctx_, success);
 
             JLOG(j_.trace()) << "HookInfo[" << callbackAccountID << "-"
-                             << ctx_.tx.getAccountID(sfAccount) << "]: "
-                             << "Callback finalizeHookResult = " << result;
+                             << ctx_.tx.getAccountID(sfAccount)
+                             << "]: Callback finalizeHookResult = " << result;
         }
         catch (std::exception& e)
         {
             JLOG(j_.fatal()) << "HookError[" << callbackAccountID << "-"
-                             << ctx_.tx.getAccountID(sfAccount) << "]: "
+                             << ctx_.tx.getAccountID(sfAccount)
                              << "]: Callback failure " << e.what();
         }
     }
@@ -1686,13 +1686,13 @@ Transactor::doAgainAsWeak(
             results.push_back(aawResult);
 
             JLOG(j_.trace()) << "HookInfo[" << hookAccountID << "-"
-                             << ctx_.tx.getAccountID(sfAccount) << "]: "
-                             << " aaw Hook ExitCode = " << aawResult.exitCode;
+                             << ctx_.tx.getAccountID(sfAccount)
+                             << "]: aaw Hook ExitCode = " << aawResult.exitCode;
         }
         catch (std::exception& e)
         {
             JLOG(j_.fatal()) << "HookError[" << hookAccountID << "-"
-                             << ctx_.tx.getAccountID(sfAccount) << "]: "
+                             << ctx_.tx.getAccountID(sfAccount)
                              << "]: aaw failure " << e.what();
         }
     }

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 75;
+static constexpr std::size_t numFeatures = 76;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -363,6 +363,7 @@ extern uint256 const fixPageCap;
 extern uint256 const fix240911;
 extern uint256 const fixFloatDivide;
 extern uint256 const fixReduceImport;
+extern uint256 const fixXahauV3;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -469,6 +469,7 @@ REGISTER_FIX    (fixPageCap,                    Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fix240911,                     Supported::yes, VoteBehavior::DefaultYes);
 REGISTER_FIX    (fixFloatDivide,                Supported::yes, VoteBehavior::DefaultYes);
 REGISTER_FIX    (fixReduceImport,               Supported::yes, VoteBehavior::DefaultYes);
+REGISTER_FIX    (fixXahauV3,                    Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.


### PR DESCRIPTION
close #354

## High Level Overview of Change

Change ExitType to UNSET if `accept()` hook api is not called

Fixed as an amendment because of the effect on meta.HookExecution.HookResult

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)
