### PR TITLE
build: migrate to conan 2

### DIFF
--- a/.github/actions/xahau-ga-build/action.yml
+++ b/.github/actions/xahau-ga-build/action.yml
@@ -94,6 +94,10 @@ runs:
         fi
         
         # Run CMake configure
+        # Note: conanfile.py hardcodes 'build/generators' as the output path.
+        # If we're in a 'build' folder, Conan detects this and uses just 'generators/'
+        # If we're in '.build' (non-standard), Conan adds the full 'build/generators/'
+        # So we get: .build/build/generators/ with our non-standard folder name
         cmake .. \
           -G "${{ inputs.generator }}" \
           $CCACHE_ARGS \

--- a/.github/actions/xahau-ga-dependencies/action.yml
+++ b/.github/actions/xahau-ga-dependencies/action.yml
@@ -78,8 +78,9 @@ runs:
     - name: Export custom recipes
       shell: bash
       run: |
-        conan export external/snappy snappy/1.1.10@xahaud/stable
-        conan export external/soci soci/4.0.3@xahaud/stable
+        conan export external/snappy --version 1.1.10 --user xahaud --channel stable
+        conan export external/soci --version 4.0.3 --user xahaud --channel stable
+        conan export external/wasmedge --version 0.11.2 --user xahaud --channel stable
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/xahau-ga-macos.yml
+++ b/.github/workflows/xahau-ga-macos.yml
@@ -32,9 +32,9 @@ jobs:
 
       - name: Install Conan
         run: |
-          brew install conan@1
-          # Add Conan 1 to the PATH for this job
-          echo "$(brew --prefix conan@1)/bin" >> $GITHUB_PATH
+          brew install conan
+          # Verify Conan 2 is installed
+          conan --version
 
       - name: Install Coreutils
         run: |
@@ -60,12 +60,20 @@ jobs:
 
       - name: Install CMake
         run: |
-          if which cmake > /dev/null 2>&1; then
-              echo "cmake executable exists"
-              cmake --version
-          else
-              brew install cmake
-          fi
+          # Install CMake 3.x to match local dev environments
+          # With Conan 2 and the policy args passed to CMake, newer versions
+          # can have issues with dependencies that require cmake_minimum_required < 3.5
+          brew uninstall cmake --ignore-dependencies 2>/dev/null || true
+
+          # Download and install CMake 3.31.7 directly
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-macos-universal.tar.gz -o cmake.tar.gz
+          tar -xzf cmake.tar.gz
+
+          # Move the entire CMake.app to /Applications
+          sudo mv cmake-3.31.7-macos-universal/CMake.app /Applications/
+
+          echo "/Applications/CMake.app/Contents/bin" >> $GITHUB_PATH
+          /Applications/CMake.app/Contents/bin/cmake --version
 
       - name: Install ccache
         run: brew install ccache
@@ -92,8 +100,30 @@ jobs:
 
       - name: Configure Conan
         run: |
-          conan profile new default --detect || true # Ignore error if profile exists
-          conan profile update settings.compiler.cppstd=20 default
+          # Create the default profile directory if it doesn't exist
+          mkdir -p ~/.conan2/profiles
+
+          # Detect compiler version
+          COMPILER_VERSION=$(clang --version | grep -oE 'version [0-9]+' | grep -oE '[0-9]+')
+
+          # Create profile with our specific settings
+          cat > ~/.conan2/profiles/default <<EOF
+          [settings]
+          arch=armv8
+          build_type=Release
+          compiler=apple-clang
+          compiler.cppstd=20
+          compiler.libcxx=libc++
+          compiler.version=${COMPILER_VERSION}
+          os=Macos
+
+          [conf]
+          # Workaround for gRPC with newer Apple Clang
+          tools.build:cxxflags=["-Wno-missing-template-arg-list-after-template-kw"]
+          EOF
+
+          # Display profile for verification
+          conan profile show
 
       - name: Install dependencies
         uses: ./.github/actions/xahau-ga-dependencies

--- a/.github/workflows/xahau-ga-nix.yml
+++ b/.github/workflows/xahau-ga-nix.yml
@@ -41,8 +41,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build ${{ matrix.cc }} ${{ matrix.cxx }} ccache
-          # Install specific Conan version needed
-          pip install --upgrade "conan<2"
+          # Install Conan 2
+          pip install --upgrade "conan>=2.0"
 
       - name: Configure ccache
         uses: ./.github/actions/xahau-configure-ccache
@@ -54,18 +54,30 @@ jobs:
 
       - name: Configure Conan
         run: |
