### PR TITLE
Update Sample Configuration Files in /cfg for Congruence with xahaud

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Note:** Throughout this README, references to "we" or "our" pertain to the community and contributors involved in the Xahau network. It does not imply a legal entity or a specific collection of individuals.
 
-[Xahau](https://xahau.network/) is a decentralized cryptographic ledger that builds upon the robust foundation of the XRP Ledger. It inherits the XRP Ledger's Byzantine Fault Tolerant consensus algorithm and enhances it with additional features and functionalities. Developers and users familiar with the XRP Ledger will find that most documentation and tutorials available on [xrpl.org](https://xrpl.org) are relevant and applicable to Xahau, including those related to running validators and managing validator keys. For Xahau specific documentation you can visit our [documentation](https://docs.xahau.network/)
+[Xahau](https://xahau.network/) is a decentralized cryptographic ledger that builds upon the robust foundation of the XRP Ledger. It inherits the XRP Ledger's Byzantine Fault Tolerant consensus algorithm and enhances it with additional features and functionalities. Developers and users familiar with the XRP Ledger will find that most documentation and tutorials available on [xrpl.org](https://xrpl.org) are relevant and applicable to Xahau, including those related to running validators and managing validator keys. For Xahau specific documentation you can visit our [documentation](https://xahau.network/)
 
 ## XAH
 XAH is the public, counterparty-free asset native to Xahau and functions primarily as network gas. Transactions submitted to the Xahau network must supply an appropriate amount of XAH, to be burnt by the network as a fee, in order to be successfully included in a validated ledger. In addition, XAH also acts as a bridge currency within the Xahau DEX. XAH is traded on the open-market and is available for anyone to access. Xahau was created in 2023 with a supply of 600 million units of XAH.
@@ -12,7 +12,7 @@ The server software that powers Xahau is called `xahaud` and is available in thi
 
 ### Build from Source
 
-* [Read the build instructions in our documentation](https://docs.xahau.network/infrastructure/building-xahau)
+* [Read the build instructions in our documentation](https://xahau.network/infrastructure/building-xahau)
 * If you encounter any issues, please [open an issue](https://github.com/xahau/xahaud/issues)
 
 ## Highlights of Xahau
@@ -58,7 +58,7 @@ git-subtree. See those directories' README files for more details.
 
 - **Documentation**: Documentation for XRPL, Xahau and Hooks.
   - [Xrpl Documentation](https://xrpl.org)
-  - [Xahau Documentation](https://docs.xahau.network/)
+  - [Xahau Documentation](https://xahau.network/)
   - [Hooks Technical Documentation](https://xrpl-hooks.readme.io/)
 - **Explorers**: Explore the Xahau ledger using various explorers:
   - [xahauexplorer.com](https://xahauexplorer.com)

--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -1,7 +1,7 @@
 #
 # Default validators.txt
 #
-# This file is located in the same folder as your rippled.cfg file
+# This file is located in the same folder as your xahaud.cfg file
 # and defines which validators your server trusts not to collude.
 #
 # This file is UTF-8 with DOS, UNIX, or Mac style line endings.
@@ -17,18 +17,17 @@
 #   See validator_list_sites and validator_list_keys below.
 #
 #   Examples:
-#    n9KorY8QtTdRx7TVDpwnG9NvyxsDwHUKUEeDLY3AkiGncVaSXZi5
-#    n9MqiExBcoG19UXwoLjBJnhsxEhAZMuWwJDRdkyDz1EkEkwzQTNt
+#    n9L3GdotB8a3AqtsvS7NXt4BUTQSAYyJUr9xtFj2qXJjfbZsawKY
+#    n9M7G6eLwQtUjfCthWUmTN8L4oEZn1sNr46yvKrpsq58K1C6LAxz
 #
 # [validator_list_sites]
 #
 #   List of URIs serving lists of recommended validators.
 #
 #   Examples:
-#    https://vl.ripple.com
-#    https://vl.xrplf.org
+#    https://vl.xahau.org
 #    http://127.0.0.1:8000
-#    file:///etc/opt/ripple/vl.txt
+#    file:///etc/opt/xahaud/vl.txt
 #
 # [validator_list_keys]
 #
@@ -39,50 +38,46 @@
 #   Validator list keys should be hex-encoded.
 #
 #   Examples:
-#    ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
-#    ED307A760EE34F2D0CAA103377B1969117C38B8AA0AA1E2A24DAC1F32FC97087ED
+#    EDA46E9C39B1389894E690E58914DC1029602870370A0993E5B87C4A24EAF4A8E8
 #
 # [import_vl_keys]
 #
 #   This section is used to import the public keys of trusted validator list publishers.
 #   The keys are used to authenticate and accept new lists of trusted validators.
-#   In this example, the key for the publisher "vl.xrplf.org" is imported.
+#   In this example, the key for the publisher "vl.xahau.org" is imported.
 #   Each key is represented as a hexadecimal string.
 # 
 #   Examples:
-#    ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+#    EDA46E9C39B1389894E690E58914DC1029602870370A0993E5B87C4A24EAF4A8E8
 
-# The default validator list publishers that the rippled instance
+# The default validator list publishers that the xahaud instance
 # trusts.
 #
-# WARNING: Changing these values can cause your rippled instance to see a
-#          validated ledger that contradicts other rippled instances'
+# WARNING: Changing these values can cause your xahaud instance to see a
+#          validated ledger that contradicts other xahaud instances'
 #          validated ledgers (aka a ledger fork) if your validator list(s)
 #          do not sufficiently overlap with the list(s) used by others.
 #          See: https://arxiv.org/pdf/1802.07242.pdf
 
 [validator_list_sites]
-https://vl.ripple.com
-https://vl.xrplf.org
+https://vl.xahau.org
 
 [validator_list_keys]
-#vl.ripple.com
-ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
-# vl.xrplf.org
-ED45D1840EE724BE327ABE9146503D5848EFD5F38B6D5FEDE71E80ACCE5E6E738B
+#vl.xahau.org
+EDA46E9C39B1389894E690E58914DC1029602870370A0993E5B87C4A24EAF4A8E8
 
 [import_vl_keys]
-# vl.xrplf.org
-ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+# vl.xahau.org
+EDA46E9C39B1389894E690E58914DC1029602870370A0993E5B87C4A24EAF4A8E8
 
-# To use the test network (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),
+# To use the test network (see https://xahau.network/docs/infrastructure/installing-xahaud),
 # use the following configuration instead:
 #
-# [validator_list_sites]
-# https://vl.altnet.rippletest.net
-#
-# [validator_list_keys]
-# ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860
+# [validators]
+# nHBoJCE3wPgkTcrNPMHyTJFQ2t77EyCAqcBRspFCpL6JhwCm94VZ
+# nHUVv4g47bFMySAZFUKVaXUYEmfiUExSoY4FzwXULNwJRzju4XnQ
+# nHBvr8avSFTz4TFxZvvi4rEJZZtyqE3J6KAAcVWVtifsE7edPM7q
+# nHUH3Z8TRU57zetHbEPr1ynyrJhxQCwrJvNjr4j1SMjYADyW1WWe
 #
 # [import_vl_keys]
 # ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860

--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -44,11 +44,12 @@
 #
 #   This section is used to import the public keys of trusted validator list publishers.
 #   The keys are used to authenticate and accept new lists of trusted validators.
-#   In this example, the key for the publisher "vl.xahau.org" is imported.
 #   Each key is represented as a hexadecimal string.
 # 
 #   Examples:
-#    EDA46E9C39B1389894E690E58914DC1029602870370A0993E5B87C4A24EAF4A8E8
+#	 ED45D1840EE724BE327ABE9146503D5848EFD5F38B6D5FEDE71E80ACCE5E6E738B
+#	 ED42AEC58B701EEBB77356FFFEC26F83C1F0407263530F068C7C73D392C7E06FD1
+#	 ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
 
 # The default validator list publishers that the xahaud instance
 # trusts.
@@ -63,12 +64,13 @@
 https://vl.xahau.org
 
 [validator_list_keys]
-#vl.xahau.org
+# vl.xahau.org
 EDA46E9C39B1389894E690E58914DC1029602870370A0993E5B87C4A24EAF4A8E8
 
 [import_vl_keys]
-# vl.xahau.org
-EDA46E9C39B1389894E690E58914DC1029602870370A0993E5B87C4A24EAF4A8E8
+ED45D1840EE724BE327ABE9146503D5848EFD5F38B6D5FEDE71E80ACCE5E6E738B
+ED42AEC58B701EEBB77356FFFEC26F83C1F0407263530F068C7C73D392C7E06FD1
+ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
 
 # To use the test network (see https://xahau.network/docs/infrastructure/installing-xahaud),
 # use the following configuration instead:

--- a/cfg/xahaud-example.cfg
+++ b/cfg/xahaud-example.cfg
@@ -1020,7 +1020,7 @@
 #
 #   Example:
 #       type=nudb
-#       path=db/nudb
+#       path=/opt/xahaud/db/nudb
 #
 #   The "type" field must be present and controls the choice of backend:
 #
@@ -1634,7 +1634,7 @@ port_ws_admin_local
 #ssl_cert = /etc/ssl/certs/server.crt
 
 [port_rpc_admin_local]
-port = 5005
+port = 5009
 ip = 127.0.0.1
 admin = 127.0.0.1
 protocol = http
@@ -1647,7 +1647,7 @@ ip = 0.0.0.0
 protocol = peer
 
 [port_ws_admin_local]
-port = 6006
+port = 6009
 ip = 127.0.0.1
 admin = 127.0.0.1
 protocol = ws
@@ -1658,7 +1658,7 @@ ip = 127.0.0.1
 secure_gateway = 127.0.0.1
 
 #[port_ws_public]
-#port = 6005
+#port = 6008
 #ip = 127.0.0.1
 #protocol = wss
 
@@ -1679,7 +1679,7 @@ secure_gateway = 127.0.0.1
 #    deletion.
 [node_db]
 type=NuDB
-path=/var/lib/xahaud/db/nudb
+path=/opt/xahaud/db/nudb
 online_delete=512
 advisory_delete=0
 
@@ -1688,7 +1688,7 @@ advisory_delete=0
 # NuDB requires SSD storage. Helpful information can be found at
 # https://xrpl.org/history-sharding.html
 #[shard_db]
-#path=/var/lib/xahaud/db/shards/nudb
+#path=/opt/xahaud/db/shards/nudb
 #max_historical_shards=50
 #
 # This optional section can be configured with a list
@@ -1699,7 +1699,7 @@ advisory_delete=0
 #/path/2
 
 [database_path]
-/var/lib/xahaud/db
+/opt/xahaud/db
 
 
 # To use Postgres, uncomment this section and fill in the appropriate connection

--- a/cfg/xahaud-example.cfg
+++ b/cfg/xahaud-example.cfg
@@ -9,7 +9,7 @@
 #
 #   2. Peer Protocol
 #
-#   3. Ripple Protocol
+#   3. XRPL Protocol
 #
 #   4. HTTPS Client
 #
@@ -29,18 +29,17 @@
 #
 # Purpose
 #
-#   This file documents and provides examples of all rippled server process
-#   configuration options. When the rippled server instance is launched, it
+#   This file documents and provides examples of all xahaud server process
+#   configuration options. When the xahaud server instance is launched, it
 #   looks for a file with the following name:
 #
-#     rippled.cfg
+#     xahaud.cfg
 #
-#   For more information on where the rippled server instance searches for the
-#   file, visit:
+#   To run xahaud with a custom configuration file, use the "--conf {file}" flag.
+#   By default, xahaud will look in the local working directory or the home directory.
 #
-#     https://xrpl.org/commandline-usage.html#generic-options
 #
-#   This file should be named rippled.cfg. This file is UTF-8 with DOS, UNIX,
+#   This file should be named xahaud.cfg. This file is UTF-8 with DOS, UNIX,
 #   or Mac style end of lines. Blank lines and lines beginning with '#' are
 #   ignored. Undefined sections are reserved. No escapes are currently defined.
 #
@@ -89,8 +88,8 @@
 #
 #
 #
-#   rippled offers various server protocols to clients making inbound
-#   connections. The listening ports rippled uses are "universal" ports
+#   xahaud offers various server protocols to clients making inbound
+#   connections. The listening ports xahaud uses are "universal" ports
 #   which may be configured to handshake in one or more of the available
 #   supported protocols. These universal ports simplify administration:
 #   A single open port can be used for multiple protocols.
@@ -103,7 +102,7 @@
 #
 #   A list of port names and key/value pairs. A port name must start with a
 #   letter and contain only letters and numbers. The name is not case-sensitive.
-#   For each name in this list, rippled will look for a configuration file
+#   For each name in this list, xahaud will look for a configuration file
 #   section with the same name and use it to create a listening port. The
 #   name is informational only; the choice of name does not affect the function
 #   of the listening port.
@@ -134,7 +133,7 @@
 #       ip = 127.0.0.1
 #       protocol = http
 #
-#   When rippled is used as a command line client (for example, issuing a
+#   When xahaud is used as a command line client (for example, issuing a
 #   server stop command), the first port advertising the http or https
 #   protocol will be used to make the connection.
 #
@@ -175,7 +174,7 @@
 #       same time. It is possible have both Websockets and Secure Websockets
 #       together in one port.
 #
-#       NOTE    If no ports support the peer protocol, rippled cannot
+#       NOTE    If no ports support the peer protocol, xahaud cannot
 #               receive incoming peer connections or become a superpeer.
 #
 #   limit = <number>
@@ -194,7 +193,7 @@
 #       required. IP address restrictions, if any, will be checked in addition
 #       to the credentials specified here.
 #
-#       When acting in the client role, rippled will supply these credentials
+#       When acting in the client role, xahaud will supply these credentials
 #       using HTTP's Basic Authentication headers when making outbound HTTP/S
 #       requests.
 #
@@ -237,7 +236,7 @@
 #       WS, or WSS protocol interfaces. If administrative commands are
 #       disabled for a port, these credentials have no effect.
 #
-#       When acting in the client role, rippled will supply these credentials
+#       When acting in the client role, xahaud will supply these credentials
 #       in the submitted JSON for any administrative command requests when
 #       invoking JSON-RPC commands on remote servers.
 #
@@ -258,7 +257,7 @@
 #       resource controls will default to those for non-administrative users.
 #
 #       The secure_gateway IP addresses are intended to represent
-#       proxies. Since rippled trusts these hosts, they must be
+#       proxies. Since xahaud trusts these hosts, they must be
 #       responsible for properly authenticating the remote user.
 #
 #       If some IP addresses are included for both "admin" and
@@ -272,7 +271,7 @@
 #       Use the specified files when configuring SSL on the port.
 #
 #       NOTE    If no files are specified and secure protocols are selected,
-#               rippled will generate an internal self-signed certificate.
+#               xahaud will generate an internal self-signed certificate.
 #
 #       The files have these meanings:
 #
@@ -295,12 +294,12 @@
 #       Control the ciphers which the server will support over SSL on the port,
 #       specified using the OpenSSL "cipher list format".
 #
-#       NOTE    If unspecified, rippled will automatically configure a modern
+#       NOTE    If unspecified, xahaud will automatically configure a modern
 #               cipher suite. This default suite should be widely supported.
 #
 #               You should not modify this string unless you have a specific
 #               reason and cryptographic expertise. Incorrect modification may
-#               keep rippled from connecting to other instances of rippled or
+#               keep xahaud from connecting to other instances of xahaud or
 #               prevent RPC and WebSocket clients from connecting.
 #
 #   send_queue_limit = [1..65535]
@@ -351,7 +350,7 @@
 #
 #   Examples:
 #     { "command" : "server_info" }
-#     { "command" : "log_level", "partition" : "ripplecalc", "severity" : "trace" }
+#     { "command" : "log_level", "partition" : "xahaudcalc", "severity" : "trace" }
 #
 #
 #
@@ -380,16 +379,15 @@
 #-----------------
 #
 #   These settings control security and access attributes of the Peer to Peer
-#   server section of the rippled process. Peer Protocol implements the
-#   Ripple Payment protocol. It is over peer connections that transactions
-#   and validations are passed from to machine to machine, to determine the
-#   contents of validated ledgers.
+#   server section of the xahaud process. It is over peer connections that 
+#   transactions and validations are passed from to machine to machine, to 
+#   determine the contents of validated ledgers.
 #
 #
 #
 # [ips]
 #
-#   List of hostnames or ips where the Ripple protocol is served.  A default
+#   List of hostnames or ips where the XRPL protocol is served.  A default
 #   starter list is included in the code and used if no other hostnames are
 #   available.
 #
@@ -398,24 +396,23 @@
 #   does not generally matter.
 #
 #   The default list of entries is:
-#     - r.ripple.com 51235
-#     - zaphod.alloy.ee 51235
-#     - sahyadri.isrdc.in 51235
+#     - hubs.xahau.as16089.net 21337
+#     - bacab.alloy.ee 21337
 #
 #   Examples:
 #
 #   [ips]
 #   192.168.0.1
-#   192.168.0.1 2459
-#   r.ripple.com 51235
+#   192.168.0.1 21337
+#   bacab.alloy.ee 21337
 #
 #
 # [ips_fixed]
 #
-#   List of IP addresses or hostnames to which rippled should always attempt to
+#   List of IP addresses or hostnames to which xahaud should always attempt to
 #   maintain peer connections with. This is useful for manually forming private
 #   networks, for example to configure a validation server that connects to the
-#   Ripple network through a public-facing server, or for building a set
+#   Xahau Network through a public-facing server, or for building a set
 #   of cluster peers.
 #
 #   One address or domain names per line is allowed. A port must be specified
@@ -465,7 +462,7 @@
 #
 #   IP address or domain of NTP servers to use for time synchronization.
 #
-#   These NTP servers are suitable for rippled servers located in the United
+#   These NTP servers are suitable for xahaud servers located in the United
 #   States:
 #      time.windows.com
 #      time.apple.com
@@ -566,7 +563,7 @@
 #
 #   minimum_txn_in_ledger_standalone = <number>
 #
-#       Like minimum_txn_in_ledger when rippled is running in standalone
+#       Like minimum_txn_in_ledger when xahaud is running in standalone
 #       mode. Default: 1000.
 #
 #   target_txn_in_ledger = <number>
@@ -703,7 +700,7 @@
 #
 # [validator_token]
 #
-#   This is an alternative to [validation_seed] that allows rippled to perform
+#   This is an alternative to [validation_seed] that allows xahaud to perform
 #   validation without having to store the validator keys on the network
 #   connected server. The field should contain a single token in the form of a
 #   base64-encoded blob.
@@ -738,19 +735,18 @@
 #
 #   Specify the file by its name or path.
 #   Unless an absolute path is specified, it will be considered relative to
-#   the folder in which the rippled.cfg file is located.
+#   the folder in which the xahaud.cfg file is located.
 #
 #   Examples:
-#    /home/ripple/validators.txt
-#    C:/home/ripple/validators.txt
+#    /home/xahaud/validators.txt
+#    C:/home/xahaud/validators.txt
 #
 #   Example content:
 #    [validators]
-#    n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7
-#    n9MD5h24qrQqiyBC8aeqqCWvpiBiYQ3jxSr91uiDvmrkyHRdYLUj
-#    n9L81uNCaPgtUJfaHh89gmdvXKAmSt5Gdsw2g1iPWaPkAHW5Nm4C
-#    n9KiYM9CgngLvtRCQHZwgC2gjpdaZcCcbt3VboxiNFcKuwFVujzS
-#    n9LdgEtkmGB9E2h3K4Vp7iGUaKuq23Zr32ehxiU8FWY7xoxbWTSA
+#    n9L3GdotB8a3AqtsvS7NXt4BUTQSAYyJUr9xtFj2qXJjfbZsawKY
+#    n9LQDHLWyFuAn5BXJuW2ow5J9uGqpmSjRYS2cFRpxf6uJbxwDzvM
+#    n9MCWyKVUkiatXVJTKUrAESB5kBFP8R3hm43jGHtg8WBnjv3iDfb
+#    n9KWXCLRhjpajuZtULTXsy6R5xbisA6ozGxM4zdEJFq6uHiFZDvW
 #
 #
 #
@@ -833,7 +829,7 @@
 #
 #   0: Disable the ledger replay feature [default]
 #   1: Enable the ledger replay feature. With this feature enabled, when
-#      acquiring a ledger from the network, a rippled node only downloads
+#      acquiring a ledger from the network, a xahaud node only downloads
 #      the ledger header and the transactions instead of the whole ledger.
 #      And the ledger is built by applying the transactions to the parent
 #      ledger.
@@ -844,10 +840,9 @@
 #
 #----------------
 #
-#   The rippled server instance uses HTTPS GET requests in a variety of
+#   The xahaud server instance uses HTTPS GET requests in a variety of
 #   circumstances, including but not limited to contacting trusted domains to
-#   fetch information such as mapping an email address to a Ripple Payment
-#   Network address.
+#   fetch information such as mapping an email address to a user's r address.
 #
 # [ssl_verify]
 #
@@ -884,15 +879,15 @@
 #
 #------------
 #
-#   rippled has an optional operating mode called Reporting Mode. In Reporting
-#   Mode, rippled does not connect to the peer to peer network. Instead, rippled
-#   will continuously extract data from one or more rippled servers that are
+#   xahaud has an optional operating mode called Reporting Mode. In Reporting
+#   Mode, xahaud does not connect to the peer to peer network. Instead, xahaud 
+#   will continuously extract data from one or more xahaud servers that are
 #   connected to the peer to peer network (referred to as an ETL source).
 #   Reporting mode servers will forward RPC requests that require access to the
 #   peer to peer network (submit, fee, etc) to an ETL source.
 #
 #   [reporting]  Settings for Reporting Mode. If and only if this section is
-#                present, rippled will start in reporting mode. This section
+#                present, xahaud will start in reporting mode. This section
 #                contains a list of ETL source names, and key-value pairs. The
 #                ETL source names each correspond to a configuration file
 #                section; the names must match exactly. The key-value pairs are
@@ -997,16 +992,16 @@
 #
 #------------
 #
-#   rippled creates 4 SQLite database to hold bookkeeping information
+#   xahaud creates 4 SQLite database to hold bookkeeping information
 #   about transactions, local credentials, and various other things.
 #   It also creates the NodeDB, which holds all the objects that
-#   make up the current and historical ledgers. In Reporting Mode, rippled
+#   make up the current and historical ledgers. In Reporting Mode, xahauad 
 #   uses a Postgres database instead of SQLite.
 #
 #   The simplest way to work with Postgres is to install it locally.
 #   When it is running, execute the initdb.sh script in the current
 #   directory as: sudo -u postgres ./initdb.sh
-#   This will create the rippled user and an empty database of the same name.
+#   This will create the xahaud user and an empty database of the same name.
 #
 #   The size of the NodeDB grows in proportion to the amount of new data and the
 #   amount of historical data (a configurable setting) so the performance of the
@@ -1014,7 +1009,7 @@
 #   the performance of the server.
 #
 #   Partial pathnames will be considered relative to the location of
-#   the rippled.cfg file.
+#   the xahaud.cfg file.
 #
 #   [node_db]               Settings for the Node Database (required)
 #
@@ -1032,11 +1027,11 @@
 #   type = NuDB
 #
 #       NuDB is a high-performance database written by Ripple Labs and optimized
-#       for rippled and solid-state drives.
+#       for and solid-state drives.
 #
 #       NuDB maintains its high speed regardless of the amount of history
 #       stored. Online delete may be selected, but is not required. NuDB is
-#       available on all platforms that rippled runs on.
+#       available on all platforms that xahaud runs on.
 #
 #   type = RocksDB
 #
@@ -1124,7 +1119,7 @@
 #
 #   Optional keys for NuDB and RocksDB:
 #
-#       earliest_seq        The default is 32570 to match the XRP ledger
+#       earliest_seq        The default is 32570 to match the XRP Ledger's
 #                           network's earliest allowed sequence. Alternate
 #                           networks may set this value. Minimum value of 1.
 #                           If a [shard_db] section is defined, and this
@@ -1166,7 +1161,7 @@
 #
 #       recovery_wait_seconds
 #                           The online delete process checks periodically
-#                           that rippled is still in sync with the network,
+#                           that xahaud is still in sync with the network,
 #                           and that the validated ledger is less than
 #                           'age_threshold_seconds' old. If not, then continue
 #                           sleeping for this number of seconds and 
@@ -1205,8 +1200,8 @@
 #   The server creates and maintains 4 to 5 bookkeeping SQLite databases in
 #   the 'database_path' location. If you omit this configuration setting,
 #   the server creates a directory called "db" located in the same place as
-#   your rippled.cfg file.
-#   Partial pathnames are relative to the location of the rippled executable.
+#   your xahaud.cfg file.
+#   Partial pathnames are relative to the location of the xahaud executable.
 #
 #   [shard_db]      Settings for the Shard Database (optional)
 #
@@ -1282,7 +1277,7 @@
 #                           The default is "wal", which uses a write-ahead
 #                           log to implement database transactions.
 #                           Alternately, "memory" saves disk I/O, but if
-#                           rippled crashes during a transaction, the
+#                           xahaud crashes during a transaction, the
 #                           database is likely to be corrupted.
 #                           See https://www.sqlite.org/pragma.html#pragma_journal_mode
 #                           for more details about the available options.
@@ -1292,7 +1287,7 @@
 #       synchronous         Valid values: off, normal, full, extra
 #                           The default is "normal", which works well with
 #                           the "wal" journal mode. Alternatively, "off"
-#                           allows rippled to continue as soon as data is
+#                           allows xahaud to continue as soon as data is
 #                           passed to the OS, which can significantly
 #                           increase speed, but risks data corruption if
 #                           the host computer crashes before writing that
@@ -1306,7 +1301,7 @@
 #                           The default is "file", which will use files
 #                           for temporary database tables and indices.
 #                           Alternatively, "memory" may save I/O, but
-#                           rippled does not currently use many, if any,
+#                           xahaud does not currently use many, if any,
 #                           of these temporary objects.
 #                           See https://www.sqlite.org/pragma.html#pragma_temp_store
 #                           for more details about the available options.
@@ -1318,9 +1313,9 @@
 #      conninfo             Info for connecting to Postgres. Format is
 #                           postgres://[username]:[password]@[ip]/[database].
 #                           The database and user must already exist. If this
-#                           section is missing and rippled is running in
-#                           Reporting Mode, rippled will connect as the
-#                           user running rippled to a database with the
+#                           section is missing and xahaud is running in
+#                           Reporting Mode, xahaud will connect as the
+#                           user running xahaud to a database with the
 #                           same name. On Linux and Mac OS X, the connection
 #                           will take place using the server's UNIX domain
 #                           socket. On Windows, through the localhost IP
@@ -1329,7 +1324,7 @@
 #      use_tx_tables        Valid values: 1, 0
 #                           The default is 1 (true). Determines whether to use
 #                           the SQLite transaction database. If set to 0,
-#                           rippled will not write to the transaction database,
+#                           xahaud will not write to the transaction database,
 #                           and will reject tx, account_tx and tx_history RPCs.
 #                           In Reporting Mode, this setting is ignored.
 #
@@ -1357,7 +1352,7 @@
 #
 #   These settings are designed to help server administrators diagnose
 #   problems, and obtain detailed information about the activities being
-#   performed by the rippled process.
+#   performed by the xahaud process.
 #
 #
 #
@@ -1374,7 +1369,7 @@
 #
 #   Configuration parameters for the Beast. Insight stats collection module.
 #
-#   Insight is a module that collects information from the areas of rippled
+#   Insight is a module that collects information from the areas of xahaud 
 #   that have instrumentation. The configuration parameters control where the
 #   collection metrics are sent. The parameters are expressed as key = value
 #   pairs with no white space. The main parameter is the choice of server:
@@ -1383,7 +1378,7 @@
 #
 #       Choice of server to send metrics to. Currently the only choice is
 #       "statsd" which sends UDP packets to a StatsD daemon, which must be
-#       running while rippled is running. More information on StatsD is
+#       running while xahaud is running. More information on StatsD is
 #       available here:
 #           https://github.com/b/statsd_spec
 #
@@ -1393,7 +1388,7 @@
 #                 in the format, n.n.n.n:port.
 #
 #       "prefix"  A string prepended to each collected metric. This is used
-#                 to distinguish between different running instances of rippled.
+#                 to distinguish between different running instances of xahaud.
 #
 #     If this section is missing, or the server type is unspecified or unknown,
 #     statistics are not collected or reported.
@@ -1420,7 +1415,7 @@
 #
 #   Example:
 #     [perf]
-#     perf_log=/var/log/rippled/perf.log
+#     perf_log=/var/log/xahaud/perf.log
 #     log_interval=2
 #
 #-------------------------------------------------------------------------------
@@ -1429,8 +1424,8 @@
 #
 #----------
 #
-#   The vote settings configure settings for the entire Ripple network.
-#   While a single instance of rippled cannot unilaterally enforce network-wide
+#   The vote settings configure settings for the entire Xahau Network.
+#   While a single instance of xahaud cannot unilaterally enforce network-wide
 #   settings, these choices become part of the instance's vote during the
 #   consensus process for each voting ledger.
 #
@@ -1442,9 +1437,9 @@
 #
 #       The cost of the reference transaction fee, specified in drops.
 #       The reference transaction is the simplest form of transaction.
-#       It represents an XRP payment between two parties.
+#       It represents an XAH payment between two parties.
 #
-#       If this parameter is unspecified, rippled will use an internal
+#       If this parameter is unspecified, xahaud will use an internal
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
@@ -1453,26 +1448,26 @@
 #   account_reserve = <drops>
 #
 #       The account reserve requirement is specified in drops. The portion of an
-#       account's XRP balance that is at or below the reserve may only be
+#       account's XAH balance that is at or below the reserve may only be
 #       spent on transaction fees, and not transferred out of the account.
 #
-#       If this parameter is unspecified, rippled will use an internal
+#       If this parameter is unspecified, xahaud will use an internal
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
-#           account_reserve = 10000000   # 10 XRP
+#           account_reserve = 10000000   # 10 XAH
 #
 #   owner_reserve = <drops>
 #
-#       The owner reserve is the amount of XRP reserved in the account for
+#       The owner reserve is the amount of XAH reserved in the account for
 #       each ledger item owned by the account. Ledger items an account may
 #       own include trust lines, open orders, and tickets.
 #
-#       If this parameter is unspecified, rippled will use an internal
+#       If this parameter is unspecified, xahaud will use an internal
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
-#           owner_reserve = 2000000      # 2 XRP
+#           owner_reserve = 2000000      # 2 XAH
 #
 #-------------------------------------------------------------------------------
 #
@@ -1510,7 +1505,7 @@
 #   tool instead.
 #
 #   This flag has no effect on the "sign" and "sign_for" command line options
-#   that rippled makes available.
+#   that xahaud makes available.
 #
 #   The default value of this field is "false"
 #
@@ -1589,7 +1584,7 @@
 #--------------------
 #
 #   Administrators can use these values as a starting point for configuring
-#   their instance of rippled, but each value should be checked to make sure
+#   their instance of xahaud, but each value should be checked to make sure
 #   it meets the business requirements for the organization.
 #
 # Server
@@ -1599,7 +1594,7 @@
 #   "peer"
 #
 #       Peer protocol open to everyone. This is required to accept
-#       incoming rippled connections. This does not affect automatic
+#       incoming xahaud connections. This does not affect automatic
 #       or manual outgoing Peer protocol connections.
 #
 #   "rpc"
@@ -1627,8 +1622,8 @@
 #   NOTE
 #
 #       To accept connections on well known ports such as 80 (HTTP) or
-#       443 (HTTPS), most operating systems will require rippled to
-#       run with administrator privileges, or else rippled will not start.
+#       443 (HTTPS), most operating systems will require xahaud to
+#       run with administrator privileges, or else xahaud will not start.
 
 [server]
 port_rpc_admin_local
@@ -1645,7 +1640,7 @@ admin = 127.0.0.1
 protocol = http
 
 [port_peer]
-port = 51235
+port = 21337
 ip = 0.0.0.0
 # alternatively, to accept connections on IPv4 + IPv6, use:
 #ip = ::
@@ -1669,9 +1664,9 @@ secure_gateway = 127.0.0.1
 
 #-------------------------------------------------------------------------------
 
-# This is primary persistent datastore for rippled.  This includes transaction
+# This is primary persistent datastore for xahaud.  This includes transaction
 # metadata, account states, and ledger headers.  Helpful information can be
-# found at https://xrpl.org/capacity-planning.html#node-db-type
+# found at https://xahau.network/docs/infrastructure/system-requirements
 # type=NuDB is recommended for non-validators with fast SSDs. Validators or
 #    slow / spinning disks should use RocksDB. Caution: Spinning disks are
 #    not recommended. They do not perform well enough to consistently remain
@@ -1684,16 +1679,16 @@ secure_gateway = 127.0.0.1
 #    deletion.
 [node_db]
 type=NuDB
-path=/var/lib/rippled/db/nudb
+path=/var/lib/xahaud/db/nudb
 online_delete=512
 advisory_delete=0
 
 # This is the persistent datastore for shards. It is important for the health
-# of the ripple network that rippled operators shard as much as practical.
+# of the Xahau Network that xahaud operators shard as much as practical.
 # NuDB requires SSD storage. Helpful information can be found at
 # https://xrpl.org/history-sharding.html
 #[shard_db]
-#path=/var/lib/rippled/db/shards/nudb
+#path=/var/lib/xahaud/db/shards/nudb
 #max_historical_shards=50
 #
 # This optional section can be configured with a list
@@ -1704,7 +1699,7 @@ advisory_delete=0
 #/path/2
 
 [database_path]
-/var/lib/rippled/db
+/var/lib/xahaud/db
 
 
 # To use Postgres, uncomment this section and fill in the appropriate connection
@@ -1719,7 +1714,7 @@ advisory_delete=0
 # This needs to be an absolute directory reference, not a relative one.
 # Modify this value as required.
 [debug_logfile]
-/var/log/rippled/debug.log
+/var/log/xahaud/debug.log
 
 [sntp_servers]
 time.windows.com
@@ -1727,15 +1722,19 @@ time.apple.com
 time.nist.gov
 pool.ntp.org
 
-# To use the XRP test network
-# (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),
+# To use the Xahau Test Network
+# (see https://xahau.network/docs/infrastructure/installing-xahaud),
 # use the following [ips] section:
 # [ips]
-# r.altnet.rippletest.net 51235
+# 79.110.60.121 21338
+# 79.110.60.122 21338
+# 79.110.60.124 21338
+# 79.110.60.125 21338
+
 
 # File containing trusted validator keys or validator list publishers.
 # Unless an absolute path is specified, it will be considered relative to the
-# folder in which the rippled.cfg file is located.
+# folder in which the xahaud.cfg file is located.
 [validators_file]
 validators.txt
 

--- a/cfg/xahaud-reporting.cfg
+++ b/cfg/xahaud-reporting.cfg
@@ -9,7 +9,7 @@
 #
 #   2. Peer Protocol
 #
-#   3. Ripple Protocol
+#   3. XRPL Protocol
 #
 #   4. HTTPS Client
 #
@@ -29,18 +29,16 @@
 #
 # Purpose
 #
-#   This file documents and provides examples of all rippled server process
-#   configuration options. When the rippled server instance is launched, it
+#   This file documents and provides examples of all xahaud server process
+#   configuration options. When the xahaud server instance is launched, it
 #   looks for a file with the following name:
 #
-#     rippled.cfg
+#     xahaud.cfg
 #
-#   For more information on where the rippled server instance searches for the
-#   file, visit:
+#   To run xahaud with a custom configuration file, use the "--conf {file}" flag.
+#   By default, xahaud will look in the local working directory or the home directory
 #
-#     https://xrpl.org/commandline-usage.html#generic-options
-#
-#   This file should be named rippled.cfg. This file is UTF-8 with DOS, UNIX,
+#   This file should be named xahaud.cfg. This file is UTF-8 with DOS, UNIX,
 #   or Mac style end of lines. Blank lines and lines beginning with '#' are
 #   ignored. Undefined sections are reserved. No escapes are currently defined.
 #
@@ -89,8 +87,8 @@
 #
 #
 #
-#   rippled offers various server protocols to clients making inbound
-#   connections. The listening ports rippled uses are "universal" ports
+#   xahaud offers various server protocols to clients making inbound
+#   connections. The listening ports xahaud uses are "universal" ports
 #   which may be configured to handshake in one or more of the available
 #   supported protocols. These universal ports simplify administration:
 #   A single open port can be used for multiple protocols.
@@ -103,7 +101,7 @@
 #
 #   A list of port names and key/value pairs. A port name must start with a
 #   letter and contain only letters and numbers. The name is not case-sensitive.
-#   For each name in this list, rippled will look for a configuration file
+#   For each name in this list, xahaud will look for a configuration file
 #   section with the same name and use it to create a listening port. The
 #   name is informational only; the choice of name does not affect the function
 #   of the listening port.
@@ -134,7 +132,7 @@
 #       ip = 127.0.0.1
 #       protocol = http
 #
-#   When rippled is used as a command line client (for example, issuing a
+#   When xahaud is used as a command line client (for example, issuing a
 #   server stop command), the first port advertising the http or https
 #   protocol will be used to make the connection.
 #
@@ -175,7 +173,7 @@
 #       same time. It is possible have both Websockets and Secure Websockets
 #       together in one port.
 #
-#       NOTE    If no ports support the peer protocol, rippled cannot
+#       NOTE    If no ports support the peer protocol, xahaud cannot
 #               receive incoming peer connections or become a superpeer.
 #
 #   limit = <number>
@@ -194,7 +192,7 @@
 #       required. IP address restrictions, if any, will be checked in addition
 #       to the credentials specified here.
 #
-#       When acting in the client role, rippled will supply these credentials
+#       When acting in the client role, xahaud will supply these credentials
 #       using HTTP's Basic Authentication headers when making outbound HTTP/S
 #       requests.
 #
@@ -227,7 +225,7 @@
 #       WS, or WSS protocol interfaces. If administrative commands are
 #       disabled for a port, these credentials have no effect.
 #
-#       When acting in the client role, rippled will supply these credentials
+#       When acting in the client role, xahaud will supply these credentials
 #       in the submitted JSON for any administrative command requests when
 #       invoking JSON-RPC commands on remote servers.
 #
@@ -247,11 +245,11 @@
 #       resource controls will default to those for non-administrative users.
 #
 #       The secure_gateway IP addresses are intended to represent
-#       proxies. Since rippled trusts these hosts, they must be
+#       proxies. Since xahaud trusts these hosts, they must be
 #       responsible for properly authenticating the remote user.
 #
 #       The same IP address cannot be used in both "admin" and "secure_gateway"
-#       lists for the same port. In this case, rippled will abort with an error
+#       lists for the same port. In this case, xahaud will abort with an error
 #       message to the console shortly after startup
 #
 #   ssl_key = <filename>
@@ -261,7 +259,7 @@
 #       Use the specified files when configuring SSL on the port.
 #
 #       NOTE    If no files are specified and secure protocols are selected,
-#               rippled will generate an internal self-signed certificate.
+#               xahaud will generate an internal self-signed certificate.
 #
 #       The files have these meanings:
 #
@@ -284,12 +282,12 @@
 #       Control the ciphers which the server will support over SSL on the port,
 #       specified using the OpenSSL "cipher list format".
 #
-#       NOTE    If unspecified, rippled will automatically configure a modern
+#       NOTE    If unspecified, xahaud will automatically configure a modern
 #               cipher suite. This default suite should be widely supported.
 #
 #               You should not modify this string unless you have a specific
 #               reason and cryptographic expertise. Incorrect modification may
-#               keep rippled from connecting to other instances of rippled or
+#               keep xahaud from connecting to other instances of xahaud or
 #               prevent RPC and WebSocket clients from connecting.
 #
 #   send_queue_limit = [1..65535]
@@ -340,7 +338,7 @@
 #
 #   Examples:
 #     { "command" : "server_info" }
-#     { "command" : "log_level", "partition" : "ripplecalc", "severity" : "trace" }
+#     { "command" : "log_level", "partition" : "xahaucalc", "severity" : "trace" }
 #
 #
 #
@@ -369,8 +367,8 @@
 #-----------------
 #
 #   These settings control security and access attributes of the Peer to Peer
-#   server section of the rippled process. Peer Protocol implements the
-#   Ripple Payment protocol. It is over peer connections that transactions
+#   server section of the xahaud process. Peer Protocol implements the
+#   XRPL Payment protocol. It is over peer connections that transactions
 #   and validations are passed from to machine to machine, to determine the
 #   contents of validated ledgers.
 #
@@ -378,7 +376,7 @@
 #
 # [ips]
 #
-#   List of hostnames or ips where the Ripple protocol is served.  A default
+#   List of hostnames or ips where the XRPL protocol is served.  A default
 #   starter list is included in the code and used if no other hostnames are
 #   available.
 #
@@ -387,24 +385,23 @@
 #   does not generally matter.
 #
 #   The default list of entries is:
-#     - r.ripple.com 51235
-#     - zaphod.alloy.ee 51235
-#     - sahyadri.isrdc.in 51235
+#     - bacab.alloy.ee 21337
+#     - hubs.xahau.as16089.net 21337
 #
 #   Examples:
 #
 #   [ips]
 #   192.168.0.1
-#   192.168.0.1 2459
-#   r.ripple.com 51235
+#   192.168.0.1 21337
+#   bacab.alloy.ee 21337
 #
 #
 # [ips_fixed]
 #
-#   List of IP addresses or hostnames to which rippled should always attempt to
+#   List of IP addresses or hostnames to which xahaud should always attempt to
 #   maintain peer connections with. This is useful for manually forming private
 #   networks, for example to configure a validation server that connects to the
-#   Ripple network through a public-facing server, or for building a set
+#   Xahau Network through a public-facing server, or for building a set
 #   of cluster peers.
 #
 #   One address or domain names per line is allowed. A port must be specified
@@ -454,7 +451,7 @@
 #
 #   IP address or domain of NTP servers to use for time synchronization.
 #
-#   These NTP servers are suitable for rippled servers located in the United
+#   These NTP servers are suitable for xahaud servers located in the United
 #   States:
 #      time.windows.com
 #      time.apple.com
@@ -555,7 +552,7 @@
 #
 #   minimum_txn_in_ledger_standalone = <number>
 #
-#       Like minimum_txn_in_ledger when rippled is running in standalone
+#       Like minimum_txn_in_ledger when xahaud is running in standalone
 #       mode. Default: 1000.
 #
 #   target_txn_in_ledger = <number>
@@ -682,7 +679,7 @@
 #
 # [validator_token]
 #
-#   This is an alternative to [validation_seed] that allows rippled to perform
+#   This is an alternative to [validation_seed] that allows xahaud to perform
 #   validation without having to store the validator keys on the network
 #   connected server. The field should contain a single token in the form of a
 #   base64-encoded blob.
@@ -717,22 +714,21 @@
 #
 #   Specify the file by its name or path.
 #   Unless an absolute path is specified, it will be considered relative to
-#   the folder in which the rippled.cfg file is located.
+#   the folder in which the xahaud.cfg file is located.
 #
 #   Examples:
-#    /home/ripple/validators.txt
-#    C:/home/ripple/validators.txt
+#    /home/xahaud/validators.txt
+#    C:/home/xahaud/validators.txt
 #
 #   Example content:
 #    [validators]
-#    n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7
-#    n9MD5h24qrQqiyBC8aeqqCWvpiBiYQ3jxSr91uiDvmrkyHRdYLUj
-#    n9L81uNCaPgtUJfaHh89gmdvXKAmSt5Gdsw2g1iPWaPkAHW5Nm4C
-#    n9KiYM9CgngLvtRCQHZwgC2gjpdaZcCcbt3VboxiNFcKuwFVujzS
-#    n9LdgEtkmGB9E2h3K4Vp7iGUaKuq23Zr32ehxiU8FWY7xoxbWTSA
-#
-#
-#
+#    n9L3GdotB8a3AqtsvS7NXt4BUTQSAYyJUr9xtFj2qXJjfbZsawKY
+#    n9LQDHLWyFuAn5BXJuW2ow5J9uGqpmSjRYS2cFRpxf6uJbxwDzvM
+#    n9MCWyKVUkiatXVJTKUrAESB5kBFP8R3hm43jGHtg8WBnjv3iDfb
+#    n9KWXCLRhjpajuZtULTXsy6R5xbisA6ozGxM4zdEJFq6uHiFZDvW
+
+
+
 # [path_search]
 #   When searching for paths, the default search aggressiveness. This can take
 #   exponentially more resources as the size is increased.
@@ -795,7 +791,7 @@
 #
 #   0: Disable the ledger replay feature [default]
 #   1: Enable the ledger replay feature. With this feature enabled, when
-#      acquiring a ledger from the network, a rippled node only downloads
+#      acquiring a ledger from the network, a xahaud node only downloads
 #      the ledger header and the transactions instead of the whole ledger.
 #      And the ledger is built by applying the transactions to the parent
 #      ledger.
@@ -806,9 +802,9 @@
 #
 #----------------
 #
-#   The rippled server instance uses HTTPS GET requests in a variety of
+#   The xahaud server instance uses HTTPS GET requests in a variety of
 #   circumstances, including but not limited to contacting trusted domains to
-#   fetch information such as mapping an email address to a Ripple Payment
+#   fetch information such as mapping an email address to a XRPL Payment
 #   Network address.
 #
 # [ssl_verify]
@@ -846,15 +842,15 @@
 #
 #------------
 #
-#   rippled has an optional operating mode called Reporting Mode. In Reporting
-#   Mode, rippled does not connect to the peer to peer network. Instead, rippled
-#   will continuously extract data from one or more rippled servers that are
+#   xahaud has an optional operating mode called Reporting Mode. In Reporting
+#   Mode, xahaud does not connect to the peer to peer network. Instead, xahaud
+#   will continuously extract data from one or more xahaud servers that are
 #   connected to the peer to peer network (referred to as an ETL source).
 #   Reporting mode servers will forward RPC requests that require access to the
 #   peer to peer network (submit, fee, etc) to an ETL source.
 #
 #   [reporting]  Settings for Reporting Mode. If and only if this section is
-#                present, rippled will start in reporting mode. This section
+#                present, xahaud will start in reporting mode. This section
 #                contains a list of ETL source names, and key-value pairs. The
 #                ETL source names each correspond to a configuration file
 #                section; the names must match exactly. The key-value pairs are
@@ -959,16 +955,16 @@
 #
 #------------
 #
-#   rippled creates 4 SQLite database to hold bookkeeping information
+#   xahaud creates 4 SQLite database to hold bookkeeping information
 #   about transactions, local credentials, and various other things.
 #   It also creates the NodeDB, which holds all the objects that
-#   make up the current and historical ledgers. In Reporting Mode, rippled
+#   make up the current and historical ledgers. In Reporting Mode, xahaud
 #   uses a Postgres database instead of SQLite.
 #
 #   The simplest way to work with Postgres is to install it locally.
 #   When it is running, execute the initdb.sh script in the current
 #   directory as: sudo -u postgres ./initdb.sh
-#   This will create the rippled user and an empty database of the same name.
+#   This will create the xahaud user and an empty database of the same name.
 #
 #   The size of the NodeDB grows in proportion to the amount of new data and the
 #   amount of historical data (a configurable setting) so the performance of the
@@ -976,7 +972,7 @@
 #   the performance of the server.
 #
 #   Partial pathnames will be considered relative to the location of
-#   the rippled.cfg file.
+#   the xahaud.cfg file.
 #
 #   [node_db]               Settings for the Node Database (required)
 #
@@ -994,11 +990,11 @@
 #   type = NuDB
 #
 #       NuDB is a high-performance database written by Ripple Labs and optimized
-#       for rippled and solid-state drives.
+#       for solid-state drives.
 #
 #       NuDB maintains its high speed regardless of the amount of history
 #       stored. Online delete may be selected, but is not required. NuDB is
-#       available on all platforms that rippled runs on.
+#       available on all platforms that xahaud runs on.
 #
 #   type = RocksDB
 #
@@ -1103,14 +1099,14 @@
 #
 #       recovery_wait_seconds
 #                           The online delete process checks periodically
-#                           that rippled is still in sync with the network,
+#                           that xahaud is still in sync with the network,
 #                           and that the validated ledger is less than
 #                           'age_threshold_seconds' old. By default, if it
 #                           is not the online delete process aborts and
 #                           tries again later. If 'recovery_wait_seconds'
-#                           is set and rippled is out of sync, but likely to
+#                           is set and xahaud is out of sync, but likely to
 #                           recover quickly, then online delete will wait
-#                           this number of seconds for rippled to get back
+#                           this number of seconds for xahaud to get back
 #                           into sync before it aborts.
 #                           Set this value if the node is otherwise staying
 #                           in sync, or recovering quickly, but the online
@@ -1146,8 +1142,8 @@
 #   The server creates and maintains 4 to 5 bookkeeping SQLite databases in
 #   the 'database_path' location. If you omit this configuration setting,
 #   the server creates a directory called "db" located in the same place as
-#   your rippled.cfg file.
-#   Partial pathnames are relative to the location of the rippled executable.
+#   your xahaud.cfg file.
+#   Partial pathnames are relative to the location of the xahaud executable.
 #
 #   [shard_db]      Settings for the Shard Database (optional)
 #
@@ -1223,7 +1219,7 @@
 #                           The default is "wal", which uses a write-ahead
 #                           log to implement database transactions.
 #                           Alternately, "memory" saves disk I/O, but if
-#                           rippled crashes during a transaction, the
+#                           xahaud crashes during a transaction, the
 #                           database is likely to be corrupted.
 #                           See https://www.sqlite.org/pragma.html#pragma_journal_mode
 #                           for more details about the available options.
@@ -1233,7 +1229,7 @@
 #       synchronous         Valid values: off, normal, full, extra
 #                           The default is "normal", which works well with
 #                           the "wal" journal mode. Alternatively, "off"
-#                           allows rippled to continue as soon as data is
+#                           allows xahaud to continue as soon as data is
 #                           passed to the OS, which can significantly
 #                           increase speed, but risks data corruption if
 #                           the host computer crashes before writing that
@@ -1247,7 +1243,7 @@
 #                           The default is "file", which will use files
 #                           for temporary database tables and indices.
 #                           Alternatively, "memory" may save I/O, but
-#                           rippled does not currently use many, if any,
+#                           xahaud does not currently use many, if any,
 #                           of these temporary objects.
 #                           See https://www.sqlite.org/pragma.html#pragma_temp_store
 #                           for more details about the available options.
@@ -1259,9 +1255,9 @@
 #      conninfo             Info for connecting to Postgres. Format is
 #                           postgres://[username]:[password]@[ip]/[database].
 #                           The database and user must already exist. If this
-#                           section is missing and rippled is running in
-#                           Reporting Mode, rippled will connect as the
-#                           user running rippled to a database with the
+#                           section is missing and xahaud is running in
+#                           Reporting Mode, xahaud will connect as the
+#                           user running xahaud to a database with the
 #                           same name. On Linux and Mac OS X, the connection
 #                           will take place using the server's UNIX domain
 #                           socket. On Windows, through the localhost IP
@@ -1270,7 +1266,7 @@
 #      use_tx_tables        Valid values: 1, 0
 #                           The default is 1 (true). Determines whether to use
 #                           the SQLite transaction database. If set to 0,
-#                           rippled will not write to the transaction database,
+#                           xahaud will not write to the transaction database,
 #                           and will reject tx, account_tx and tx_history RPCs.
 #                           In Reporting Mode, this setting is ignored.
 #
@@ -1298,7 +1294,7 @@
 #
 #   These settings are designed to help server administrators diagnose
 #   problems, and obtain detailed information about the activities being
-#   performed by the rippled process.
+#   performed by the xahaud process.
 #
 #
 #
@@ -1315,7 +1311,7 @@
 #
 #   Configuration parameters for the Beast. Insight stats collection module.
 #
-#   Insight is a module that collects information from the areas of rippled
+#   Insight is a module that collects information from the areas of xahaud
 #   that have instrumentation. The configuration parameters control where the
 #   collection metrics are sent. The parameters are expressed as key = value
 #   pairs with no white space. The main parameter is the choice of server:
@@ -1324,7 +1320,7 @@
 #
 #       Choice of server to send metrics to. Currently the only choice is
 #       "statsd" which sends UDP packets to a StatsD daemon, which must be
-#       running while rippled is running. More information on StatsD is
+#       running while xahaud is running. More information on StatsD is
 #       available here:
 #           https://github.com/b/statsd_spec
 #
@@ -1334,7 +1330,7 @@
 #                 in the format, n.n.n.n:port.
 #
 #       "prefix"  A string prepended to each collected metric. This is used
-#                 to distinguish between different running instances of rippled.
+#                 to distinguish between different running instances of xahaud.
 #
 #     If this section is missing, or the server type is unspecified or unknown,
 #     statistics are not collected or reported.
@@ -1361,7 +1357,7 @@
 #
 #   Example:
 #     [perf]
-#     perf_log=/var/log/rippled/perf.log
+#     perf_log=/var/log/xahaud/perf.log
 #     log_interval=2
 #
 #-------------------------------------------------------------------------------
@@ -1370,8 +1366,8 @@
 #
 #----------
 #
-#   The vote settings configure settings for the entire Ripple network.
-#   While a single instance of rippled cannot unilaterally enforce network-wide
+#   The vote settings configure settings for the entire Xahau Network.
+#   While a single instance of xahaud cannot unilaterally enforce network-wide
 #   settings, these choices become part of the instance's vote during the
 #   consensus process for each voting ledger.
 #
@@ -1383,9 +1379,9 @@
 #
 #       The cost of the reference transaction fee, specified in drops.
 #       The reference transaction is the simplest form of transaction.
-#       It represents an XRP payment between two parties.
+#       It represents an XAH payment between two parties.
 #
-#       If this parameter is unspecified, rippled will use an internal
+#       If this parameter is unspecified, xahaud will use an internal
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
@@ -1394,26 +1390,26 @@
 #   account_reserve = <drops>
 #
 #       The account reserve requirement is specified in drops. The portion of an
-#       account's XRP balance that is at or below the reserve may only be
+#       account's XAH balance that is at or below the reserve may only be
 #       spent on transaction fees, and not transferred out of the account.
 #
-#       If this parameter is unspecified, rippled will use an internal
+#       If this parameter is unspecified, xahaud will use an internal
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
-#           account_reserve = 10000000   # 10 XRP
+#           account_reserve = 10000000   # 10 XAH
 #
 #   owner_reserve = <drops>
 #
-#       The owner reserve is the amount of XRP reserved in the account for
+#       The owner reserve is the amount of XAH reserved in the account for
 #       each ledger item owned by the account. Ledger items an account may
 #       own include trust lines, open orders, and tickets.
 #
-#       If this parameter is unspecified, rippled will use an internal
+#       If this parameter is unspecified, xahaud will use an internal
 #       default. Don't change this without understanding the consequences.
 #
 #       Example:
-#           owner_reserve = 2000000      # 2 XRP
+#           owner_reserve = 2000000      # 2 XAH
 #
 #-------------------------------------------------------------------------------
 #
@@ -1451,7 +1447,7 @@
 #   tool instead.
 #
 #   This flag has no effect on the "sign" and "sign_for" command line options
-#   that rippled makes available.
+#   that xahaud makes available.
 #
 #   The default value of this field is "false"
 #
@@ -1530,7 +1526,7 @@
 #--------------------
 #
 #   Administrators can use these values as a starting point for configuring
-#   their instance of rippled, but each value should be checked to make sure
+#   their instance of xahaud, but each value should be checked to make sure
 #   it meets the business requirements for the organization.
 #
 # Server
@@ -1540,7 +1536,7 @@
 #   "peer"
 #
 #       Peer protocol open to everyone. This is required to accept
-#       incoming rippled connections. This does not affect automatic
+#       incoming xahaud connections. This does not affect automatic
 #       or manual outgoing Peer protocol connections.
 #
 #   "rpc"
@@ -1568,8 +1564,8 @@
 #   NOTE
 #
 #       To accept connections on well known ports such as 80 (HTTP) or
-#       443 (HTTPS), most operating systems will require rippled to
-#       run with administrator privileges, or else rippled will not start.
+#       443 (HTTPS), most operating systems will require xahaud to
+#       run with administrator privileges, or else xahaud will not start.
 
 [server]
 port_rpc_admin_local
@@ -1587,7 +1583,7 @@ admin = 127.0.0.1
 protocol = http
 
 [port_peer]
-port = 51235
+port = 21337
 ip = 0.0.0.0
 # alternatively, to accept connections on IPv4 + IPv6, use:
 #ip = ::
@@ -1611,9 +1607,9 @@ protocol = ws
 
 #-------------------------------------------------------------------------------
 
-# This is primary persistent datastore for rippled.  This includes transaction
+# This is primary persistent datastore for xahaud.  This includes transaction
 # metadata, account states, and ledger headers.  Helpful information can be
-# found at https://xrpl.org/capacity-planning.html#node-db-type
+# found at https://xahau.network/docs/infrastructure/system-requirements
 # type=NuDB is recommended for non-validators with fast SSDs. Validators or
 #    slow / spinning disks should use RocksDB. Caution: Spinning disks are
 #    not recommended. They do not perform well enough to consistently remain
@@ -1626,16 +1622,16 @@ protocol = ws
 #    deletion.
 [node_db]
 type=NuDB
-path=/var/lib/rippled-reporting/db/nudb
+path=/var/lib/xahaud-reporting/db/nudb
 # online_delete=512 #
 advisory_delete=0
 
 # This is the persistent datastore for shards. It is important for the health
-# of the ripple network that rippled operators shard as much as practical.
+# of the Xahau Network that xahaud operators shard as much as practical.
 # NuDB requires SSD storage. Helpful information can be found at
 # https://xrpl.org/history-sharding.html
 #[shard_db]
-#path=/var/lib/rippled/db/shards/nudb
+#path=/var/lib/xahaud/db/shards/nudb
 #max_historical_shards=50
 #
 # This optional section can be configured with a list
@@ -1646,7 +1642,7 @@ advisory_delete=0
 #/path/2
 
 [database_path]
-/var/lib/rippled-reporting/db
+/var/lib/xahaud-reporting/db
 
 # To use Postgres, uncomment this section and fill in the appropriate connection
 # info. Postgres can only be used in Reporting Mode.
@@ -1660,7 +1656,7 @@ advisory_delete=0
 # This needs to be an absolute directory reference, not a relative one.
 # Modify this value as required.
 [debug_logfile]
-/var/log/rippled-reporting/debug.log
+/var/log/xahaud-reporting/debug.log
 
 [sntp_servers]
 time.windows.com
@@ -1668,17 +1664,20 @@ time.apple.com
 time.nist.gov
 pool.ntp.org
 
-# To use the XRP test network
-# (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),
+# To use the Xahau Test Network
+# (see https://xahau.network/docs/infrastructure/installing-xahaud),
 # use the following [ips] section:
 # [ips]
-# r.altnet.rippletest.net 51235
+# 79.110.60.121 21338
+# 79.110.60.122 21338
+# 79.110.60.124 21338
+# 79.110.60.125 21338
 
 # File containing trusted validator keys or validator list publishers.
 # Unless an absolute path is specified, it will be considered relative to the
-# folder in which the rippled.cfg file is located.
+# folder in which the xahaud.cfg file is located.
 [validators_file]
-/opt/rippled-reporting/etc/validators.txt
+/opt/xahaud-reporting/etc/validators.txt
 
 # Turn down default logging to save disk space in the long run.
 # Valid values here are trace, debug, info, warning, error, and fatal

--- a/cfg/xahaud-reporting.cfg
+++ b/cfg/xahaud-reporting.cfg
@@ -1622,7 +1622,7 @@ protocol = ws
 #    deletion.
 [node_db]
 type=NuDB
-path=/var/lib/xahaud-reporting/db/nudb
+path=/opt/xahaud-reporting/db/nudb
 # online_delete=512 #
 advisory_delete=0
 
@@ -1631,7 +1631,7 @@ advisory_delete=0
 # NuDB requires SSD storage. Helpful information can be found at
 # https://xrpl.org/history-sharding.html
 #[shard_db]
-#path=/var/lib/xahaud/db/shards/nudb
+#path=/opt/xahaud-reporting/db/shards/nudb
 #max_historical_shards=50
 #
 # This optional section can be configured with a list
@@ -1642,7 +1642,7 @@ advisory_delete=0
 #/path/2
 
 [database_path]
-/var/lib/xahaud-reporting/db
+/opt/xahaud-reporting/db
 
 # To use Postgres, uncomment this section and fill in the appropriate connection
 # info. Postgres can only be used in Reporting Mode.
@@ -1698,5 +1698,5 @@ etl_source
 
 [etl_source]
 source_grpc_port=50051
-source_ws_port=6005
+source_ws_port=6008
 source_ip=127.0.0.1

--- a/cfg/xahaud-standalone.cfg
+++ b/cfg/xahaud-standalone.cfg
@@ -1,4 +1,4 @@
-# standalone: ./rippled -a --ledgerfile config/genesis.json --conf config/rippled-standalone.cfg
+# standalone: ./xahaud -a --ledgerfile config/genesis.json --conf config/xahaud-standalone.cfg
 [server]
 port_rpc_admin_local
 port_ws_public
@@ -21,7 +21,7 @@ ip = 0.0.0.0
 protocol = ws
 
 # [port_peer]
-# port = 51235
+# port = 21337
 # ip = 0.0.0.0
 # protocol = peer
 
@@ -69,7 +69,8 @@ time.nist.gov
 pool.ntp.org
 
 [ips]
-r.ripple.com 51235
+bacab.alloy.ee 21337
+hubs.xahau.as16089.net 21337
 
 [validators_file]
 validators-example.txt
@@ -94,7 +95,7 @@ validators-example.txt
 1000000
 
 [network_id]
-21338
+21337
 
 [amendments]
 740352F2412A9909880C23A559FCECEDA3BE2126FED62FC7660D628A06927F11 Flow


### PR DESCRIPTION
The sample configuration files still reference things like "rippled", "XRP", and "port 51235" throughout. This commit revises the config files to use terminology and settings that are congruent with xahaud:

"rippled" -> "xahaud"
"Ripple Network" -> "Xahau Network"
"51235" -> "21337"
"xrpl.org" -> "xahau.network" (as appropriate)

Additionally, validator keys and publishers have been updated.