### PR TITLE
add strict filtering to account_tx api

### DIFF
--- a/src/ripple/app/rdb/RelationalDatabase.h
+++ b/src/ripple/app/rdb/RelationalDatabase.h
@@ -69,6 +69,7 @@ public:
         std::uint32_t offset;
         std::uint32_t limit;
         bool bUnlimited;
+        bool strict;
     };
 
     struct AccountTxPageOptions
@@ -79,6 +80,7 @@ public:
         std::optional<AccountTxMarker> marker;
         std::uint32_t limit;
         bool bAdmin;
+        bool strict;
     };
 
     using AccountTx =
@@ -101,6 +103,7 @@ public:
         bool forward = false;
         uint32_t limit = 0;
         std::optional<AccountTxMarker> marker;
+        bool strict;
     };
 
     struct AccountTxResult

--- a/src/ripple/app/rdb/backend/RWDBDatabase.h
+++ b/src/ripple/app/rdb/backend/RWDBDatabase.h
@@ -43,6 +43,34 @@ private:
     std::map<uint256, AccountTx> transactionMap_;
     std::map<AccountID, AccountTxData> accountTxMap_;
 
+    // helper function to scan for an account ID inside the tx and meta blobs
+    // used for strict filtering of account_tx
+    bool
+    isAccountInvolvedInTx(AccountID const& account, AccountTx const& accountTx)
+    {
+        auto const& txn = accountTx.first;
+        auto const& meta = accountTx.second;
+
+        // Search metadata
+        Blob const metaBlob = meta->getAsObject().getSerializer().peekData();
+        if (metaBlob.size() >= account.size() &&
+            std::search(
+                metaBlob.begin(),
+                metaBlob.end(),
+                account.data(),
+                account.data() + account.size()) != metaBlob.end())
+            return true;
+
+        // Search transaction blob
+        Blob const txnBlob = txn->getSTransaction()->getSerializer().peekData();
+        return txnBlob.size() >= account.size() &&
+            std::search(
+                txnBlob.begin(),
+                txnBlob.end(),
+                account.data(),
+                account.data() + account.size()) != txnBlob.end();
+    }
+
 public:
     RWDBDatabase(Application& app, Config const& config, JobQueue& jobQueue)
         : app_(app), useTxTables_(config.useTxTables())
@@ -193,7 +221,17 @@ public:
         std::size_t count = 0;
         for (const auto& [_, accountData] : accountTxMap_)
         {
-            count += accountData.transactions.size();
+            for (const auto& tx : accountData.transactions)
+            {
+                // RH NOTE: options isn't provided to this function
+                // but this function is probably only used internally
+                // so make it reflect the true number (unfiltered)
+
+                // if (options.strict &&
+                //    !isAccountInvolvedInTx(options.account, tx))
+                //    continue;
+                count++;
+            }
         }
         return count;
     }