-          conan profile new default --detect || true # Ignore error if profile exists
-          conan profile update settings.compiler.cppstd=20 default
-          conan profile update settings.compiler=${{ matrix.compiler }} default
-          conan profile update settings.compiler.libcxx=libstdc++11 default
-          conan profile update env.CC=/usr/bin/${{ matrix.cc }} default
-          conan profile update env.CXX=/usr/bin/${{ matrix.cxx }} default
-          conan profile update conf.tools.build:compiler_executables='{"c": "/usr/bin/${{ matrix.cc }}", "cpp": "/usr/bin/${{ matrix.cxx }}"}' default
+          # Create the default profile directory if it doesn't exist
+          mkdir -p ~/.conan2/profiles
 
-          # Set compiler version from matrix
-          conan profile update settings.compiler.version=${{ matrix.compiler_version }} default
+          # Create profile with our specific settings
+          cat > ~/.conan2/profiles/default <<EOF
+          [settings]
+          arch=x86_64
+          build_type=Release
+          compiler=${{ matrix.compiler }}
+          compiler.cppstd=20
+          compiler.libcxx=libstdc++11
+          compiler.version=${{ matrix.compiler_version }}
+          os=Linux
+
+          [buildenv]
+          CC=/usr/bin/${{ matrix.cc }}
+          CXX=/usr/bin/${{ matrix.cxx }}
+
+          [conf]
+          tools.build:compiler_executables={"c": "/usr/bin/${{ matrix.cc }}", "cpp": "/usr/bin/${{ matrix.cxx }}"}
+          EOF
+
           # Display profile for verification
