### PR TITLE
Cancel Stale GA Builds 

### DIFF
--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -2,9 +2,9 @@ name: Build using Docker
 
 on:
   push:
-    branches: [ "dev", "candidate", "release", "jshooks" ]
+    branches: ["dev", "candidate", "release", "jshooks"]
   pull_request:
-    branches: [ "dev", "candidate", "release", "jshooks" ]
+    branches: ["dev", "candidate", "release", "jshooks"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,24 +16,40 @@ env:
 jobs:
   checkout:
     runs-on: [self-hosted, vanity]
+    outputs:
+      checkout_path: ${{ steps.vars.outputs.checkout_path }}
     steps:
+      - name: Prepare checkout path
+        id: vars
+        run: |
+          SAFE_BRANCH=$(echo "${{ github.ref_name }}" | sed -e 's/[^a-zA-Z0-9._-]/-/g')
+          CHECKOUT_PATH="${SAFE_BRANCH}-${{ github.sha }}"
+          echo "checkout_path=${CHECKOUT_PATH}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
         with:
-          clean: false
+          path: ${{ steps.vars.outputs.checkout_path }}
+          clean: true
+          fetch-depth: 2 # Only get the last 2 commits, to avoid fetching all history
+
   checkpatterns:
     runs-on: [self-hosted, vanity]
     needs: checkout
+    defaults:
+      run:
+        working-directory: ${{ needs.checkout.outputs.checkout_path }}
     steps:
       - name: Check for suspicious patterns
         run: /bin/bash suspicious_patterns.sh
+
   build:
-    # This runner only runs one workflow at a time, and queues them
     runs-on: [self-hosted, vanity]
-    needs: checkpatterns
+    needs: [checkpatterns, checkout]
+    defaults:
+      run:
+        working-directory: ${{ needs.checkout.outputs.checkout_path }}
     steps:
       - name: Set Cleanup Script Path
-        # This way we don't need to configure CONTAINER_NAME in multiple places,
-        # just configure it in the build script, and add cleanup steps to this script.
         run: |
           echo "JOB_CLEANUP_SCRIPT=$(mktemp)" >> $GITHUB_ENV
 
@@ -44,10 +60,9 @@ jobs:
         if: always()
         run: |
           echo "Running cleanup script: $JOB_CLEANUP_SCRIPT"
-          # Run cleanup script and store exit status
           /bin/bash -e -x "$JOB_CLEANUP_SCRIPT"
           CLEANUP_EXIT_CODE=$?
-          
+
           if [[ "$CLEANUP_EXIT_CODE" -eq 0 ]]; then
             echo "Cleanup script succeeded."
             rm -f "$JOB_CLEANUP_SCRIPT"
@@ -55,7 +70,7 @@ jobs:
           else
             echo "⚠️ Cleanup script failed! Keeping for debugging: $JOB_CLEANUP_SCRIPT"
           fi
-          
+
           if [[ "${DEBUG_BUILD_CONTAINERS_AFTER_CLEANUP}" == "1" ]]; then
             echo "🔍 Checking for leftover containers..."
             BUILD_CONTAINERS=$(docker ps --format '{{.Names}}' | grep '^xahaud_cached_builder' || echo "")
@@ -70,7 +85,21 @@ jobs:
 
   tests:
     runs-on: [self-hosted, vanity]
-    needs: build
+    needs: [build, checkout]
+    defaults:
+      run:
+        working-directory: ${{ needs.checkout.outputs.checkout_path }}
     steps:
       - name: Unit tests
         run: /bin/bash docker-unit-tests.sh
+
+  cleanup:
+    runs-on: [self-hosted, vanity]
+    needs: [tests, checkout]
+    if: always()
+    steps:
+      - name: Cleanup workspace
+        run: |
+          CHECKOUT_PATH="${{ needs.checkout.outputs.checkout_path }}"
+          echo "Cleaning workspace for ${CHECKOUT_PATH}"
+          rm -rf "${{ github.workspace }}/${CHECKOUT_PATH}"

--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -38,8 +38,17 @@ jobs:
         if: always()
         run: |
           echo "Running cleanup script: $JOB_CLEANUP_SCRIPT"
+          # Run cleanup script and store exit status
           /bin/bash "$JOB_CLEANUP_SCRIPT"
-          rm -f "$JOB_CLEANUP_SCRIPT"
+          CLEANUP_EXIT_CODE=$?
+      
+          if [[ "$CLEANUP_EXIT_CODE" -eq 0 ]]; then
+            echo "Cleanup script succeeded."
+            rm -f "$JOB_CLEANUP_SCRIPT"
+            echo "Cleanup script removed."
+          else
+            echo "⚠️ Cleanup script failed! Keeping for debugging: $JOB_CLEANUP_SCRIPT"
+          fi
 
   tests:
     runs-on: [self-hosted, vanity]

--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -7,32 +7,40 @@ on:
     branches: [ "dev", "candidate", "release", "jshooks" ]
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   checkout:
     runs-on: [self-hosted, vanity]
     steps:
-    - uses: actions/checkout@v4
-      with:
-        clean: false
+      - uses: actions/checkout@v4
+        with:
+          clean: false
   checkpatterns:
     runs-on: [self-hosted, vanity]
     needs: checkout
     steps:
-    - name: Check for suspicious patterns
-      run: /bin/bash suspicious_patterns.sh
+      - name: Check for suspicious patterns
+        run: /bin/bash suspicious_patterns.sh
   build:
+    # This runner only runs one workflow at a time, and queues them
     runs-on: [self-hosted, vanity]
     needs: checkpatterns
     steps:
-    - name: Build using Docker
-      run: /bin/bash release-builder.sh
+      - name: Set Container Name Environment Variable
+        run: |
+          echo "CONTAINER_NAME=xahaud_cached_builder_$(echo "$GITHUB_ACTOR" | awk '{print tolower($0)}')" >> $GITHUB_ENV
+      - name: Build using Docker
+        run: /bin/bash release-builder.sh
+      - name: Stop Container
+        if: always()
+        run: |
+          echo "Stopping container: $CONTAINER_NAME"
+          docker stop "$CONTAINER_NAME" || true
   tests:
     runs-on: [self-hosted, vanity]
     needs: build
     steps:
-    - name: Unit tests
-      run: /bin/bash docker-unit-tests.sh
-
+      - name: Unit tests
+        run: /bin/bash docker-unit-tests.sh

--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -29,6 +29,8 @@ jobs:
     needs: checkpatterns
     steps:
       - name: Set Cleanup Script Path
+        # This way we don't need to configure CONTAINER_NAME in multiple places,
+        # just configure it in the build script, and add cleanup steps to this script.
         run: echo "JOB_CLEANUP_SCRIPT=$(mktemp)" >> $GITHUB_ENV
 
       - name: Build using Docker

--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -37,7 +37,7 @@ jobs:
         if: always()
         run: |
           echo "Stopping container: $CONTAINER_NAME"
-          docker stop "$CONTAINER_NAME" || true
+          docker stop --time=15 "$CONTAINER_NAME" || echo "failed to stop container or container not running"
   tests:
     runs-on: [self-hosted, vanity]
     needs: build

--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -28,16 +28,19 @@ jobs:
     runs-on: [self-hosted, vanity]
     needs: checkpatterns
     steps:
-      - name: Set Container Name Environment Variable
-        run: |
-          echo "CONTAINER_NAME=xahaud_cached_builder_$(echo "$GITHUB_ACTOR" | awk '{print tolower($0)}')" >> $GITHUB_ENV
+      - name: Set Cleanup Script Path
+        run: echo "JOB_CLEANUP_SCRIPT=$(mktemp)" >> $GITHUB_ENV
+
       - name: Build using Docker
         run: /bin/bash release-builder.sh
-      - name: Stop Container
+
+      - name: Stop Container (Cleanup)
         if: always()
         run: |
-          echo "Stopping container: $CONTAINER_NAME"
-          docker stop --time=15 "$CONTAINER_NAME" || echo "failed to stop container or container not running"
+          echo "Running cleanup script: $JOB_CLEANUP_SCRIPT"
+          /bin/bash "$JOB_CLEANUP_SCRIPT"
+          rm -f "$JOB_CLEANUP_SCRIPT"
+
   tests:
     runs-on: [self-hosted, vanity]
     needs: build

--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DEBUG_BUILD_CONTAINERS_AFTER_CLEANUP: 1
+
 jobs:
   checkout:
     runs-on: [self-hosted, vanity]
@@ -31,7 +34,8 @@ jobs:
       - name: Set Cleanup Script Path
         # This way we don't need to configure CONTAINER_NAME in multiple places,
         # just configure it in the build script, and add cleanup steps to this script.
-        run: echo "JOB_CLEANUP_SCRIPT=$(mktemp)" >> $GITHUB_ENV
+        run: |
+          echo "JOB_CLEANUP_SCRIPT=$(mktemp)" >> $GITHUB_ENV
 
       - name: Build using Docker
         run: /bin/bash release-builder.sh
@@ -41,15 +45,27 @@ jobs:
         run: |
           echo "Running cleanup script: $JOB_CLEANUP_SCRIPT"
           # Run cleanup script and store exit status
-          /bin/bash "$JOB_CLEANUP_SCRIPT"
+          /bin/bash -e -x "$JOB_CLEANUP_SCRIPT"
           CLEANUP_EXIT_CODE=$?
-      
+          
           if [[ "$CLEANUP_EXIT_CODE" -eq 0 ]]; then
             echo "Cleanup script succeeded."
             rm -f "$JOB_CLEANUP_SCRIPT"
             echo "Cleanup script removed."
           else
             echo "⚠️ Cleanup script failed! Keeping for debugging: $JOB_CLEANUP_SCRIPT"
+          fi
+          
+          if [[ "${DEBUG_BUILD_CONTAINERS_AFTER_CLEANUP}" == "1" ]]; then
+            echo "🔍 Checking for leftover containers..."
+            BUILD_CONTAINERS=$(docker ps --format '{{.Names}}' | grep '^xahaud_cached_builder' || echo "")
+
+            if [[ -n "$BUILD_CONTAINERS" ]]; then
+              echo "⚠️ WARNING: Some build containers are still running"
+              echo "$BUILD_CONTAINERS"
+            else
+              echo "✅ No build containers found"
+            fi
           fi
 
   tests:

--- a/docker-unit-tests.sh
+++ b/docker-unit-tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
+echo "Mounting $(pwd)/io in ubuntu and running unit tests"
 docker run --rm -i -v $(pwd):/io ubuntu sh -c '/io/release-build/xahaud -u'
-

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -18,13 +18,13 @@ if [[ "$GITHUB_REPOSITORY" == "" ]]; then
 fi
 
 # Caching is currently disabled, but in the future this may require a different namespacing strategy
-CONTAINER_NAME_TMP="xahaud_cached_builder_$(echo "${GITHUB_ACTOR:-unknown}" | awk '{print tolower($0)}')"
-CONTAINER_NAME=${CONTAINER_NAME:-$CONTAINER_NAME_TMP}
+CONTAINER_NAME_DEFAULT="xahaud_cached_builder_$(echo "${GITHUB_ACTOR:-unknown}" | awk '{print tolower($0)}')"
+CONTAINER_NAME=${CONTAINER_NAME:-$CONTAINER_NAME_DEFAULT}
 
 # Ensure no container with CONTAINER_NAME is running
 if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-    echo "⚠️ A running container (${CONTAINER_NAME}) was detected."
-    docker stop "$CONTAINER_NAME"
+    echo "⚠️ A running container (${CONTAINER_NAME}) was detected. Exiting."
+    exit 1
 fi
 
 echo "-- BUILD CORES:       $BUILD_CORES"

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -19,6 +19,8 @@ fi
 
 # Caching is currently disabled, but in the future this may require a different namespacing strategy
 CONTAINER_NAME_DEFAULT="xahaud_cached_builder_$(echo "${GITHUB_ACTOR:-unknown}" | awk '{print tolower($0)}')"
+# Note that the CI can set this itself and does so so it can use an always() step to stop the container
+# at the end of the workflow, canceled or not.
 CONTAINER_NAME=${CONTAINER_NAME:-$CONTAINER_NAME_DEFAULT}
 
 # Ensure no container with CONTAINER_NAME is running

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -5,8 +5,6 @@
 # debugging.
 set -ex
 
-set -e
-
 echo "START BUILDING (HOST)"
 
 echo "Cleaning previously built binary"
@@ -19,7 +17,15 @@ if [[ "$GITHUB_REPOSITORY" == "" ]]; then
   BUILD_CORES=8
 fi
 
-CONTAINER_NAME=xahaud_cached_builder_$(echo "$GITHUB_ACTOR" | awk '{print tolower($0)}')
+# Caching is currently disabled, but in the future this may require a different namespacing strategy
+CONTAINER_NAME_TMP="xahaud_cached_builder_$(echo "${GITHUB_ACTOR:-unknown}" | awk '{print tolower($0)}')"
+CONTAINER_NAME=${CONTAINER_NAME:-$CONTAINER_NAME_TMP}
+
+# Ensure no container with CONTAINER_NAME is running
+if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "⚠️ A running container (${CONTAINER_NAME}) was detected."
+    docker stop "$CONTAINER_NAME"
+fi
 
 echo "-- BUILD CORES:       $BUILD_CORES"
 echo "-- GITHUB_REPOSITORY: $GITHUB_REPOSITORY"

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -17,16 +17,25 @@ if [[ "$GITHUB_REPOSITORY" == "" ]]; then
   BUILD_CORES=8
 fi
 
+EXIT_IF_CONTAINER_RUNNING=${EXIT_IF_CONTAINER_RUNNING:-1}
+
 # Caching is currently disabled, but in the future this may require a different namespacing strategy
 CONTAINER_NAME_DEFAULT="xahaud_cached_builder_$(echo "${GITHUB_ACTOR:-unknown}" | awk '{print tolower($0)}')"
 # Note that the CI can set this itself and does so so it can use an always() step to stop the container
 # at the end of the workflow, canceled or not.
 CONTAINER_NAME=${CONTAINER_NAME:-$CONTAINER_NAME_DEFAULT}
 
-# Ensure no container with CONTAINER_NAME is running
+# Check if the container is already running
 if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-    echo "⚠️ A running container (${CONTAINER_NAME}) was detected. Exiting."
-    exit 1
+    echo "⚠️ A running container (${CONTAINER_NAME}) was detected."
+
+    if [[ "$EXIT_IF_CONTAINER_RUNNING" -eq 1 ]]; then
+        echo "❌ EXIT_IF_CONTAINER_RUNNING is set. Exiting."
+        exit 1
+    else
+        echo "🛑 Stopping the running container: ${CONTAINER_NAME}"
+        docker stop "${CONTAINER_NAME}"
+    fi
 fi
 
 echo "-- BUILD CORES:       $BUILD_CORES"

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -18,12 +18,12 @@ if [[ "$GITHUB_REPOSITORY" == "" ]]; then
 fi
 
 EXIT_IF_CONTAINER_RUNNING=${EXIT_IF_CONTAINER_RUNNING:-1}
-
-# Caching is currently disabled, but in the future this may require a different namespacing strategy
-CONTAINER_NAME_DEFAULT="xahaud_cached_builder_$(echo "${GITHUB_ACTOR:-unknown}" | awk '{print tolower($0)}')"
-# Note that the CI can set this itself and does so so it can use an always() step to stop the container
-# at the end of the workflow, canceled or not.
-CONTAINER_NAME=${CONTAINER_NAME:-$CONTAINER_NAME_DEFAULT}
+# Ensure still works outside of GH Actions by setting these to /dev/null
+# GA will run this script and then delete it at the end of the job
+JOB_CLEANUP_SCRIPT=${JOB_CLEANUP_SCRIPT:-/dev/null}
+NORMALIZED_WORKFLOW=$(echo "$GITHUB_WORKFLOW" | tr -c 'a-zA-Z0-9' '-')
+NORMALIZED_REF=$(echo "$GITHUB_REF" | tr -c 'a-zA-Z0-9' '-')
+CONTAINER_NAME="xahaud_cached_builder_${NORMALIZED_WORKFLOW}-${NORMALIZED_REF}"
 
 # Check if the container is already running
 if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
@@ -79,6 +79,8 @@ else
     # GH Action, runner
     echo "GH Action, runner, clean & re-create create persistent container"
     docker rm -f $CONTAINER_NAME
+    echo "echo 'Stopping container: $CONTAINER_NAME'" >> "$JOB_CLEANUP_SCRIPT"
+    echo "docker stop --time=15 \"$CONTAINER_NAME\" || echo 'Failed to stop container or container not running'" >> "$JOB_CLEANUP_SCRIPT"
     docker run -di --user 0:$(id -g) --name $CONTAINER_NAME -v /data/builds:/data/builds -v `pwd`:/io --network host ghcr.io/foobarwidget/holy-build-box-x64 /hbb_exe/activate-exec bash
     docker exec -i $CONTAINER_NAME /hbb_exe/activate-exec bash -x /io/build-full.sh "$GITHUB_REPOSITORY" "$GITHUB_SHA" "$BUILD_CORES" "$GITHUB_RUN_NUMBER"
     docker stop $CONTAINER_NAME


### PR DESCRIPTION
* Sets the concurrency group to the active branch/PR (ref) and workflow
  * New commits to this group will cancel prior workflow runs
* Adds a cleanup script and always() executes it in the build job
  * release-build.sh writes commands to this to stop the container 
* Leaves the cached builds disabled and TBD but provides required teardown structure
* Checks out to a unique path so mounted folders are unique

```
I remember the issue now. The docker containers are being cached so if you 1 user makes a commit to 2 branches the docker container used the cache from one to test another.

Push Commit Branch 1 -> Triggers Build
Push Commit Branch 2 - Triggers Build (waits)
Branch 1 Build will finish, Branch 2 will start to build.
Branch 2 Build will finish, Brach 1 will test, but tests using Branch 2 Build.
```

This issue MAY be solved by the unique checkout path introduced