@@ -607,12 +645,17 @@ public:
         {
             for (const auto& [txSeq, txIndex] : txIt->second)
             {
+                AccountTx const accountTx = accountData.transactions[txIndex];
+                if (options.strict &&
+                    !isAccountInvolvedInTx(options.account, accountTx))
+                    continue;
+
                 if (skipped < options.offset)
                 {
                     ++skipped;
                     continue;
                 }
-                AccountTx const accountTx = accountData.transactions[txIndex];
+
                 std::uint32_t const inLedger = rangeCheckedCast<std::uint32_t>(
                     accountTx.second->getLgrSeq());
                 accountTx.first->setStatus(COMMITTED);
@@ -652,13 +695,18 @@ public:
                  innerRIt != rIt->second.rend();
                  ++innerRIt)
             {
+                AccountTx const accountTx =
+                    accountData.transactions[innerRIt->second];
+
+                if (options.strict &&
+                    !isAccountInvolvedInTx(options.account, accountTx))
+                    continue;
+
                 if (skipped < options.offset)
                 {
                     ++skipped;
                     continue;
                 }
-                AccountTx const accountTx =
-                    accountData.transactions[innerRIt->second];
                 std::uint32_t const inLedger = rangeCheckedCast<std::uint32_t>(
                     accountTx.second->getLgrSeq());
                 accountTx.first->setLedger(inLedger);
@@ -694,12 +742,19 @@ public:
         {
             for (const auto& [txSeq, txIndex] : txIt->second)
             {
+                AccountTx const accountTx = accountData.transactions[txIndex];
+
+                if (options.strict &&
+                    !isAccountInvolvedInTx(options.account, accountTx))
+                    continue;
+
+                const auto& [txn, txMeta] = accountTx;
+
                 if (skipped < options.offset)
                 {
                     ++skipped;
                     continue;
                 }
-                const auto& [txn, txMeta] = accountData.transactions[txIndex];
                 result.emplace_back(
                     txn->getSTransaction()->getSerializer().peekData(),
                     txMeta->getAsObject().getSerializer().peekData(),
@@ -738,13 +793,20 @@ public:
                  innerRIt != rIt->second.rend();
                  ++innerRIt)
             {
+                AccountTx const accountTx =
+                    accountData.transactions[innerRIt->second];
+
+                if (options.strict &&
+                    !isAccountInvolvedInTx(options.account, accountTx))
+                    continue;
+
+                const auto& [txn, txMeta] = accountTx;
+
                 if (skipped < options.offset)
                 {
                     ++skipped;
                     continue;
                 }
-                const auto& [txn, txMeta] =
-                    accountData.transactions[innerRIt->second];
                 result.emplace_back(
                     txn->getSTransaction()->getSerializer().peekData(),
                     txMeta->getAsObject().getSerializer().peekData(),
@@ -838,17 +900,22 @@ public:
                         return {newmarker, total};
                     }
 
-                    Blob rawTxn = accountData.transactions[index]
-                                      .first->getSTransaction()
+                    AccountTx const& accountTx =
+                        accountData.transactions[index];
+
+                    Blob rawTxn = accountTx.first->getSTransaction()
                                       ->getSerializer()
                                       .peekData();
-                    Blob rawMeta = accountData.transactions[index]
-                                       .second->getAsObject()
+                    Blob rawMeta = accountTx.second->getAsObject()
                                        .getSerializer()
                                        .peekData();
 
                     if (rawMeta.size() == 0)
                         onUnsavedLedger(ledgerSeq);
+
+                    if (options.strict &&
+                        !isAccountInvolvedInTx(options.account, accountTx))
+                        continue;
 
                     onTransaction(
                         rangeCheckedCast<std::uint32_t>(ledgerSeq),
@@ -893,17 +960,22 @@ public:
                         return {newmarker, total};
                     }
 
-                    Blob rawTxn = accountData.transactions[index]
-                                      .first->getSTransaction()
+                    AccountTx const& accountTx =
+                        accountData.transactions[index];
+
+                    Blob rawTxn = accountTx.first->getSTransaction()
                                       ->getSerializer()
                                       .peekData();
-                    Blob rawMeta = accountData.transactions[index]
-                                       .second->getAsObject()
+                    Blob rawMeta = accountTx.second->getAsObject()
                                        .getSerializer()
                                        .peekData();
 
                     if (rawMeta.size() == 0)
                         onUnsavedLedger(ledgerSeq);
+
+                    if (options.strict &&
+                        !isAccountInvolvedInTx(options.account, accountTx))
+                        continue;
 
                     onTransaction(
                         rangeCheckedCast<std::uint32_t>(ledgerSeq),

--- a/src/ripple/app/rdb/backend/detail/impl/Node.cpp
+++ b/src/ripple/app/rdb/backend/detail/impl/Node.cpp
@@ -765,8 +765,18 @@ transactionsSQL(
 
     std::string sql;
 
-    std::string filterClause = options.strict ? "AND (hex(TxnMeta) LIKE '%" +
-            accountHex + "%' OR hex(RawTxn) LIKE '%" + accountHex + "%')"
+    // For metadata search:
+    // 1. Look for account ID not preceded by 8814 (RegularKey field)
+    // 2. OR look for account in raw transaction
+    std::string filterClause = options.strict ? "AND (("
+                                                "hex(TxnMeta) LIKE '%" +
+            accountHex +
+            "%' AND "
+            "hex(TxnMeta) NOT LIKE '%8814" +
+            accountHex +
+            "%'"
+            ") OR hex(RawTxn) LIKE '%" +
+            accountHex + "%')"
                                               : "";
 
     if (count)

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -40,6 +40,17 @@ strHex(FwdIt begin, FwdIt end)
     return result;
 }
 
+template <class FwdIt>
+std::string
+strHex(FwdIt begin, std::size_t length)
+{
+    std::string result;
+    result.reserve(2 * length);
+    boost::algorithm::hex(
+        begin, std::next(begin, length), std::back_inserter(result));
+    return result;
+}
+
 template <class T, class = decltype(std::declval<T>().begin())>
 std::string
 strHex(T const& from)

--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -223,7 +223,8 @@ doAccountTxHelp(RPC::Context& context, AccountTxArgs const& args)
         result.ledgerRange.max,
         result.marker,
         args.limit,
-        isUnlimited(context.role)};
+        isUnlimited(context.role),
+        args.strict};
 
     auto const db =
         dynamic_cast<SQLiteDatabase*>(&context.app.getRelationalDatabase());
@@ -368,6 +369,9 @@ doAccountTxJson(RPC::JsonContext& context)
     args.binary = params.isMember(jss::binary) && params[jss::binary].asBool();
     args.forward =
         params.isMember(jss::forward) && params[jss::forward].asBool();
+
+    args.strict =
+        params.isMember(jss::strict) ? params[jss::strict].asBool() : true;
 
     if (!params.isMember(jss::account))
         return rpcError(rpcINVALID_PARAMS);


### PR DESCRIPTION
Some accounts (A) are set as regular key on other accounts (B), and their account_tx feed is populated almost entirely with transactions that don't affect A at all. This filter `strict` scans the txn blob and metadata blob of each txn for the account ID (A), and if its not found anywhere in the txn then the txn does not appear in the account_tx list.