-          conan profile show default
+          conan profile show
 
       - name: Check environment
         run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -33,7 +33,7 @@ git checkout develop
 ## Minimum Requirements
 
 - [Python 3.7](https://www.python.org/downloads/)
-- [Conan 1.55](https://conan.io/downloads.html)
+- [Conan 2.x](https://conan.io/downloads)
 - [CMake 3.16](https://cmake.org/download/)
 
 `rippled` is written in the C++20 dialect and includes the `<concepts>` header.
@@ -65,13 +65,24 @@ can't build earlier Boost versions.
 1. (Optional) If you've never used Conan, use autodetect to set up a default profile.
 
    ```
-   conan profile new default --detect
+   conan profile detect --force
    ```
 
 2. Update the compiler settings.
 
+   For Conan 2, you can edit the profile directly at `~/.conan2/profiles/default`,
+   or use the Conan CLI. Ensure C++20 is set:
+
    ```
-   conan profile update settings.compiler.cppstd=20 default
+   conan profile show
+   ```
+
+   Look for `compiler.cppstd=20` in the output. If it's not set, edit the profile:
+
+   ```
+   # Edit ~/.conan2/profiles/default and ensure these settings exist:
+   [settings]
+   compiler.cppstd=20
    ```
 
    Linux developers will commonly have a default Conan [profile][] that compiles
@@ -80,7 +91,9 @@ can't build earlier Boost versions.
    then you will need to choose the `libstdc++11` ABI.
 
    ```
-   conan profile update settings.compiler.libcxx=libstdc++11 default
+   # In ~/.conan2/profiles/default, ensure:
+   [settings]
+   compiler.libcxx=libstdc++11
    ```
 
    On Windows, you should use the x64 native build tools.
@@ -91,7 +104,9 @@ can't build earlier Boost versions.
    architecture.
 
    ```
-   conan profile update settings.arch=x86_64 default
+   # In ~/.conan2/profiles/default, ensure:
+   [settings]
+   arch=x86_64
    ```
 
 3. (Optional) If you have multiple compilers installed on your platform,
@@ -100,16 +115,18 @@ can't build earlier Boost versions.
    in the generated CMake toolchain file.
 
    ```
-   conan profile update 'conf.tools.build:compiler_executables={"c": "<path>", "cpp": "<path>"}' default
+   # In ~/.conan2/profiles/default, add under [conf] section:
+   [conf]
+   tools.build:compiler_executables={"c": "<path>", "cpp": "<path>"}
    ```
 
-   It should choose the compiler for dependencies as well,
-   but not all of them have a Conan recipe that respects this setting (yet).
-   For the rest, you can set these environment variables:
+   For setting environment variables for dependencies:
 
    ```
-   conan profile update env.CC=<path> default
-   conan profile update env.CXX=<path> default
+   # In ~/.conan2/profiles/default, add under [buildenv] section:
+   [buildenv]
+   CC=<path>
+   CXX=<path>
    ```
 
 4. Export our [Conan recipe for Snappy](./external/snappy).
@@ -117,14 +134,20 @@ can't build earlier Boost versions.
    which allows you to statically link it with GCC, if you want.
 
    ```
-   conan export external/snappy snappy/1.1.10@xahaud/stable
+   conan export external/snappy --version 1.1.10 --user xahaud --channel stable
    ```
 
 5. Export our [Conan recipe for SOCI](./external/soci).
    It patches their CMake to correctly import its dependencies.
 
    ```
-   conan export external/soci soci/4.0.3@xahaud/stable
+   conan export external/soci --version 4.0.3 --user xahaud --channel stable
+   ```
+
+6. Export our [Conan recipe for WasmEdge](./external/wasmedge).
+
+   ```
+   conan export external/wasmedge --version 0.11.2 --user xahaud --channel stable
    ```
 
 ### Build and Test
@@ -259,23 +282,26 @@ and can be helpful for detecting `#include` omissions.
 If you have trouble building dependencies after changing Conan settings,
 try removing the Conan cache.
 
+For Conan 2:
 ```
-rm -rf ~/.conan/data
+rm -rf ~/.conan2/p
+```
+
+Or clear the entire Conan 2 cache:
+```
+conan cache clean "*"
 ```
 
 
-### no std::result_of
+### macOS compilation with Apple Clang 17+
 
-If your compiler version is recent enough to have removed `std::result_of` as
-part of C++20, e.g. Apple Clang 15.0, then you might need to add a preprocessor
-definition to your build.
+If you're on macOS with Apple Clang 17 or newer, you need to add a compiler flag to work around a compilation error in gRPC dependencies.
+
+Edit `~/.conan2/profiles/default` and add under the `[conf]` section:
 
 ```
-conan profile update 'options.boost:extra_b2_flags="define=BOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
-conan profile update 'env.CFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
-conan profile update 'env.CXXFLAGS="-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"' default
-conan profile update 'conf.tools.build:cflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
-conan profile update 'conf.tools.build:cxxflags+=["-DBOOST_ASIO_HAS_STD_INVOKE_RESULT"]' default
+[conf]
+tools.build:cxxflags=["-Wno-missing-template-arg-list-after-template-kw"]
 ```
 
 

--- a/build-core.sh
+++ b/build-core.sh
@@ -59,7 +59,8 @@ cd release-build &&
 # The tool_requires('b2/5.3.2') in conanfile.py should force b2 to build from source
 # with the correct toolchain, avoiding the GLIBCXX_3.4.29 issue
 echo "=== Installing dependencies ===" &&
-conan install .. --output-folder . --build missing --settings build_type=$BUILD_TYPE &&
+conan install .. --output-folder . --build missing --settings build_type=$BUILD_TYPE \
+  -o with_wasmedge=False -o tool_requires_b2=True &&
 cmake .. -G Ninja \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake \

--- a/build-core.sh
+++ b/build-core.sh
@@ -12,6 +12,13 @@ echo "-- GITHUB_REPOSITORY: $1"
 echo "-- GITHUB_SHA:        $2"
 echo "-- GITHUB_RUN_NUMBER: $4"
 
+# Use mounted filesystem for temp files to avoid container space limits
+export TMPDIR=/io/tmp
+export TEMP=/io/tmp
+export TMP=/io/tmp
+mkdir -p /io/tmp
+echo "=== Using temp directory: /io/tmp ==="
+
 umask 0000;
 
 cd /io/ &&
@@ -43,9 +50,15 @@ export LDFLAGS="-static-libstdc++"
 git config --global --add safe.directory /io &&
 git checkout src/ripple/protocol/impl/BuildInfo.cpp &&
 sed -i s/\"0.0.0\"/\"$(date +%Y).$(date +%-m).$(date +%-d)-$(git rev-parse --abbrev-ref HEAD)$(if [ -n "$4" ]; then echo "+$4"; fi)\"/g src/ripple/protocol/impl/BuildInfo.cpp &&
-conan export external/snappy snappy/1.1.10@xahaud/stable &&
-conan export external/soci soci/4.0.3@xahaud/stable &&
+conan export external/snappy --version 1.1.10 --user xahaud --channel stable &&
+conan export external/soci --version 4.0.3 --user xahaud --channel stable &&
+conan export external/wasmedge --version 0.11.2 --user xahaud --channel stable &&
 cd release-build &&
+# Install dependencies - tool_requires in conanfile.py handles glibc 2.28 compatibility
+# for build tools (protoc, grpc plugins, b2) in HBB environment
+# The tool_requires('b2/5.3.2') in conanfile.py should force b2 to build from source
+# with the correct toolchain, avoiding the GLIBCXX_3.4.29 issue
+echo "=== Installing dependencies ===" &&
 conan install .. --output-folder . --build missing --settings build_type=$BUILD_TYPE &&
 cmake .. -G Ninja \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -56,10 +69,13 @@ cmake .. -G Ninja \
   -Dxrpld=TRUE \
   -Dtests=TRUE &&
 ccache -z &&
-ninja -j $3 &&
+ninja -j $3 && echo "=== Re-running final link with verbose output ===" && rm -f rippled && ninja -v rippled &&
 ccache -s &&
-strip -s rippled &&	
+strip -s rippled &&
 mv rippled xahaud &&
+echo "=== Full ldd output ===" &&
+ldd xahaud &&
+echo "=== Running libcheck ===" &&
 libcheck xahaud &&
 echo "Build host: `hostname`" > release.info &&
 echo "Build date: `date`" >> release.info &&

--- a/build-full.sh
+++ b/build-full.sh
@@ -69,6 +69,7 @@ source /opt/rh/gcc-toolset-11/enable
 export PATH=/usr/local/bin:$PATH
 export CC='ccache gcc' &&
 export CXX='ccache g++' &&
+export HBB_RELEASE_BUILD=1 &&
 echo "-- Build Rippled --" &&
 pwd &&
 

--- a/build-full.sh
+++ b/build-full.sh
@@ -69,7 +69,6 @@ source /opt/rh/gcc-toolset-11/enable
 export PATH=/usr/local/bin:$PATH
 export CC='ccache gcc' &&
 export CXX='ccache g++' &&
-export HBB_RELEASE_BUILD=1 &&
 echo "-- Build Rippled --" &&
 pwd &&
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,21 +23,26 @@ class Xrpl(ConanFile):
         'unity': [True, False],
     }
 
+    import os
+
+    # Check if we're in HBB release build environment
+    IS_HBB_BUILD = os.getenv('HBB_RELEASE_BUILD') == '1'
+
     requires = [
-        'boost/1.86.0',
         'date/3.0.1',
         'libarchive/3.6.0',
-        'lz4/1.9.3',
+        'lz4/1.9.4',
         'grpc/1.50.1',
         'nudb/2.0.8',
         'openssl/1.1.1u',
-        'protobuf/3.21.9',
-        'snappy/1.1.10@xahaud/stable',
+        'protobuf/3.21.12',
         'soci/4.0.3@xahaud/stable',
-        'sqlite3/3.42.0',
-        'zlib/1.2.13',
-        'wasmedge/0.11.2',
+        'zlib/1.3.1',
     ]
+
+    # Only include deps that aren't manually installed in HBB
+    if not IS_HBB_BUILD:
+        requires.append('wasmedge/0.11.2@xahaud/stable')
 
     default_options = {
         'assertions': False,
@@ -51,41 +56,41 @@ class Xrpl(ConanFile):
         'tests': True,
         'unity': False,
 
-        'cassandra-cpp-driver:shared': False,
-        'date:header_only': True,
-        'grpc:shared': False,
-        'grpc:secure': True,
-        'libarchive:shared': False,
-        'libarchive:with_acl': False,
-        'libarchive:with_bzip2': False,
-        'libarchive:with_cng': False,
-        'libarchive:with_expat': False,
-        'libarchive:with_iconv': False,
-        'libarchive:with_libxml2': False,
-        'libarchive:with_lz4': True,
-        'libarchive:with_lzma': False,
-        'libarchive:with_lzo': False,
-        'libarchive:with_nettle': False,
-        'libarchive:with_openssl': False,
-        'libarchive:with_pcreposix': False,
-        'libarchive:with_xattr': False,
-        'libarchive:with_zlib': False,
-        'libpq:shared': False,
-        'lz4:shared': False,
-        'openssl:shared': False,
-        'protobuf:shared': False,
-        'protobuf:with_zlib': True,
-        'rocksdb:enable_sse': False,
-        'rocksdb:lite': False,
-        'rocksdb:shared': False,
-        'rocksdb:use_rtti': True,
-        'rocksdb:with_jemalloc': False,
-        'rocksdb:with_lz4': True,
-        'rocksdb:with_snappy': True,
-        'snappy:shared': False,
-        'soci:shared': False,
-        'soci:with_sqlite3': True,
-        'soci:with_boost': True,
+        'cassandra-cpp-driver/*:shared': False,
+        'date/*:header_only': True,
+        'grpc/*:shared': False,
+        'grpc/*:secure': True,
+        'libarchive/*:shared': False,
+        'libarchive/*:with_acl': False,
+        'libarchive/*:with_bzip2': False,
+        'libarchive/*:with_cng': False,
+        'libarchive/*:with_expat': False,
+        'libarchive/*:with_iconv': False,
+        'libarchive/*:with_libxml2': False,
+        'libarchive/*:with_lz4': True,
+        'libarchive/*:with_lzma': False,
+        'libarchive/*:with_lzo': False,
+        'libarchive/*:with_nettle': False,
+        'libarchive/*:with_openssl': False,
+        'libarchive/*:with_pcreposix': False,
+        'libarchive/*:with_xattr': False,
+        'libarchive/*:with_zlib': False,
+        'libpq/*:shared': False,
+        'lz4/*:shared': False,
+        'openssl/*:shared': False,
+        'protobuf/*:shared': False,
+        'protobuf/*:with_zlib': True,
+        'rocksdb/*:enable_sse': False,
+        'rocksdb/*:lite': False,
+        'rocksdb/*:shared': False,
+        'rocksdb/*:use_rtti': True,
+        'rocksdb/*:with_jemalloc': False,
+        'rocksdb/*:with_lz4': True,
+        'rocksdb/*:with_snappy': True,
+        'snappy/*:shared': False,
+        'soci/*:shared': False,
+        'soci/*:with_sqlite3': True,
+        'soci/*:with_boost': True,
     }
 
     def set_version(self):
@@ -96,11 +101,38 @@ class Xrpl(ConanFile):
             match = next(m for m in matches if m)
             self.version = match.group(1)
 
+    def build_requirements(self):
+        # These provide build tools (protoc, grpc plugins) that run during build
+        self.tool_requires('protobuf/3.21.12')
+        self.tool_requires('grpc/1.50.1')
+        # Force b2 to build from source for glibc compatibility in HBB builds
+        if self.IS_HBB_BUILD:
+            self.tool_requires('b2/5.3.2')
+
     def configure(self):
         if self.settings.compiler == 'apple-clang':
-            self.options['boost'].visibility = 'global'
+            self.options['boost/*'].visibility = 'global'
+
+        # HBB builds have both manual boost (for WasmEdge) and Conan boost (for the app and deps like nudb/soci)
+        # The linker will deduplicate symbols from both versions
+
 
     def requirements(self):
+        # Force sqlite3 version to avoid conflicts with soci
+        self.requires('sqlite3/3.42.0', override=True)
+        # Force our custom snappy build for all dependencies
+        self.requires('snappy/1.1.10@xahaud/stable', override=True)
+
+        # Force boost version for all dependencies to avoid conflicts
+        # NOTE: HBB builds have both manual boost (for WasmEdge) and Conan boost because:
+        #   - WasmEdge is manually built and linked against minimal system boost (filesystem + system)
+        #   - The application itself requires boost (chrono, coroutine, thread, etc.)
+        #   - Dependencies like nudb/soci also require boost components
+        #   - The application and deps use Conan's boost (via CMake toolchain)
+        #   - Both are boost 1.86.0, so symbols are identical (no version conflicts)
+        #   - Static linking means symbols are resolved at link time, not runtime
+        self.requires('boost/1.86.0', override=True)
+
         if self.options.jemalloc:
             self.requires('jemalloc/5.2.1')
         if self.options.reporting:

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,12 +21,9 @@ class Xrpl(ConanFile):
         'static': [True, False],
         'tests': [True, False],
         'unity': [True, False],
+        'with_wasmedge': [True, False],
+        'tool_requires_b2': [True, False],
     }
-
-    import os
-
-    # Check if we're in HBB release build environment
-    IS_HBB_BUILD = os.getenv('HBB_RELEASE_BUILD') == '1'
 
     requires = [
         'date/3.0.1',
@@ -40,10 +37,6 @@ class Xrpl(ConanFile):
         'zlib/1.3.1',
     ]
 
-    # Only include deps that aren't manually installed in HBB
-    if not IS_HBB_BUILD:
-        requires.append('wasmedge/0.11.2@xahaud/stable')
-
     default_options = {
         'assertions': False,
         'coverage': False,
@@ -55,6 +48,8 @@ class Xrpl(ConanFile):
         'static': True,
         'tests': True,
         'unity': False,
+        'with_wasmedge': True,
+        'tool_requires_b2': False,
 
         'cassandra-cpp-driver/*:shared': False,
         'date/*:header_only': True,
@@ -105,8 +100,8 @@ class Xrpl(ConanFile):
         # These provide build tools (protoc, grpc plugins) that run during build
         self.tool_requires('protobuf/3.21.12')
         self.tool_requires('grpc/1.50.1')
-        # Force b2 to build from source for glibc compatibility in HBB builds
-        if self.IS_HBB_BUILD:
+        # Explicitly require b2 (e.g. for building from source for glibc compatibility)
+        if self.options.tool_requires_b2:
             self.tool_requires('b2/5.3.2')
 
     def configure(self):
@@ -118,17 +113,11 @@ class Xrpl(ConanFile):
         self.requires('sqlite3/3.42.0', override=True)
         # Force our custom snappy build for all dependencies
         self.requires('snappy/1.1.10@xahaud/stable', override=True)
-
         # Force boost version for all dependencies to avoid conflicts
-        # NOTE: HBB builds have both manual boost (for WasmEdge) and Conan boost because:
-        #   - WasmEdge is manually built and linked against minimal system boost (filesystem + system)
-        #   - The application itself requires boost (chrono, coroutine, thread, etc.)
-        #   - Dependencies like nudb/soci also require boost components
-        #   - The application and deps use Conan's boost (via CMake toolchain)
-        #   - Both are boost 1.86.0, so symbols are identical (no version conflicts)
-        #   - Static linking means symbols are resolved at link time, not runtime
         self.requires('boost/1.86.0', override=True)
 
+        if self.options.with_wasmedge:
+            self.requires('wasmedge/0.11.2@xahaud/stable')
         if self.options.jemalloc:
             self.requires('jemalloc/5.2.1')
         if self.options.reporting:

--- a/conanfile.py
+++ b/conanfile.py
@@ -113,10 +113,6 @@ class Xrpl(ConanFile):
         if self.settings.compiler == 'apple-clang':
             self.options['boost/*'].visibility = 'global'
 
-        # HBB builds have both manual boost (for WasmEdge) and Conan boost (for the app and deps like nudb/soci)
-        # The linker will deduplicate symbols from both versions
-
-
     def requirements(self):
         # Force sqlite3 version to avoid conflicts with soci
         self.requires('sqlite3/3.42.0', override=True)

--- a/external/wasmedge/conanfile.py
+++ b/external/wasmedge/conanfile.py
@@ -38,8 +38,15 @@ class WasmedgeConan(ConanFile):
             raise ConanInvalidConfiguration("Binaries for this combination of version/os/arch/compiler are not available")
 
     def package_id(self):
-        del self.info.settings.compiler.version
-        self.info.settings.compiler = self._compiler_alias
+        # Make binary compatible across compiler versions (since we're downloading prebuilt)
+        self.info.settings.rm_safe("compiler.version")
+        # Group compilers by their binary compatibility
+        # Note: We must use self.info.settings here, not self.settings (forbidden in Conan 2)
+        compiler_name = str(self.info.settings.compiler)
+        if compiler_name in ["Visual Studio", "msvc"]:
+            self.info.settings.compiler = "Visual Studio"
+        else:
+            self.info.settings.compiler = "gcc"
 
     def build(self):
         # This is packaging binaries so the download needs to be in build

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -1,8 +1,10 @@
-#!/bin/bash 
+#!/bin/bash
 # We use set -e and bash with -u to bail on first non zero exit code of any
 # processes launched or upon any unbound variable.
 # We use set -x to print commands before running them to help with
 # debugging.
+
+set -ex
 
 echo "START BUILDING (HOST)"
 

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -93,7 +93,7 @@ RUN /hbb_exe/activate-exec bash -c "dnf install -y epel-release && \
     dnf clean all"
 
 # Install Conan 2 and CMake
-RUN /hbb_exe/activate-exec pip3 install "conan>=2.0" && \
+RUN /hbb_exe/activate-exec pip3 install "conan>=2.0,<3.0" && \
     /hbb_exe/activate-exec wget -q https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz -O cmake.tar.gz && \
     mkdir cmake && \
     tar -xzf cmake.tar.gz --strip-components=1 -C cmake && \

--- a/release-builder.sh
+++ b/release-builder.sh
@@ -90,28 +90,36 @@ RUN /hbb_exe/activate-exec bash -c "dnf install -y epel-release && \
         llvm14-static llvm14-devel && \
     dnf clean all"
 
-# Install Conan and CMake
-RUN /hbb_exe/activate-exec pip3 install "conan==1.66.0" && \
+# Install Conan 2 and CMake
+RUN /hbb_exe/activate-exec pip3 install "conan>=2.0" && \
     /hbb_exe/activate-exec wget -q https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz -O cmake.tar.gz && \
     mkdir cmake && \
     tar -xzf cmake.tar.gz --strip-components=1 -C cmake && \
     rm cmake.tar.gz
 
-# Install Boost 1.86.0
-RUN /hbb_exe/activate-exec bash -c "cd /tmp && \
+# Dual Boost configuration in HBB environment:
+# - Manual Boost in /usr/local (minimal: for WasmEdge which is pre-built in Docker)
+# - Conan Boost (full: for the application and all dependencies via toolchain)
+#
+# Install minimal Boost 1.86.0 for WasmEdge only (filesystem and its dependencies)
+# The main application will use Conan-provided Boost for all other components
+# IMPORTANT: Understanding Boost linking options:
+#   - link=static: Creates static Boost libraries (.a files) instead of shared (.so files)
+#   - runtime-link=shared: Links Boost libraries against shared libc (glibc)
+# WasmEdge only needs boost::filesystem and boost::system
+RUN /hbb_exe/activate-exec bash -c "echo 'Boost cache bust: v5-minimal' && \
+    rm -rf /usr/local/lib/libboost* /usr/local/include/boost && \
+    cd /tmp && \
     wget -q https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz -O boost.tar.gz && \
     mkdir boost && \
     tar -xzf boost.tar.gz --strip-components=1 -C boost && \
     cd boost && \
     ./bootstrap.sh && \
-    ./b2 link=static -j${BUILD_CORES} && \
-    ./b2 install && \
+    ./b2 install \
+        link=static runtime-link=shared -j${BUILD_CORES} \
+        --with-filesystem --with-system && \
     cd /tmp && \
     rm -rf boost boost.tar.gz"
-
-ENV BOOST_ROOT=/usr/local/src/boost_1_86_0
-ENV Boost_LIBRARY_DIRS=/usr/local/lib
-ENV BOOST_INCLUDEDIR=/usr/local/src/boost_1_86_0
 
 ENV CMAKE_EXE_LINKER_FLAGS="-static-libstdc++"
 
@@ -155,6 +163,10 @@ RUN cd /tmp && \
     cd build && \
     /hbb_exe/activate-exec bash -c "source /opt/rh/gcc-toolset-11/enable && \
     ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/ar /usr/bin/ar && \
+    ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/ranlib /usr/bin/ranlib && \
+    echo '=== Binutils version check ===' && \
+    ar --version | head -1 && \
+    ranlib --version | head -1 && \
     cmake .. \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -176,14 +188,28 @@ RUN cd /tmp && \
 # Set environment variables
 ENV PATH=/usr/local/bin:$PATH
 
-# Configure ccache and Conan
+# Configure ccache and Conan 2
+# NOTE: Using echo commands instead of heredocs because heredocs in Docker RUN commands are finnicky
 RUN /hbb_exe/activate-exec bash -c "ccache -M 10G && \
     ccache -o cache_dir=/cache/ccache && \
     ccache -o compiler_check=content && \
-    conan config set storage.path=/cache/conan && \
-    (conan profile new default --detect || true) && \
-    conan profile update settings.compiler.libcxx=libstdc++11 default && \
-    conan profile update settings.compiler.cppstd=20 default"
+    mkdir -p ~/.conan2 /cache/conan2 /cache/conan2_download /cache/conan2_sources && \
+    echo 'core.cache:storage_path=/cache/conan2' > ~/.conan2/global.conf && \
+    echo 'core.download:download_cache=/cache/conan2_download' >> ~/.conan2/global.conf && \
+    echo 'core.sources:download_cache=/cache/conan2_sources' >> ~/.conan2/global.conf && \
+    conan profile detect --force && \
+    echo '[settings]' > ~/.conan2/profiles/default && \
+    echo 'arch=x86_64' >> ~/.conan2/profiles/default && \
+    echo 'build_type=Release' >> ~/.conan2/profiles/default && \
+    echo 'compiler=gcc' >> ~/.conan2/profiles/default && \
+    echo 'compiler.cppstd=20' >> ~/.conan2/profiles/default && \
+    echo 'compiler.libcxx=libstdc++11' >> ~/.conan2/profiles/default && \
+    echo 'compiler.version=11' >> ~/.conan2/profiles/default && \
+    echo 'os=Linux' >> ~/.conan2/profiles/default && \
+    echo '' >> ~/.conan2/profiles/default && \
+    echo '[conf]' >> ~/.conan2/profiles/default && \
+    echo '# Force building from source for packages with binary compatibility issues' >> ~/.conan2/profiles/default && \
+    echo '*:tools.system.package_manager:mode=build' >> ~/.conan2/profiles/default"
 
 DOCKERFILE_EOF
 )


### PR DESCRIPTION
# PR #585: Migrate to Conan 2

## Summary

This PR migrates the xahaud build system from Conan 1 to Conan 2, addressing deprecation warnings and preparing for Conan 1's end-of-life. The migration maintains full compatibility with both local development and Holy Build Box (HBB) release builds while simplifying several aspects of the build configuration.

## Key Changes

### 1. Conan 2 Syntax and Configuration

#### Updated Command Syntax
- **Export commands**: Changed from `conan export <path> <reference>` to `conan export <path> --version <ver> --user <user> --channel <channel>`
- **Profile management**: Migrated from Conan 1 profile format to Conan 2's cleaner syntax
- **Cache paths**: Updated from `/cache/conan` to `/cache/conan2` with separate download and source caches
- **Version overrides**: Ensure consistency with `override=True` for boost/1.86.0, sqlite3/3.42.0, snappy/1.1.10

#### Profile Structure (Conan 2 Format)
```ini
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=20
compiler.libcxx=libstdc++11
compiler.version=11
os=Linux

[conf]
# Build tools configuration
tools.build:compiler_executables={"c": "/usr/bin/gcc", "cpp": "/usr/bin/g++"}
```

### 2. Dual Boost Configuration Documentation

The PR clarifies and documents the intentional dual Boost setup in HBB builds:

- **Manual Boost (minimal)**: Built in Docker for WasmEdge only (filesystem + system components)
- **Conan Boost (full)**: Provides all components needed by the application and dependencies (nudb, soci)

Both are version 1.86.0, ensuring symbol compatibility. The static linking resolves any potential conflicts at link time.

**Why not just use Conan's Boost for everything?** WasmEdge is compiled during the Docker image build (for caching efficiency), while Conan runs later inside a container using that image. The Docker-cached WasmEdge build needs Boost libraries to be present at Docker build time, before Conan has even run.

**Why not manage everything through Conan?** This is technically possible but would require:
- A custom WasmEdge recipe that builds from source (upstream only provides prebuilt binaries)
- A custom LLVM 14.x recipe (Conan Center jumped from 13.x to 19.x, skipping the version WasmEdge needs)
- Figuring out how to make Conan recipes use system libraries (not straightforward in Conan's isolated build environment)

The current approach of Docker-cached manual builds + Conan for standard dependencies is a pragmatic compromise that avoids maintaining complex custom recipes.

### 3. Build Tool Requirements

Added `tool_requires()` for build tools to ensure proper glibc compatibility:
- `protobuf/3.21.12` - Provides protoc compiler
- `grpc/1.50.1` - Provides gRPC plugins
- `b2/5.3.2` (HBB only) - Forces source build to avoid GLIBCXX version issues

Additionally, the HBB Docker configuration includes:
```ini
[conf]
# Force building from source for packages with binary compatibility issues
*:tools.system.package_manager:mode=build
```
This ensures all Conan packages are built from source with HBB's gcc-toolset-11, avoiding prebuilt binaries that might have incompatible glibc requirements.

### 4. Updated Custom WasmEdge Recipe

Updated `external/wasmedge/conanfile.py` to handle prebuilt WasmEdge binaries:
- Updated `package_id()` implementation for Conan 2

### 5. CI/CD Updates

All GitHub Actions workflows updated for Conan 2:
- **Linux**: Full Conan 2 profile configuration
- **macOS**: CMake 3.31.7 for compatibility, Apple Clang workarounds
- **Docker**: Comprehensive dependency installation with proper caching


## Technical Details

### HBB Build Environment

The Holy Build Box environment requires special handling for glibc 2.28 compatibility:
- Prebuilt b2 binaries require GLIBCXX_3.4.29 (too new for HBB's glibc 2.28)
- Solution: Force b2 to build from source via `tool_requires('b2/5.3.2')`
- Manual LLVM 14 and WasmEdge installation for static linking

**Key constraint**: WasmEdge requires LLVM 14.x specifically for WebAssembly compilation, but Conan Center only offers 11.x, 12.x, 13.x, or 19.x. This gap necessitates manual installation.

### Build Verification

Added comprehensive build verification:
- Verbose final link step to debug symbol resolution
- Full `ldd` output to verify dynamic dependencies
- `libcheck` validation for system library compliance

### Temporary File Handling

Improved temp file management in containerized builds:
```bash
export TMPDIR=/io/tmp
export TEMP=/io/tmp
export TMP=/io/tmp
```

## Migration Benefits

1. **Future-proof**: Conan 1 reaches end-of-life soon
2. **Cleaner syntax**: Conan 2's profile and configuration format is more maintainable
3. **Better caching**: Separate download/source caches improve build performance
4. **Explicit dependencies**: `tool_requires()` clearly separates build tools from library dependencies
5. **Improved documentation**: Dual Boost setup is now clearly explained

## Testing

- ✅ Local development builds (macOS, Linux)
- ✅ HBB release builds with glibc 2.28 compatibility
- ✅ CI/CD pipelines (all platforms)
- ✅ Static linking verification via `ldd` and `libcheck`

## Breaking Changes

None. The migration maintains full backwards compatibility:
- Same compiler requirements
- Same dependency versions (except minor bumps for bug fixes)
- Same build outputs
- Same binary compatibility

## Notes for Reviewers

1. The dual Boost setup in HBB is intentional and documented - both versions are 1.86.0
2. The `tool_requires('b2/5.3.2')` in HBB is necessary to avoid glibc incompatibility
3. The WasmEdge recipe handles prebuilt binaries only (no source build option from upstream)

## Checklist

- [x] All tests pass
- [x] HBB release builds work
- [x] Backwards compatibility maintained