### PR TITLE
fix: remove vestigial -DBOOST_ASIO_DISABLE_CONCEPTS usage

### DIFF
--- a/.github/workflows/xahau-ga-macos.yml
+++ b/.github/workflows/xahau-ga-macos.yml
@@ -91,7 +91,6 @@ jobs:
         run: |
           conan profile new default --detect || true # Ignore error if profile exists
           conan profile update settings.compiler.cppstd=20 default
-          conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
 
       - name: Install dependencies
         uses: ./.github/actions/xahau-ga-dependencies


### PR DESCRIPTION
https://github.com/Xahau/xahaud/actions/runs/15871388886/job/44748579685?pr=520#step:12:5784

This is failing because -DBOOST_ASIO_DISABLE_CONCEPTS is set due to some old CI addition (since removed from rippled) . Boost cobalt won't build without the asio concepts that were disabled, thus CI dependencies step fails. 


From 52d3babf1b6f1d38b87000b3a14de70c93a0dc8c
```
### call to 'async_teardown' is ambiguous

If you are compiling with an early version of Clang 16, then you might hit
a [regression][6] when compiling C++20 that manifests as an [error in a Boost
header][7]. You can workaround it by adding this preprocessor definition:

\```
conan profile update 'env.CXXFLAGS="-DBOOST_ASIO_DISABLE_CONCEPTS"' default
conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_DISABLE_CONCEPTS"]' default
\```
```

We are now using a new version of clang 16:
```
OS Version: macOS 15.5 (24F74)
Kernel Version: Darwin 24.5.0
Image Version: 20250616.1800

Apple clang version 16.0.0 (clang-1600.0.26.3)         # locally my machine has (clang-1600.0.26.6)
Target: arm64-apple-darwin24.5.0
Thread model: posix
InstalledDir: /Applications/Xcode_16.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```