### PR TITLE
Prevent dangling reference in getHash()

### DIFF
--- a/src/ripple/rpc/handlers/ServerDefinitions.cpp
+++ b/src/ripple/rpc/handlers/ServerDefinitions.cpp
@@ -462,15 +462,9 @@ public:
     uint256 const&
     getHash() const
     {
-        if (!defsHash)
-        {
-            // should be unreachable
-            // if this does happen we don't want 0 xor 0 so use a random value
-            // here
-            return uint256(
-                "DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA0");
-        }
-        return *defsHash;
+        static const uint256 fallbackHash(
+            "DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA0");
+        return defsHash ? *defsHash : fallbackHash;
     }
 
     Json::Value const&


### PR DESCRIPTION
Replace temporary uint256 with static variable when returning fallback hash
to avoid returning a const reference to a local temporary object.