### PR TITLE
fix: prevent SOCI from linking ALL boost libraries

### DIFF
--- a/external/soci/conanfile.py
+++ b/external/soci/conanfile.py
@@ -154,7 +154,7 @@ class SociConan(ConanFile):
         self.cpp_info.components["soci_core"].set_property("cmake_target_name", "SOCI::soci_core{}".format(target_suffix))
         self.cpp_info.components["soci_core"].libs = ["{}soci_core{}".format(lib_prefix, lib_suffix)]
         if self.options.with_boost:
-            self.cpp_info.components["soci_core"].requires.append("boost::boost")
+            self.cpp_info.components["soci_core"].requires.append("boost::headers")
 
         # soci_empty
         if self.options.empty:


### PR DESCRIPTION
SOCI's vendored conanfile was using boost::boost which links against every single Boost library (40+ libraries) when only boost::headers is needed for SOCI's template specializations (boost::optional and boost::gregorian::date support).

This was causing excessive linking and potential symbol conflicts, particularly on Linux CI where boost_stacktrace_from_exception was causing multiple definition errors with libstdc++.

Changed SOCI's boost dependency from boost::boost to boost::headers since SOCI only needs Boost headers for its template specializations, not the compiled libraries. The project already provides all necessary Boost libraries through the ripple_boost target.

This reduces the linked libraries from 40+ down to just the ~14 that the project actually uses, fixing the Linux CI build failures and reducing binary size.

Note: The SOCI Conan recipe for Conan 2.0 [already implements this](https://github.com/conan-io/conan-center-index/blob/master/recipes/soci/all/conanfile.py#L125) fix correctly.
