### PR TITLE
build: upgrade openssl from 1.1.1u to 3.6.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -31,7 +31,7 @@ class Xrpl(ConanFile):
         'lz4/1.9.4',
         'grpc/1.50.1',
         'nudb/2.0.8',
-        'openssl/1.1.1u',
+        'openssl/3.6.0',
         'protobuf/3.21.12',
         'soci/4.0.3@xahaud/stable',
         'zlib/1.3.1',


### PR DESCRIPTION
Updates OpenSSL dependency to the latest 3.x series available on Conan Center.