### PR TITLE
Cron (on ledger cronjobs)

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -736,6 +736,7 @@ if (tests)
     src/test/app/BaseFee_test.cpp
     src/test/app/Check_test.cpp
     src/test/app/ClaimReward_test.cpp
+    src/test/app/Cron_test.cpp
     src/test/app/Clawback_test.cpp
     src/test/app/CrossingLimits_test.cpp
     src/test/app/DeliverMin_test.cpp
@@ -900,6 +901,7 @@ if (tests)
     src/test/jtx/impl/amount.cpp
     src/test/jtx/impl/balance.cpp
     src/test/jtx/impl/check.cpp
+    src/test/jtx/impl/cron.cpp
     src/test/jtx/impl/delivermin.cpp
     src/test/jtx/impl/deposit.cpp
     src/test/jtx/impl/envconfig.cpp

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -444,6 +444,7 @@ target_sources (rippled PRIVATE
   src/ripple/app/tx/impl/CreateCheck.cpp
   src/ripple/app/tx/impl/CreateOffer.cpp
   src/ripple/app/tx/impl/CreateTicket.cpp
+  src/ripple/app/tx/impl/Cron.cpp
   src/ripple/app/tx/impl/DeleteAccount.cpp
   src/ripple/app/tx/impl/DepositPreauth.cpp
   src/ripple/app/tx/impl/Escrow.cpp
@@ -461,6 +462,7 @@ target_sources (rippled PRIVATE
   src/ripple/app/tx/impl/Payment.cpp
   src/ripple/app/tx/impl/Remit.cpp
   src/ripple/app/tx/impl/SetAccount.cpp
+  src/ripple/app/tx/impl/SetCron.cpp
   src/ripple/app/tx/impl/SetHook.cpp
   src/ripple/app/tx/impl/SetRemarks.cpp
   src/ripple/app/tx/impl/SetRegularKey.cpp

--- a/src/ripple/app/hook/impl/applyHook.cpp
+++ b/src/ripple/app/hook/impl/applyHook.cpp
@@ -1056,8 +1056,8 @@ hook::getHookCanEmit(
         (hookObj.isFieldPresent(sfHookCanEmit)
              ? hookObj.getFieldH256(sfHookCanEmit)
              : hookDef->isFieldPresent(sfHookCanEmit)
-             ? hookDef->getFieldH256(sfHookCanEmit)
-             : defaultHookCanEmit);
+                 ? hookDef->getFieldH256(sfHookCanEmit)
+                 : defaultHookCanEmit);
     return hookCanEmit;
 }
 
@@ -2943,10 +2943,10 @@ DEFINE_HOOK_FUNCTION(
                 ripple::Keylet kl = keylet_type == keylet_code::CHILD
                     ? ripple::keylet::child(id)
                     : keylet_type == keylet_code::EMITTED_TXN
-                    ? ripple::keylet::emittedTxn(id)
-                    : keylet_type == keylet_code::HOOK_DEFINITION
-                    ? ripple::keylet::hookDefinition(id)
-                    : ripple::keylet::unchecked(id);
+                        ? ripple::keylet::emittedTxn(id)
+                        : keylet_type == keylet_code::HOOK_DEFINITION
+                            ? ripple::keylet::hookDefinition(id)
+                            : ripple::keylet::unchecked(id);
 
                 return serialize_keylet(kl, memory, write_ptr, write_len);
             }
@@ -2975,10 +2975,10 @@ DEFINE_HOOK_FUNCTION(
                 ripple::Keylet kl = keylet_type == keylet_code::HOOK
                     ? ripple::keylet::hook(id)
                     : keylet_type == keylet_code::SIGNERS
-                    ? ripple::keylet::signers(id)
-                    : keylet_type == keylet_code::OWNER_DIR
-                    ? ripple::keylet::ownerDir(id)
-                    : ripple::keylet::account(id);
+                        ? ripple::keylet::signers(id)
+                        : keylet_type == keylet_code::OWNER_DIR
+                            ? ripple::keylet::ownerDir(id)
+                            : ripple::keylet::account(id);
 
                 return serialize_keylet(kl, memory, write_ptr, write_len);
             }
@@ -3018,10 +3018,10 @@ DEFINE_HOOK_FUNCTION(
                 ripple::Keylet kl = keylet_type == keylet_code::CHECK
                     ? ripple::keylet::check(id, seq)
                     : keylet_type == keylet_code::ESCROW
-                    ? ripple::keylet::escrow(id, seq)
-                    : keylet_type == keylet_code::NFT_OFFER
-                    ? ripple::keylet::nftoffer(id, seq)
-                    : ripple::keylet::offer(id, seq);
+                        ? ripple::keylet::escrow(id, seq)
+                        : keylet_type == keylet_code::NFT_OFFER
+                            ? ripple::keylet::nftoffer(id, seq)
+                            : ripple::keylet::offer(id, seq);
 
                 return serialize_keylet(kl, memory, write_ptr, write_len);
             }
@@ -3139,11 +3139,13 @@ DEFINE_HOOK_FUNCTION(
                 WRITE_WASM_MEMORY_AND_RETURN(
                     write_ptr,
                     write_len,
-                    keylet_type == keylet_code::AMENDMENTS ? cAmendments.data()
-                        : keylet_type == keylet_code::FEES ? cFees.data()
-                        : keylet_type == keylet_code::NEGATIVE_UNL
-                        ? cNegativeUNL.data()
-                        : cEmittedDir.data(),
+                    keylet_type == keylet_code::AMENDMENTS
+                        ? cAmendments.data()
+                        : keylet_type == keylet_code::FEES
+                            ? cFees.data()
+                            : keylet_type == keylet_code::NEGATIVE_UNL
+                                ? cNegativeUNL.data()
+                                : cEmittedDir.data(),
                     34,
                     memory,
                     memory_length);
@@ -6004,9 +6006,9 @@ DEFINE_HOOK_FUNCTION(
 
     size_t free_count = hook_api::max_slots - hookCtx.slot.size();
 
-    size_t needed_count = slot_into_tx == 0 && slot_into_meta == 0 ? 2
-        : slot_into_tx != 0 && slot_into_meta != 0                 ? 0
-                                                                   : 1;
+    size_t needed_count = slot_into_tx == 0 && slot_into_meta == 0
+        ? 2
+        : slot_into_tx != 0 && slot_into_meta != 0 ? 0 : 1;
 
     if (free_count < needed_count)
         return NO_FREE_SLOTS;

--- a/src/ripple/app/hook/impl/applyHook.cpp
+++ b/src/ripple/app/hook/impl/applyHook.cpp
@@ -75,6 +75,11 @@ getTransactionalStakeHolders(STTx const& tx, ReadView const& rv)
 
     switch (tt)
     {
+        case ttCRON: {
+            ADD_TSH(tx.getAccountID(sfOwner), tshWEAK);
+            break;
+        }
+
         case ttREMIT: {
             if (destAcc)
                 ADD_TSH(*destAcc, tshSTRONG);
@@ -1051,8 +1056,8 @@ hook::getHookCanEmit(
         (hookObj.isFieldPresent(sfHookCanEmit)
              ? hookObj.getFieldH256(sfHookCanEmit)
              : hookDef->isFieldPresent(sfHookCanEmit)
-                 ? hookDef->getFieldH256(sfHookCanEmit)
-                 : defaultHookCanEmit);
+             ? hookDef->getFieldH256(sfHookCanEmit)
+             : defaultHookCanEmit);
     return hookCanEmit;
 }
 
@@ -2938,10 +2943,10 @@ DEFINE_HOOK_FUNCTION(
                 ripple::Keylet kl = keylet_type == keylet_code::CHILD
                     ? ripple::keylet::child(id)
                     : keylet_type == keylet_code::EMITTED_TXN
-                        ? ripple::keylet::emittedTxn(id)
-                        : keylet_type == keylet_code::HOOK_DEFINITION
-                            ? ripple::keylet::hookDefinition(id)
-                            : ripple::keylet::unchecked(id);
+                    ? ripple::keylet::emittedTxn(id)
+                    : keylet_type == keylet_code::HOOK_DEFINITION
+                    ? ripple::keylet::hookDefinition(id)
+                    : ripple::keylet::unchecked(id);
 
                 return serialize_keylet(kl, memory, write_ptr, write_len);
             }
@@ -2970,10 +2975,10 @@ DEFINE_HOOK_FUNCTION(
                 ripple::Keylet kl = keylet_type == keylet_code::HOOK
                     ? ripple::keylet::hook(id)
                     : keylet_type == keylet_code::SIGNERS
-                        ? ripple::keylet::signers(id)
-                        : keylet_type == keylet_code::OWNER_DIR
-                            ? ripple::keylet::ownerDir(id)
-                            : ripple::keylet::account(id);
+                    ? ripple::keylet::signers(id)
+                    : keylet_type == keylet_code::OWNER_DIR
+                    ? ripple::keylet::ownerDir(id)
+                    : ripple::keylet::account(id);
 
                 return serialize_keylet(kl, memory, write_ptr, write_len);
             }
@@ -3013,10 +3018,10 @@ DEFINE_HOOK_FUNCTION(
                 ripple::Keylet kl = keylet_type == keylet_code::CHECK
                     ? ripple::keylet::check(id, seq)
                     : keylet_type == keylet_code::ESCROW
-                        ? ripple::keylet::escrow(id, seq)
-                        : keylet_type == keylet_code::NFT_OFFER
-                            ? ripple::keylet::nftoffer(id, seq)
-                            : ripple::keylet::offer(id, seq);
+                    ? ripple::keylet::escrow(id, seq)
+                    : keylet_type == keylet_code::NFT_OFFER
+                    ? ripple::keylet::nftoffer(id, seq)
+                    : ripple::keylet::offer(id, seq);
 
                 return serialize_keylet(kl, memory, write_ptr, write_len);
             }
@@ -3134,13 +3139,11 @@ DEFINE_HOOK_FUNCTION(
                 WRITE_WASM_MEMORY_AND_RETURN(
                     write_ptr,
                     write_len,
-                    keylet_type == keylet_code::AMENDMENTS
-                        ? cAmendments.data()
-                        : keylet_type == keylet_code::FEES
-                            ? cFees.data()
-                            : keylet_type == keylet_code::NEGATIVE_UNL
-                                ? cNegativeUNL.data()
-                                : cEmittedDir.data(),
+                    keylet_type == keylet_code::AMENDMENTS ? cAmendments.data()
+                        : keylet_type == keylet_code::FEES ? cFees.data()
+                        : keylet_type == keylet_code::NEGATIVE_UNL
+                        ? cNegativeUNL.data()
+                        : cEmittedDir.data(),
                     34,
                     memory,
                     memory_length);
@@ -6001,9 +6004,9 @@ DEFINE_HOOK_FUNCTION(
 
     size_t free_count = hook_api::max_slots - hookCtx.slot.size();
 
-    size_t needed_count = slot_into_tx == 0 && slot_into_meta == 0
-        ? 2
-        : slot_into_tx != 0 && slot_into_meta != 0 ? 0 : 1;
+    size_t needed_count = slot_into_tx == 0 && slot_into_meta == 0 ? 2
+        : slot_into_tx != 0 && slot_into_meta != 0                 ? 0
+                                                                   : 1;
 
     if (free_count < needed_count)
         return NO_FREE_SLOTS;

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -1477,6 +1477,63 @@ TxQ::accept(Application& app, OpenView& view)
         }
     }
 
+    // Inject cron transactions, if any
+    if (view.rules().enabled(featureCron))
+    {
+        uint32_t currentTime =
+            view.parentCloseTime().time_since_epoch().count();
+        uint256 klStart = keylet::cron(0, AccountID(beast::zero)).key;
+        uint256 const klEnd =
+            keylet::cron(currentTime + 1, AccountID(beast::zero)).key;
+
+        std::set<AccountID> cronAccs;
+
+        auto counter = 0;
+        while (++counter < 128 && klStart < klEnd)
+        {
+            std::optional<uint256 const> next = view.succ(klStart, klEnd);
+            if (!next.has_value())
+                break;
+
+            Keylet kl{ltANY, *next};
+
+            if (view.exists(kl))
+            {
+                auto sle = view.read(kl);
+                if (safe_cast<TxType>(sle->getFieldU16(sfLedgerEntryType)) ==
+                    ltCRON)
+                {
+                    // valid cron object, add it to the list
+                    cronAccs.emplace(sle->getAccountID(sfOwner));
+                }
+            }
+
+            klStart = *next;
+        }
+
+        auto const seq = view.info().seq;
+
+        // insert Cron pseudos for each of the accs we need to ping
+        for (AccountID const& id : cronAccs)
+        {
+            STTx cronTx(ttCRON, [=](auto& obj) {
+                obj[sfAccount] = AccountID();
+                obj[sfLedgerSequence] = seq;
+                obj[sfOwner] = id;
+            });
+
+            uint256 txID = cronTx.getTransactionID();
+
+            auto s = std::make_shared<ripple::Serializer>();
+            cronTx.add(*s);
+
+            app.getHashRouter().setFlags(txID, SF_PRIVATE2);
+            app.getHashRouter().setFlags(txID, SF_EMITTED);
+            view.rawTxInsert(txID, std::move(s), nullptr);
+            ledgerChanged = true;
+        }
+    }
+
     // Inject emitted transactions if any
     if (view.rules().enabled(featureHooks))
         do

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -1489,7 +1489,8 @@ TxQ::accept(Application& app, OpenView& view)
         std::set<AccountID> cronAccs;
 
         auto counter = 0;
-        while (++counter < 128 && klStart < klEnd)
+        // include max 128 cron txns in the ledger
+        while (++counter < 129 && klStart < klEnd)
         {
             std::optional<uint256 const> next = view.succ(klStart, klEnd);
             if (!next.has_value())

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -1500,8 +1500,8 @@ TxQ::accept(Application& app, OpenView& view)
             if (view.exists(kl))
             {
                 auto sle = view.read(kl);
-                if (safe_cast<TxType>(sle->getFieldU16(sfLedgerEntryType)) ==
-                    ltCRON)
+                if (safe_cast<LedgerEntryType>(
+                        sle->getFieldU16(sfLedgerEntryType)) == ltCRON)
                 {
                     // valid cron object, add it to the list
                     cronAccs.emplace(sle->getAccountID(sfOwner));

--- a/src/ripple/app/tx/impl/Cron.cpp
+++ b/src/ripple/app/tx/impl/Cron.cpp
@@ -173,6 +173,12 @@ Cron::doApply()
     return tesSUCCESS;
 }
 
+void
+Cron::preCompute()
+{
+    assert(account_ == beast::zero);
+}
+
 XRPAmount
 Cron::calculateBaseFee(ReadView const& view, STTx const& tx)
 {

--- a/src/ripple/app/tx/impl/Cron.cpp
+++ b/src/ripple/app/tx/impl/Cron.cpp
@@ -36,7 +36,6 @@ Cron::makeTxConsequences(PreflightContext const& ctx)
     return TxConsequences{ctx.tx, TxConsequences::normal};
 }
 
-
 NotTEC
 Cron::preflight(PreflightContext const& ctx)
 {
@@ -76,9 +75,8 @@ Cron::preflight(PreflightContext const& ctx)
         return temBAD_SEQUENCE;
     }
 
-    return tesSUCCESS;   
+    return tesSUCCESS;
 }
-
 
 TER
 Cron::preclaim(PreclaimContext const& ctx)
@@ -112,7 +110,7 @@ Cron::doApply()
     }
 
     uint256 ptr = sle->getFieldH256(sfCron);
-    Keylet klOld {ltCRON, ptr};
+    Keylet klOld{ltCRON, ptr};
     auto sleCron = view.peek(klOld);
     if (!sleCron)
     {
@@ -122,7 +120,7 @@ Cron::doApply()
 
     uint32_t delay = sleCron->getFieldU32(sfDelaySeconds);
     uint32_t recur = sleCron->getFieldU32(sfRepeatCount);
-    
+
     uint32_t currentTime = view.parentCloseTime().time_since_epoch().count();
 
     // do all this sanity checking before we modify the ledger...
@@ -134,11 +132,12 @@ Cron::doApply()
     // if there are further crons to do then a new one is created at the next
     // time point
 
-    if (!view.dirRemove(keylet::ownerDir(id), (*sleCron)[sfOwnerNode], klOld, false))
+    if (!view.dirRemove(
+            keylet::ownerDir(id), (*sleCron)[sfOwnerNode], klOld, false))
         return tefBAD_LEDGER;
 
     view.erase(sleCron);
-    
+
     if (recur == 0)
     {
         // already at last execution, stop here
@@ -151,9 +150,11 @@ Cron::doApply()
     // more executions remain, so create a new object
 
     Keylet klCron = keylet::cron(afterTime, id);
-    
-    // insert into owner dir, we don't need to check reserve because we've just deleted an object
-    auto const page = view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
+
+    // insert into owner dir, we don't need to check reserve because we've just
+    // deleted an object
+    auto const page =
+        view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
     if (!page)
         return tecDIR_FULL;
 
@@ -164,7 +165,7 @@ Cron::doApply()
     sleCron->setAccountID(sfOwner, id);
 
     sle->setFieldH256(sfCron, klCron.key);
-    
+
     view.insert(sleCron);
     view.update(sle);
 

--- a/src/ripple/app/tx/impl/Cron.cpp
+++ b/src/ripple/app/tx/impl/Cron.cpp
@@ -160,6 +160,7 @@ Cron::doApply()
 
     sleCron = std::make_shared<SLE>(klCron);
 
+    sleCron->setFieldU64(sfOwnerNode, *page);
     sleCron->setFieldU32(sfDelaySeconds, delay);
     sleCron->setFieldU32(sfRepeatCount, recur - 1);
     sleCron->setAccountID(sfOwner, id);

--- a/src/ripple/app/tx/impl/Cron.cpp
+++ b/src/ripple/app/tx/impl/Cron.cpp
@@ -1,0 +1,180 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 XRPL-Labs
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/tx/impl/Cron.h>
+#include <ripple/basics/Log.h>
+#include <ripple/core/Config.h>
+#include <ripple/ledger/View.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/PublicKey.h>
+#include <ripple/protocol/Quality.h>
+#include <ripple/protocol/TxFlags.h>
+#include <ripple/protocol/st.h>
+
+namespace ripple {
+
+TxConsequences
+Cron::makeTxConsequences(PreflightContext const& ctx)
+{
+    return TxConsequences{ctx.tx, TxConsequences::normal};
+}
+
+
+NotTEC
+Cron::preflight(PreflightContext const& ctx)
+{
+    if (!ctx.rules.enabled(featureCron))
+        return temDISABLED;
+
+    auto const ret = preflight0(ctx);
+    if (!isTesSuccess(ret))
+        return ret;
+
+    auto account = ctx.tx.getAccountID(sfAccount);
+    if (account != beast::zero)
+    {
+        JLOG(ctx.j.warn()) << "Cron: Bad source id";
+        return temBAD_SRC_ACCOUNT;
+    }
+
+    // No point in going any further if the transaction fee is malformed.
+    auto const fee = ctx.tx.getFieldAmount(sfFee);
+    if (!fee.native() || fee != beast::zero)
+    {
+        JLOG(ctx.j.warn()) << "Cron: invalid fee";
+        return temBAD_FEE;
+    }
+
+    if (!ctx.tx.getSigningPubKey().empty() || !ctx.tx.getSignature().empty() ||
+        ctx.tx.isFieldPresent(sfSigners))
+    {
+        JLOG(ctx.j.warn()) << "Cron: Bad signature";
+        return temBAD_SIGNATURE;
+    }
+
+    if (ctx.tx.getFieldU32(sfSequence) != 0 ||
+        ctx.tx.isFieldPresent(sfPreviousTxnID))
+    {
+        JLOG(ctx.j.warn()) << "Cron: Bad sequence";
+        return temBAD_SEQUENCE;
+    }
+
+    return tesSUCCESS;   
+}
+
+
+TER
+Cron::preclaim(PreclaimContext const& ctx)
+{
+    if (!ctx.view.rules().enabled(featureCron))
+        return temDISABLED;
+
+    return tesSUCCESS;
+}
+
+TER
+Cron::doApply()
+{
+    auto& view = ctx_.view();
+    auto const& tx = ctx_.tx;
+
+    AccountID const& id = tx.getAccountID(sfOwner);
+
+    auto sle = view.peek(keylet::account(id));
+    if (!sle)
+    {
+        // should never happen... but might in a race condition with acc delete
+        JLOG(j_.warn()) << "Cron: sfOwner account missing. " << id;
+        return tesSUCCESS;
+    }
+
+    if (!sle->isFieldPresent(sfCron))
+    {
+        JLOG(j_.warn()) << "Cron: sfCron missing from account " << id;
+        return tefINTERNAL;
+    }
+
+    uint256 ptr = sle->getFieldH256(sfCron);
+    Keylet klOld {ltCRON, ptr};
+    auto sleCron = view.peek(klOld);
+    if (!sleCron)
+    {
+        JLOG(j_.warn()) << "Cron: Cron object missing for account " << id;
+        return tesSUCCESS;
+    }
+
+    uint32_t delay = sleCron->getFieldU32(sfDelaySeconds);
+    uint32_t recur = sleCron->getFieldU32(sfRepeatCount);
+    
+    uint32_t currentTime = view.parentCloseTime().time_since_epoch().count();
+
+    // do all this sanity checking before we modify the ledger...
+    uint32_t afterTime = currentTime + delay;
+    if (afterTime < currentTime)
+        return tefINTERNAL;
+
+    // in all circumstances the Cron object is deleted...
+    // if there are further crons to do then a new one is created at the next
+    // time point
+
+    if (!view.dirRemove(keylet::ownerDir(id), (*sleCron)[sfOwnerNode], klOld, false))
+        return tefBAD_LEDGER;
+
+    view.erase(sleCron);
+    
+    if (recur == 0)
+    {
+        // already at last execution, stop here
+        adjustOwnerCount(view, sle, -1, j_);
+        sle->makeFieldAbsent(sfCron);
+        view.update(sle);
+        return tesSUCCESS;
+    }
+
+    // more executions remain, so create a new object
+
+    Keylet klCron = keylet::cron(afterTime, id);
+    
+    // insert into owner dir, we don't need to check reserve because we've just deleted an object
+    auto const page = view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
+    if (!page)
+        return tecDIR_FULL;
+
+    sleCron = std::make_shared<SLE>(klCron);
+
+    sleCron->setFieldU32(sfDelaySeconds, delay);
+    sleCron->setFieldU32(sfRepeatCount, recur - 1);
+    sleCron->setAccountID(sfOwner, id);
+
+    sle->setFieldH256(sfCron, klCron.key);
+    
+    view.insert(sleCron);
+    view.update(sle);
+
+    return tesSUCCESS;
+}
+
+XRPAmount
+Cron::calculateBaseFee(ReadView const& view, STTx const& tx)
+{
+    return XRPAmount{0};
+}
+
+}  // namespace ripple

--- a/src/ripple/app/tx/impl/Cron.h
+++ b/src/ripple/app/tx/impl/Cron.h
@@ -50,6 +50,9 @@ public:
 
     TER
     doApply() override;
+
+    void
+    preCompute() override;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/Cron.h
+++ b/src/ripple/app/tx/impl/Cron.h
@@ -50,7 +50,6 @@ public:
 
     TER
     doApply() override;
-
 };
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/Cron.h
+++ b/src/ripple/app/tx/impl/Cron.h
@@ -1,0 +1,58 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 XRPL-Labs
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TX_CRON_H_INCLUDED
+#define RIPPLE_TX_CRON_H_INCLUDED
+
+#include <ripple/app/tx/impl/Transactor.h>
+#include <ripple/basics/Log.h>
+#include <ripple/core/Config.h>
+#include <ripple/protocol/Indexes.h>
+
+namespace ripple {
+
+class Cron : public Transactor
+{
+public:
+    static constexpr ConsequencesFactoryType ConsequencesFactory{Custom};
+
+    explicit Cron(ApplyContext& ctx) : Transactor(ctx)
+    {
+    }
+
+    static XRPAmount
+    calculateBaseFee(ReadView const& view, STTx const& tx);
+
+    static TxConsequences
+    makeTxConsequences(PreflightContext const& ctx);
+
+    static NotTEC
+    preflight(PreflightContext const& ctx);
+
+    static TER
+    preclaim(PreclaimContext const&);
+
+    TER
+    doApply() override;
+
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/tx/impl/InvariantCheck.cpp
+++ b/src/ripple/app/tx/impl/InvariantCheck.cpp
@@ -491,6 +491,7 @@ LedgerEntryTypesMatch::visitEntry(
             case ltNFTOKEN_PAGE:
             case ltNFTOKEN_OFFER:
             case ltURI_TOKEN:
+            case ltCRON:
             case ltIMPORT_VLSEQ:
             case ltUNL_REPORT:
                 break;

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -60,11 +60,37 @@ SetCron::preflight(PreflightContext const& ctx)
     // -R - Invalid
     // -- - Clear any existing cron (succeeds even if there isn't one)
 
-    if (tx.isFieldPresent(sfRepeatCount) && !tx.isFieldPresent(sfDelaySeconds))
+    bool const hasDelay = tx.isFieldPresent(sfDelaySeconds);
+    bool const hasRepeat = tx.isFieldPresent(sfRepeatCount);
+
+    if (hasRepeat && !hasDelay)
     {
         JLOG(j.warn()) << "SetCron: DelaySeconds must also be specified when "
                           "RepeatCount is present.";
         return temMALFORMED;
+    }
+
+    if (hasDelay)
+    {
+        auto delay = tx.getFieldU32(sfDelaySeconds);
+        if (delay > 31536000UL /* 365 days in seconds */)
+        {
+            JLOG(j.debug()) << "SetCron: DelaySeconds was too high. (max 14 "
+                               "days in seconds).";
+            return temMALFORMED;
+        }
+    }
+
+    if (hasRepeat)
+    {
+        auto recur = tx.getFieldU32(sfRepeatCount);
+        if (recur > 256)
+        {
+            JLOG(j.debug())
+                << "SetCron: RepeatCount too high. Limit is 256. Issue "
+                   "new SetCron to increase.";
+            return temMALFORMED;
+        }
     }
 
     return preflight2(ctx);
@@ -81,42 +107,9 @@ SetCron::preclaim(PreclaimContext const& ctx)
     auto const id = ctx.tx[sfAccount];
 
     auto const sle = ctx.view.read(keylet::account(id));
+
     if (!sle)
         return terNO_ACCOUNT;
-
-    bool const hasDelay = ctx.tx.isFieldPresent(sfDelaySeconds);
-    bool const hasRepeat = ctx.tx.isFieldPresent(sfRepeatCount);
-
-    // defensively enforce this even though we did it in preflight
-    if (!hasDelay && hasRepeat)
-        return tefINTERNAL;
-
-    if (!hasDelay)
-    {
-        // delete operation always succeeds even if there's nothing to delete
-        return tesSUCCESS;
-    }
-
-    // set operation
-
-    auto delay = ctx.tx.getFieldU32(sfDelaySeconds);
-    if (delay > 31536000UL /* 365 days in seconds */)
-    {
-        JLOG(j.debug())
-            << "SetCron: DelaySeconds was too high. (max 14 days in seconds).";
-        return tecDELAY_OR_REPEAT_COUNT_TOO_LARGE;
-    }
-
-    if (!hasRepeat)
-        return tesSUCCESS;
-
-    auto recur = ctx.tx.getFieldU32(sfRepeatCount);
-    if (recur > 256)
-    {
-        JLOG(j.debug()) << "SetCron: RepeatCount too high. Limit is 256. Issue "
-                           "new SetCron to increase.";
-        return tecDELAY_OR_REPEAT_COUNT_TOO_LARGE;
-    }
 
     return tesSUCCESS;
 }
@@ -140,7 +133,8 @@ SetCron::doApply()
     if (!isDelete)
     {
         delay = tx.getFieldU32(sfDelaySeconds);
-        recur = tx.getFieldU32(sfRepeatCount);
+        if (tx.isFieldPresent(sfRepeatCount))
+            recur = tx.getFieldU32(sfRepeatCount);
     }
 
     uint32_t currentTime = view.parentCloseTime().time_since_epoch().count();
@@ -251,7 +245,21 @@ XRPAmount
 SetCron::calculateBaseFee(ReadView const& view, STTx const& tx)
 {
     auto fee = Transactor::calculateBaseFee(view, tx);
-    return fee;
+
+    // factor a cost based on the total number of txns expected
+    // for RepeatCount of 0 we have this txn (SetCron) and the
+    // single Cron txn (2). For a RepeatCount of 1 we have this txn,
+    // the first time the cron executes, and the second time (3).
+    uint32_t recur = tx.isFieldPresent(sfRepeatCount)
+        ? tx.getFieldU32(sfRepeatCount) + 2
+        : 2;
+
+    auto finalFee = fee * recur;
+
+    if (finalFee < fee)
+        return fee;
+
+    return finalFee;
 }
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -61,15 +61,25 @@ SetCron::preflight(PreflightContext const& ctx)
     bool const hasDelay = tx.isFieldPresent(sfDelaySeconds);
     bool const hasRepeat = tx.isFieldPresent(sfRepeatCount);
 
-    if (hasRepeat && !hasDelay)
+    if (tx.isFlag(tfCronUnset))
     {
-        JLOG(j.warn()) << "SetCron: DelaySeconds must also be specified when "
-                          "RepeatCount is present.";
-        return temMALFORMED;
+        if (hasDelay || hasRepeat)
+        {
+            JLOG(j.debug()) << "SetCron: tfCronUnset flag cannot be used with "
+                               "DelaySeconds or RepeatCount.";
+            return temMALFORMED;
+        }
     }
-
-    if (hasDelay)
+    else
     {
+        if (!hasDelay)
+        {
+            JLOG(j.debug()) << "SetCron: DelaySeconds must be "
+                               "specified to create a cron.";
+            return temMALFORMED;
+        }
+
+        // check delay is not too high
         auto delay = tx.getFieldU32(sfDelaySeconds);
         if (delay > 31536000UL /* 365 days in seconds */)
         {
@@ -77,27 +87,18 @@ SetCron::preflight(PreflightContext const& ctx)
                                "days in seconds).";
             return temMALFORMED;
         }
-    }
 
-    if (hasRepeat)
-    {
-        auto recur = tx.getFieldU32(sfRepeatCount);
-        if (recur > 256)
+        // check repeat is not too high
+        if (hasRepeat)
         {
-            JLOG(j.debug())
-                << "SetCron: RepeatCount too high. Limit is 256. Issue "
-                   "new SetCron to increase.";
-            return temMALFORMED;
-        }
-    }
-
-    if (tx.isFlag(tfCronUnset))
-    {
-        if (hasDelay || hasRepeat)
-        {
-            JLOG(j.warn()) << "SetCron: tfCronUnset flag cannot be used with "
-                              "DelaySeconds or RepeatCount.";
-            return temMALFORMED;
+            auto recur = tx.getFieldU32(sfRepeatCount);
+            if (recur > 256)
+            {
+                JLOG(j.debug())
+                    << "SetCron: RepeatCount too high. Limit is 256. Issue "
+                       "new SetCron to increase.";
+                return temMALFORMED;
+            }
         }
     }
 
@@ -136,7 +137,8 @@ SetCron::doApply()
 
     if (!isDelete)
     {
-        delay = tx.getFieldU32(sfDelaySeconds);
+        if (tx.isFieldPresent(sfDelaySeconds))
+            delay = tx.getFieldU32(sfDelaySeconds);
         if (tx.isFieldPresent(sfRepeatCount))
             recur = tx.getFieldU32(sfRepeatCount);
     }
@@ -242,9 +244,8 @@ SetCron::calculateBaseFee(ReadView const& view, STTx const& tx)
     auto const baseFee = Transactor::calculateBaseFee(view, tx);
 
     auto const hasRepeat = tx.isFieldPresent(sfRepeatCount);
-    auto const hasDelay = tx.isFieldPresent(sfDelaySeconds);
 
-    if (!hasRepeat && !hasDelay)
+    if (tx.isFlag(tfCronUnset))
         // delete cron
         return baseFee;
 
@@ -253,7 +254,7 @@ SetCron::calculateBaseFee(ReadView const& view, STTx const& tx)
     // single Cron txn (2). For a RepeatCount of 1 we have this txn,
     // the first time the cron executes, and the second time (3).
     uint32_t const additionalExpectedExecutions =
-        tx.getFieldU32(sfRepeatCount) + 1;
+        hasRepeat ? tx.getFieldU32(sfRepeatCount) + 1 : 1;
     auto const additionalFee = baseFee * additionalExpectedExecutions;
 
     if (baseFee + additionalFee < baseFee)

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -1,0 +1,251 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 XRPL-Labs
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/tx/impl/SetCron.h>
+#include <ripple/basics/Log.h>
+#include <ripple/core/Config.h>
+#include <ripple/ledger/View.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/PublicKey.h>
+#include <ripple/protocol/Quality.h>
+#include <ripple/protocol/TxFlags.h>
+#include <ripple/protocol/st.h>
+
+namespace ripple {
+
+TxConsequences
+SetCron::makeTxConsequences(PreflightContext const& ctx)
+{
+    return TxConsequences{ctx.tx, TxConsequences::normal};
+}
+
+
+NotTEC
+SetCron::preflight(PreflightContext const& ctx)
+{
+    if (!ctx.rules.enabled(featureCron))
+        return temDISABLED;
+
+    if (auto const ret = preflight1(ctx); !isTesSuccess(ret))
+        return ret;
+
+    auto& tx = ctx.tx;
+    auto& j = ctx.j;
+
+    if (tx.getFlags() & tfUniversalMask)
+    {
+        JLOG(j.warn()) << "SetCron: Invalid flags set.";
+        return temINVALID_FLAG;
+    }
+
+    // DelaySeconds (D), RepeatCount (R)
+    // DR - Set Cron with Delay and Repeat
+    // D- - Set Cron (once off) with Delay only (repat implicitly 0)
+    // -R - Invalid
+    // -- - Clear any existing cron (succeeds even if there isn't one)
+    
+    if (tx.isFieldPresent(sfRepeatCount) && !tx.isFieldPresent(sfDelaySeconds))
+    {
+        JLOG(j.warn()) << "SetCron: DelaySeconds must also be specified when RepeatCount is present.";
+        return temMALFORMED;
+    }
+
+    return preflight2(ctx);
+}
+
+
+TER
+SetCron::preclaim(PreclaimContext const& ctx)
+{
+    if (!ctx.view.rules().enabled(featureCron))
+        return temDISABLED;
+
+    auto& j = ctx.j;
+
+    auto const id = ctx.tx[sfAccount];
+
+    auto const sle = ctx.view.read(keylet::account(id));
+    if (!sle)
+        return terNO_ACCOUNT;
+
+    bool const hasDelay = ctx.tx.isFieldPresent(sfDelaySeconds);
+    bool const hasRepeat = ctx.tx.isFieldPresent(sfRepeatCount);
+
+    // defensively enforce this even though we did it in preflight
+    if (!hasDelay && hasRepeat)
+        return tefINTERNAL;
+
+    if (!hasDelay)
+    {
+        // delete operation always succeeds even if there's nothing to delete
+        return tesSUCCESS;
+    }
+
+    // set operation
+
+    auto delay = ctx.tx.getFieldU32(sfDelaySeconds);
+    if (delay > 1209600UL /* 14 days in seconds */)
+    {
+        JLOG(j.debug()) << "SetCron: DelaySeconds was too high. (max 14 days in seconds).";
+        return tecDELAY_OR_REPEAT_COUNT_TOO_LARGE;
+    }
+
+    if (!hasRepeat)
+        return tesSUCCESS;
+    
+    auto recur = ctx.tx.getFieldU32(sfRepeatCount);
+    if (recur > 256)
+    {
+        JLOG(j.debug()) << "SetCron: RepeatCount too high. Limit is 256. Issue new SetCron to increase.";
+        return tecDELAY_OR_REPEAT_COUNT_TOO_LARGE;
+    }
+
+    return tesSUCCESS;
+}
+
+TER
+SetCron::doApply()
+{
+    auto& view = ctx_.view();
+    auto const& tx = ctx_.tx;
+
+    bool const isDelete = !tx.isFieldPresent(sfDelaySeconds);
+
+    if (isDelete && tx.isFieldPresent(sfRepeatCount))
+        return tefINTERNAL;
+
+    // delay can be zero, in which case the cron will usually execute next ledger.
+    uint32_t delay {0};
+    uint32_t recur {0};
+    
+    if (!isDelete)
+    {
+        delay = tx.getFieldU32(sfDelaySeconds);
+        recur = tx.getFieldU32(sfRepeatCount);
+    }
+
+    uint32_t currentTime = view.parentCloseTime().time_since_epoch().count();
+
+    // do all this sanity checking before we modify the ledger...
+    // even for a delete operation this will fall through without incident
+
+    uint32_t afterTime = currentTime + delay;
+    if (afterTime < currentTime)
+        return tefINTERNAL;
+
+
+    AccountID const& id = tx.getAccountID(sfAccount);
+    auto sle = view.peek(keylet::account(id));
+    if (!sle)
+        return tefINTERNAL;
+
+    // in all cases whatsoever, this transaction will delete an existing
+    // old cron object and return the owner reserve to the owner.
+
+    if (sle->isFieldPresent(sfCron))
+    {
+        Keylet klOld {ltCRON, sle->getFieldH256(sfCron)};
+
+        auto sleCron = view.peek(klOld);
+        if (!sleCron)
+        {
+            JLOG(j_.warn()) << "SetCron: Cron object didn't exist.";
+            return tefBAD_LEDGER;
+        }
+        
+        if (safe_cast<TxType>(sleCron->getFieldU16(sfLedgerEntryType)) != ltCRON)
+        {
+            JLOG(j_.warn()) << "SetCron: sfCron pointed to non-cron object!!";
+            return tefBAD_LEDGER;
+        }
+
+        if (!view.dirRemove(keylet::ownerDir(id), (*sleCron)[sfOwnerNode], klOld, false))
+        {
+            JLOG(j_.warn()) << "SetCron: Ownerdir bad. " << id;
+            return tefBAD_LEDGER;
+        }
+
+        view.erase(sleCron);
+        adjustOwnerCount(view, sle, -1, j_);
+        sle->makeFieldAbsent(sfCron);
+    }
+
+    // if the operation is a delete (no delay or recur specified then stop here.)
+    if (isDelete)
+    {
+        view.update(sle);
+        return tesSUCCESS;
+    }
+
+    // execution to here means we're creating a new Cron object and adding it to the
+    // user's owner dir
+
+    Keylet klCron = keylet::cron(afterTime, id);
+
+    bool const alreadyExists = view.exists(klCron);
+
+    if (!alreadyExists)
+    {
+        STAmount const reserve{
+            view.fees().accountReserve(sle->getFieldU32(sfOwnerCount) + 1)};
+
+        STAmount const afterFee =
+            mPriorBalance - ctx_.tx.getFieldAmount(sfFee).xrp();
+
+        if (afterFee > mPriorBalance || afterFee < reserve)
+            return tecINSUFFICIENT_RESERVE;
+            
+        // add to owner dir
+        auto const page = view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
+        if (!page)
+            return tecDIR_FULL;
+        
+        adjustOwnerCount(view, sle, 1, j_);
+    }
+
+    std::shared_ptr<SLE> sleCron = alreadyExists
+        ? view.peek(klCron)
+        : std::make_shared<SLE>(klCron);
+   
+    // set the fields 
+    sleCron->setFieldU32(sfDelaySeconds, delay);
+    sleCron->setFieldU32(sfRepeatCount, recur);
+    sleCron->setAccountID(sfOwner, id);
+
+    sle->setFieldH256(sfCron, klCron.key);
+    
+    view.update(sle);
+
+    if (alreadyExists)
+        view.update(sleCron);
+    else
+        view.insert(sleCron);
+
+    return tesSUCCESS;
+}
+
+XRPAmount
+SetCron::calculateBaseFee(ReadView const& view, STTx const& tx)
+{
+    auto fee = Transactor::calculateBaseFee(view, tx);
+    return fee;
+}
+
+}  // namespace ripple

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -36,7 +36,6 @@ SetCron::makeTxConsequences(PreflightContext const& ctx)
     return TxConsequences{ctx.tx, TxConsequences::normal};
 }
 
-
 NotTEC
 SetCron::preflight(PreflightContext const& ctx)
 {
@@ -60,16 +59,16 @@ SetCron::preflight(PreflightContext const& ctx)
     // D- - Set Cron (once off) with Delay only (repat implicitly 0)
     // -R - Invalid
     // -- - Clear any existing cron (succeeds even if there isn't one)
-    
+
     if (tx.isFieldPresent(sfRepeatCount) && !tx.isFieldPresent(sfDelaySeconds))
     {
-        JLOG(j.warn()) << "SetCron: DelaySeconds must also be specified when RepeatCount is present.";
+        JLOG(j.warn()) << "SetCron: DelaySeconds must also be specified when "
+                          "RepeatCount is present.";
         return temMALFORMED;
     }
 
     return preflight2(ctx);
 }
-
 
 TER
 SetCron::preclaim(PreclaimContext const& ctx)
@@ -103,17 +102,19 @@ SetCron::preclaim(PreclaimContext const& ctx)
     auto delay = ctx.tx.getFieldU32(sfDelaySeconds);
     if (delay > 1209600UL /* 14 days in seconds */)
     {
-        JLOG(j.debug()) << "SetCron: DelaySeconds was too high. (max 14 days in seconds).";
+        JLOG(j.debug())
+            << "SetCron: DelaySeconds was too high. (max 14 days in seconds).";
         return tecDELAY_OR_REPEAT_COUNT_TOO_LARGE;
     }
 
     if (!hasRepeat)
         return tesSUCCESS;
-    
+
     auto recur = ctx.tx.getFieldU32(sfRepeatCount);
     if (recur > 256)
     {
-        JLOG(j.debug()) << "SetCron: RepeatCount too high. Limit is 256. Issue new SetCron to increase.";
+        JLOG(j.debug()) << "SetCron: RepeatCount too high. Limit is 256. Issue "
+                           "new SetCron to increase.";
         return tecDELAY_OR_REPEAT_COUNT_TOO_LARGE;
     }
 
@@ -131,10 +132,11 @@ SetCron::doApply()
     if (isDelete && tx.isFieldPresent(sfRepeatCount))
         return tefINTERNAL;
 
-    // delay can be zero, in which case the cron will usually execute next ledger.
-    uint32_t delay {0};
-    uint32_t recur {0};
-    
+    // delay can be zero, in which case the cron will usually execute next
+    // ledger.
+    uint32_t delay{0};
+    uint32_t recur{0};
+
     if (!isDelete)
     {
         delay = tx.getFieldU32(sfDelaySeconds);
@@ -150,7 +152,6 @@ SetCron::doApply()
     if (afterTime < currentTime)
         return tefINTERNAL;
 
-
     AccountID const& id = tx.getAccountID(sfAccount);
     auto sle = view.peek(keylet::account(id));
     if (!sle)
@@ -161,7 +162,7 @@ SetCron::doApply()
 
     if (sle->isFieldPresent(sfCron))
     {
-        Keylet klOld {ltCRON, sle->getFieldH256(sfCron)};
+        Keylet klOld{ltCRON, sle->getFieldH256(sfCron)};
 
         auto sleCron = view.peek(klOld);
         if (!sleCron)
@@ -169,14 +170,16 @@ SetCron::doApply()
             JLOG(j_.warn()) << "SetCron: Cron object didn't exist.";
             return tefBAD_LEDGER;
         }
-        
-        if (safe_cast<TxType>(sleCron->getFieldU16(sfLedgerEntryType)) != ltCRON)
+
+        if (safe_cast<TxType>(sleCron->getFieldU16(sfLedgerEntryType)) !=
+            ltCRON)
         {
             JLOG(j_.warn()) << "SetCron: sfCron pointed to non-cron object!!";
             return tefBAD_LEDGER;
         }
 
-        if (!view.dirRemove(keylet::ownerDir(id), (*sleCron)[sfOwnerNode], klOld, false))
+        if (!view.dirRemove(
+                keylet::ownerDir(id), (*sleCron)[sfOwnerNode], klOld, false))
         {
             JLOG(j_.warn()) << "SetCron: Ownerdir bad. " << id;
             return tefBAD_LEDGER;
@@ -187,15 +190,16 @@ SetCron::doApply()
         sle->makeFieldAbsent(sfCron);
     }
 
-    // if the operation is a delete (no delay or recur specified then stop here.)
+    // if the operation is a delete (no delay or recur specified then stop
+    // here.)
     if (isDelete)
     {
         view.update(sle);
         return tesSUCCESS;
     }
 
-    // execution to here means we're creating a new Cron object and adding it to the
-    // user's owner dir
+    // execution to here means we're creating a new Cron object and adding it to
+    // the user's owner dir
 
     Keylet klCron = keylet::cron(afterTime, id);
 
@@ -211,26 +215,26 @@ SetCron::doApply()
 
         if (afterFee > mPriorBalance || afterFee < reserve)
             return tecINSUFFICIENT_RESERVE;
-            
+
         // add to owner dir
-        auto const page = view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
+        auto const page =
+            view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
         if (!page)
             return tecDIR_FULL;
-        
+
         adjustOwnerCount(view, sle, 1, j_);
     }
 
-    std::shared_ptr<SLE> sleCron = alreadyExists
-        ? view.peek(klCron)
-        : std::make_shared<SLE>(klCron);
-   
-    // set the fields 
+    std::shared_ptr<SLE> sleCron =
+        alreadyExists ? view.peek(klCron) : std::make_shared<SLE>(klCron);
+
+    // set the fields
     sleCron->setFieldU32(sfDelaySeconds, delay);
     sleCron->setFieldU32(sfRepeatCount, recur);
     sleCron->setAccountID(sfOwner, id);
 
     sle->setFieldH256(sfCron, klCron.key);
-    
+
     view.update(sle);
 
     if (alreadyExists)

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -201,32 +201,26 @@ SetCron::doApply()
 
     Keylet klCron = keylet::cron(afterTime, id);
 
-    bool const alreadyExists = view.exists(klCron);
+    std::shared_ptr<SLE> sleCron = std::make_shared<SLE>(klCron);
 
-    std::shared_ptr<SLE> sleCron =
-        alreadyExists ? view.peek(klCron) : std::make_shared<SLE>(klCron);
+    STAmount const reserve{
+        view.fees().accountReserve(sle->getFieldU32(sfOwnerCount) + 1)};
 
-    if (!alreadyExists)
-    {
-        STAmount const reserve{
-            view.fees().accountReserve(sle->getFieldU32(sfOwnerCount) + 1)};
+    STAmount const afterFee =
+        mPriorBalance - ctx_.tx.getFieldAmount(sfFee).xrp();
 
-        STAmount const afterFee =
-            mPriorBalance - ctx_.tx.getFieldAmount(sfFee).xrp();
+    if (afterFee > mPriorBalance || afterFee < reserve)
+        return tecINSUFFICIENT_RESERVE;
 
-        if (afterFee > mPriorBalance || afterFee < reserve)
-            return tecINSUFFICIENT_RESERVE;
+    // add to owner dir
+    auto const page =
+        view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
+    if (!page)
+        return tecDIR_FULL;
 
-        // add to owner dir
-        auto const page =
-            view.dirInsert(keylet::ownerDir(id), klCron, describeOwnerDir(id));
-        if (!page)
-            return tecDIR_FULL;
+    sleCron->setFieldU64(sfOwnerNode, *page);
 
-        sleCron->setFieldU64(sfOwnerNode, *page);
-
-        adjustOwnerCount(view, sle, 1, j_);
-    }
+    adjustOwnerCount(view, sle, 1, j_);
 
     // set the fields
     sleCron->setFieldU32(sfDelaySeconds, delay);
@@ -237,10 +231,7 @@ SetCron::doApply()
 
     view.update(sle);
 
-    if (alreadyExists)
-        view.update(sleCron);
-    else
-        view.insert(sleCron);
+    view.insert(sleCron);
 
     return tesSUCCESS;
 }

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -165,8 +165,8 @@ SetCron::doApply()
             return tefBAD_LEDGER;
         }
 
-        if (safe_cast<TxType>(sleCron->getFieldU16(sfLedgerEntryType)) !=
-            ltCRON)
+        if (safe_cast<LedgerEntryType>(
+                sleCron->getFieldU16(sfLedgerEntryType)) != ltCRON)
         {
             JLOG(j_.warn()) << "SetCron: sfCron pointed to non-cron object!!";
             return tefBAD_LEDGER;

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -108,17 +108,6 @@ SetCron::preflight(PreflightContext const& ctx)
 TER
 SetCron::preclaim(PreclaimContext const& ctx)
 {
-    if (ctx.tx.isFlag(tfCronUnset))
-    {
-        auto const account = ctx.tx.getAccountID(sfAccount);
-        auto const sle = ctx.view.read(keylet::account(account));
-        if (!sle)
-            return tefINTERNAL;
-
-        if (!sle->isFieldPresent(sfCron))
-            return tecNO_ENTRY;
-    }
-
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -205,6 +205,9 @@ SetCron::doApply()
 
     bool const alreadyExists = view.exists(klCron);
 
+    std::shared_ptr<SLE> sleCron =
+        alreadyExists ? view.peek(klCron) : std::make_shared<SLE>(klCron);
+
     if (!alreadyExists)
     {
         STAmount const reserve{
@@ -222,11 +225,10 @@ SetCron::doApply()
         if (!page)
             return tecDIR_FULL;
 
+        sleCron->setFieldU64(sfOwnerNode, *page);
+
         adjustOwnerCount(view, sle, 1, j_);
     }
-
-    std::shared_ptr<SLE> sleCron =
-        alreadyExists ? view.peek(klCron) : std::make_shared<SLE>(klCron);
 
     // set the fields
     sleCron->setFieldU32(sfDelaySeconds, delay);

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -19,12 +19,9 @@
 
 #include <ripple/app/tx/impl/SetCron.h>
 #include <ripple/basics/Log.h>
-#include <ripple/core/Config.h>
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
-#include <ripple/protocol/PublicKey.h>
-#include <ripple/protocol/Quality.h>
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/st.h>
 
@@ -75,7 +72,7 @@ SetCron::preflight(PreflightContext const& ctx)
         auto delay = tx.getFieldU32(sfDelaySeconds);
         if (delay > 31536000UL /* 365 days in seconds */)
         {
-            JLOG(j.debug()) << "SetCron: DelaySeconds was too high. (max 14 "
+            JLOG(j.debug()) << "SetCron: DelaySeconds was too high. (max 365 "
                                "days in seconds).";
             return temMALFORMED;
         }
@@ -99,18 +96,6 @@ SetCron::preflight(PreflightContext const& ctx)
 TER
 SetCron::preclaim(PreclaimContext const& ctx)
 {
-    if (!ctx.view.rules().enabled(featureCron))
-        return temDISABLED;
-
-    auto& j = ctx.j;
-
-    auto const id = ctx.tx[sfAccount];
-
-    auto const sle = ctx.view.read(keylet::account(id));
-
-    if (!sle)
-        return terNO_ACCOUNT;
-
     return tesSUCCESS;
 }
 
@@ -244,22 +229,27 @@ SetCron::doApply()
 XRPAmount
 SetCron::calculateBaseFee(ReadView const& view, STTx const& tx)
 {
-    auto fee = Transactor::calculateBaseFee(view, tx);
+    auto const baseFee = Transactor::calculateBaseFee(view, tx);
+
+    auto const hasRepeat = tx.isFieldPresent(sfRepeatCount);
+    auto const hasDelay = tx.isFieldPresent(sfDelaySeconds);
+
+    if (!hasRepeat && !hasDelay)
+        // delete cron
+        return baseFee;
 
     // factor a cost based on the total number of txns expected
     // for RepeatCount of 0 we have this txn (SetCron) and the
     // single Cron txn (2). For a RepeatCount of 1 we have this txn,
     // the first time the cron executes, and the second time (3).
-    uint32_t recur = tx.isFieldPresent(sfRepeatCount)
-        ? tx.getFieldU32(sfRepeatCount) + 2
-        : 2;
+    uint32_t const additionalExpectedExecutions =
+        tx.getFieldU32(sfRepeatCount) + 1;
+    auto const additionalFee = baseFee * additionalExpectedExecutions;
 
-    auto finalFee = fee * recur;
+    if (baseFee + additionalFee < baseFee)
+        return baseFee;
 
-    if (finalFee < fee)
-        return fee;
-
-    return finalFee;
+    return baseFee + additionalFee;
 }
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -100,7 +100,7 @@ SetCron::preclaim(PreclaimContext const& ctx)
     // set operation
 
     auto delay = ctx.tx.getFieldU32(sfDelaySeconds);
-    if (delay > 1209600UL /* 14 days in seconds */)
+    if (delay > 31536000UL /* 365 days in seconds */)
     {
         JLOG(j.debug())
             << "SetCron: DelaySeconds was too high. (max 14 days in seconds).";

--- a/src/ripple/app/tx/impl/SetCron.cpp
+++ b/src/ripple/app/tx/impl/SetCron.cpp
@@ -45,7 +45,7 @@ SetCron::preflight(PreflightContext const& ctx)
     auto& tx = ctx.tx;
     auto& j = ctx.j;
 
-    if (tx.getFlags() & tfUniversalMask)
+    if (tx.getFlags() & tfCronSetMask)
     {
         JLOG(j.warn()) << "SetCron: Invalid flags set.";
         return temINVALID_FLAG;
@@ -55,7 +55,8 @@ SetCron::preflight(PreflightContext const& ctx)
     // DR - Set Cron with Delay and Repeat
     // D- - Set Cron (once off) with Delay only (repat implicitly 0)
     // -R - Invalid
-    // -- - Clear any existing cron (succeeds even if there isn't one)
+    // -- - Clear any existing cron (succeeds even if there isn't one) / with
+    // tfCronUnset flag set
 
     bool const hasDelay = tx.isFieldPresent(sfDelaySeconds);
     bool const hasRepeat = tx.isFieldPresent(sfRepeatCount);
@@ -90,12 +91,33 @@ SetCron::preflight(PreflightContext const& ctx)
         }
     }
 
+    if (tx.isFlag(tfCronUnset))
+    {
+        if (hasDelay || hasRepeat)
+        {
+            JLOG(j.warn()) << "SetCron: tfCronUnset flag cannot be used with "
+                              "DelaySeconds or RepeatCount.";
+            return temMALFORMED;
+        }
+    }
+
     return preflight2(ctx);
 }
 
 TER
 SetCron::preclaim(PreclaimContext const& ctx)
 {
+    if (ctx.tx.isFlag(tfCronUnset))
+    {
+        auto const account = ctx.tx.getAccountID(sfAccount);
+        auto const sle = ctx.view.read(keylet::account(account));
+        if (!sle)
+            return tefINTERNAL;
+
+        if (!sle->isFieldPresent(sfCron))
+            return tecNO_ENTRY;
+    }
+
     return tesSUCCESS;
 }
 
@@ -105,10 +127,7 @@ SetCron::doApply()
     auto& view = ctx_.view();
     auto const& tx = ctx_.tx;
 
-    bool const isDelete = !tx.isFieldPresent(sfDelaySeconds);
-
-    if (isDelete && tx.isFieldPresent(sfRepeatCount))
-        return tefINTERNAL;
+    bool const isDelete = tx.isFlag(tfCronUnset);
 
     // delay can be zero, in which case the cron will usually execute next
     // ledger.

--- a/src/ripple/app/tx/impl/SetCron.h
+++ b/src/ripple/app/tx/impl/SetCron.h
@@ -1,0 +1,58 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2024 XRPL-Labs
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TX_SETCRON_H_INCLUDED
+#define RIPPLE_TX_SETCRON_H_INCLUDED
+
+#include <ripple/app/tx/impl/Transactor.h>
+#include <ripple/basics/Log.h>
+#include <ripple/core/Config.h>
+#include <ripple/protocol/Indexes.h>
+
+namespace ripple {
+
+class SetCron : public Transactor
+{
+public:
+    static constexpr ConsequencesFactoryType ConsequencesFactory{Custom};
+
+    explicit SetCron(ApplyContext& ctx) : Transactor(ctx)
+    {
+    }
+
+    static XRPAmount
+    calculateBaseFee(ReadView const& view, STTx const& tx);
+
+    static TxConsequences
+    makeTxConsequences(PreflightContext const& ctx);
+
+    static NotTEC
+    preflight(PreflightContext const& ctx);
+
+    static TER
+    preclaim(PreclaimContext const&);
+
+    TER
+    doApply() override;
+
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/tx/impl/SetCron.h
+++ b/src/ripple/app/tx/impl/SetCron.h
@@ -50,7 +50,6 @@ public:
 
     TER
     doApply() override;
-
 };
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -185,6 +185,8 @@ invoke_preflight(PreflightContext const& ctx)
             return invoke_preflight_helper<URIToken>(ctx);
         case ttCRON_SET:
             return invoke_preflight_helper<SetCron>(ctx);
+        case ttCRON:
+            return invoke_preflight_helper<Cron>(ctx);
         default:
             assert(false);
             return {temUNKNOWN, TxConsequences{temUNKNOWN}};
@@ -312,6 +314,8 @@ invoke_preclaim(PreclaimContext const& ctx)
             return invoke_preclaim<URIToken>(ctx);
         case ttCRON_SET:
             return invoke_preclaim<SetCron>(ctx);
+        case ttCRON:
+            return invoke_preclaim<Cron>(ctx);
         default:
             assert(false);
             return temUNKNOWN;
@@ -401,6 +405,8 @@ invoke_calculateBaseFee(ReadView const& view, STTx const& tx)
             return URIToken::calculateBaseFee(view, tx);
         case ttCRON_SET:
             return SetCron::calculateBaseFee(view, tx);
+        case ttCRON:
+            return Cron::calculateBaseFee(view, tx);
         default:
             return XRPAmount{0};
     }
@@ -596,6 +602,10 @@ invoke_apply(ApplyContext& ctx)
         }
         case ttCRON_SET: {
             SetCron p(ctx);
+            return p();
+        }
+        case ttCRON: {
+            Cron p(ctx);
             return p();
         }
         default:

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -28,6 +28,7 @@
 #include <ripple/app/tx/impl/CreateCheck.h>
 #include <ripple/app/tx/impl/CreateOffer.h>
 #include <ripple/app/tx/impl/CreateTicket.h>
+#include <ripple/app/tx/impl/Cron.h>
 #include <ripple/app/tx/impl/DeleteAccount.h>
 #include <ripple/app/tx/impl/DepositPreauth.h>
 #include <ripple/app/tx/impl/Escrow.h>
@@ -43,6 +44,7 @@
 #include <ripple/app/tx/impl/Payment.h>
 #include <ripple/app/tx/impl/Remit.h>
 #include <ripple/app/tx/impl/SetAccount.h>
+#include <ripple/app/tx/impl/SetCron.h>
 #include <ripple/app/tx/impl/SetHook.h>
 #include <ripple/app/tx/impl/SetRegularKey.h>
 #include <ripple/app/tx/impl/SetRemarks.h>
@@ -181,6 +183,8 @@ invoke_preflight(PreflightContext const& ctx)
         case ttURITOKEN_CREATE_SELL_OFFER:
         case ttURITOKEN_CANCEL_SELL_OFFER:
             return invoke_preflight_helper<URIToken>(ctx);
+        case ttCRON_SET:
+            return invoke_preflight_helper<SetCron>(ctx);
         default:
             assert(false);
             return {temUNKNOWN, TxConsequences{temUNKNOWN}};
@@ -306,6 +310,8 @@ invoke_preclaim(PreclaimContext const& ctx)
         case ttURITOKEN_CREATE_SELL_OFFER:
         case ttURITOKEN_CANCEL_SELL_OFFER:
             return invoke_preclaim<URIToken>(ctx);
+        case ttCRON_SET:
+            return invoke_preclaim<SetCron>(ctx);
         default:
             assert(false);
             return temUNKNOWN;
@@ -393,6 +399,8 @@ invoke_calculateBaseFee(ReadView const& view, STTx const& tx)
         case ttURITOKEN_CREATE_SELL_OFFER:
         case ttURITOKEN_CANCEL_SELL_OFFER:
             return URIToken::calculateBaseFee(view, tx);
+        case ttCRON_SET:
+            return SetCron::calculateBaseFee(view, tx);
         default:
             return XRPAmount{0};
     }
@@ -584,6 +592,10 @@ invoke_apply(ApplyContext& ctx)
         case ttURITOKEN_CREATE_SELL_OFFER:
         case ttURITOKEN_CANCEL_SELL_OFFER: {
             URIToken p(ctx);
+            return p();
+        }
+        case ttCRON_SET: {
+            SetCron p(ctx);
             return p();
         }
         default:

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -74,7 +74,7 @@ namespace detail {
 // Feature.cpp. Because it's only used to reserve storage, and determine how
 // large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
 // the actual number of amendments. A LogicError on startup will verify this.
-static constexpr std::size_t numFeatures = 85;
+static constexpr std::size_t numFeatures = 86;
 
 /** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
@@ -373,6 +373,7 @@ extern uint256 const fixProvisionalDoubleThreading;
 extern uint256 const featureClawback;
 extern uint256 const featureDeepFreeze;
 extern uint256 const featureIOUIssuerWeakTSH;
+extern uint256 const featureCron;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -297,6 +297,9 @@ import_vlseq(PublicKey const& key) noexcept;
 Keylet
 uritoken(AccountID const& issuer, Blob const& uri);
 
+Keylet
+cron(uint32_t timestamp, AccountID const& id);
+
 }  // namespace keylet
 
 // Everything below is deprecated and should be removed in favor of keylets:

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -58,6 +58,12 @@ enum LedgerEntryType : std::uint16_t
      */
     ltACCOUNT_ROOT = 0x0061,
 
+    /** A ledger object representing a scheduled cron execution on an account.
+     
+        \sa keylet::cron
+    */
+    ltCRON = 0x0041,
+
     /** A ledger object which contains a list of object identifiers.
 
         \sa keylet::page, keylet::quality, keylet::book, keylet::next and

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -410,6 +410,8 @@ extern SF_UINT32 const sfRewardLgrLast;
 extern SF_UINT32 const sfFirstNFTokenSequence;
 extern SF_UINT32 const sfImportSequence;
 extern SF_UINT32 const sfXahauActivationLgrSeq;
+extern SF_UINT32 const sfDelaySeconds;
+extern SF_UINT32 const sfRepeatCount;
 
 // 64-bit integers (common)
 extern SF_UINT64 const sfIndexNext;
@@ -486,6 +488,7 @@ extern SF_UINT256 const sfURITokenID;
 extern SF_UINT256 const sfGovernanceFlags;
 extern SF_UINT256 const sfGovernanceMarks;
 extern SF_UINT256 const sfEmittedTxnID;
+extern SF_UINT256 const sfCron;
 
 // currency amount (common)
 extern SF_AMOUNT const sfAmount;

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -343,7 +343,6 @@ enum TECcodes : TERUnderlyingType {
     tecINSUF_RESERVE_SELLER = 187,
     tecIMMUTABLE = 188,
     tecTOO_MANY_REMARKS = 189,
-    tecDELAY_OR_REPEAT_COUNT_TOO_LARGE = 200,
     tecLAST_POSSIBLE_ENTRY = 255,
 };
 

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -343,6 +343,7 @@ enum TECcodes : TERUnderlyingType {
     tecINSUF_RESERVE_SELLER = 187,
     tecIMMUTABLE = 188,
     tecTOO_MANY_REMARKS = 189,
+    tecDELAY_OR_REPEAT_COUNT_TOO_LARGE = 200,
     tecLAST_POSSIBLE_ENTRY = 255,
 };
 

--- a/src/ripple/protocol/TxFlags.h
+++ b/src/ripple/protocol/TxFlags.h
@@ -200,6 +200,12 @@ constexpr std::uint32_t const tfImmutable = 1;
 // Clawback flags:
 constexpr std::uint32_t const tfClawbackMask = ~tfUniversal;
 
+// CronSet Flags:
+enum CronSetFlags : uint32_t {
+    tfCronUnset = 0x00000001,
+};
+constexpr std::uint32_t const tfCronSetMask = ~(tfUniversal | tfCronUnset);
+
 // clang-format on
 
 }  // namespace ripple

--- a/src/ripple/protocol/TxFormats.h
+++ b/src/ripple/protocol/TxFormats.h
@@ -149,6 +149,12 @@ enum TxType : std::uint16_t
     ttURITOKEN_CREATE_SELL_OFFER = 48,
     ttURITOKEN_CANCEL_SELL_OFFER = 49,
 
+    /* A pseudo-txn alarm signal for invoking a hook, emitted by validators after alarm set conditions are met */
+    ttCRON = 92,
+
+    /* Sechedule an alarm for later */
+    ttCRON_SET = 93,
+
     /* A note attaching transactor that allows the owner or issuer (on a object by object basis) to attach remarks */
     ttREMARKS_SET = 94,
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -479,6 +479,7 @@ REGISTER_FEATURE(Clawback,                      Supported::yes, VoteBehavior::De
 REGISTER_FIX    (fixProvisionalDoubleThreading, Supported::yes, VoteBehavior::DefaultYes);
 REGISTER_FEATURE(DeepFreeze,                    Supported::yes, VoteBehavior::DefaultNo);
 REGISTER_FEATURE(IOUIssuerWeakTSH,              Supported::yes, VoteBehavior::DefaultNo);
+REGISTER_FEATURE(Cron,                          Supported::yes, VoteBehavior::DefaultNo);
 
 // The following amendments are obsolete, but must remain supported
 // because they could potentially get enabled.

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -72,6 +72,7 @@ enum class LedgerNameSpace : std::uint16_t {
     URI_TOKEN = 'U',
     IMPORT_VLSEQ = 'I',
     UNL_REPORT = 'R',
+    CRON = 'A',
 
     // No longer used or supported. Left here to reserve the space
     // to avoid accidental reuse.
@@ -441,6 +442,28 @@ uritoken(AccountID const& issuer, Blob const& uri)
         ltURI_TOKEN,
         indexHash(
             LedgerNameSpace::URI_TOKEN, issuer, Slice{uri.data(), uri.size()})};
+}
+
+Keylet
+cron(uint32_t timestamp, AccountID const& id)
+{
+    static const uint256 ns = indexHash(LedgerNameSpace::CRON);
+
+    uint8_t h[32];
+
+    // first 8 bytes are the namespacing
+    std::memcpy(h, ns.data(), 8);
+
+    // next 4 bytes are the timestamp in BE
+    h[8] = static_cast<uint8_t>((timestamp >> 24) & 0xFFU);
+    h[9] = static_cast<uint8_t>((timestamp >> 16) & 0xFFU);
+    h[10] = static_cast<uint8_t>((timestamp >> 8) & 0xFFU);
+    h[11] = static_cast<uint8_t>((timestamp >> 0) & 0xFFU);
+
+    // final 20 bytes are account ID
+    std::memcpy(h + 12, id.data(), 20);
+
+    return {ltCRON, uint256::fromVoid(h)};
 }
 
 }  // namespace keylet

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -444,6 +444,27 @@ uritoken(AccountID const& issuer, Blob const& uri)
             LedgerNameSpace::URI_TOKEN, issuer, Slice{uri.data(), uri.size()})};
 }
 
+// Constructs an ordered CRON keylet (32 bytes):
+//   [8-byte namespace][4-byte timestamp (big-endian, seconds)][20-byte
+//   AccountID]
+//
+// Properties
+// - Namespacing: first 8 bytes are the most-significant bytes of
+// indexHash(LedgerNameSpace::CRON).
+// - Uniqueness (per ts,acct): exactly ONE cron per (timestamp, AccountID).
+// Insert is upsert (last-write-wins).
+//   This is fine because we only ever allow one cron per account at a time—if
+//   the same (ts,acct) is written, it’s simply an update to that single entry
+//   (idempotent; no duplicate leaves).
+// - Iteration order: chronological by timestamp (BE), then by raw AccountID
+// bytes.
+//   NOTE: raw AccountID ordering may bias priority; consider hashing AccountID
+//   for uniform per-timestamp spread.
+// - Expected accidental prefix collisions (foreign objects sharing the 8-byte
+// namespace): n / 2^64,
+//   assuming uniform high-64-bit distribution of other objects.
+//   Examples: 100M → ~5.4e-12, 1B → ~5.4e-11, 10B → ~5.4e-10, 100B → ~5.4e-9
+//   (negligible).
 Keylet
 cron(uint32_t timestamp, AccountID const& id)
 {

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -481,8 +481,10 @@ cron(uint32_t timestamp, AccountID const& id)
     h[10] = static_cast<uint8_t>((timestamp >> 8) & 0xFFU);
     h[11] = static_cast<uint8_t>((timestamp >> 0) & 0xFFU);
 
+    const uint256 accHash = indexHash(LedgerNameSpace::CRON, timestamp, id);
+
     // final 20 bytes are account ID
-    std::memcpy(h + 12, id.data(), 20);
+    std::memcpy(h + 12, accHash.cdata(), 20);
 
     return {ltCRON, uint256::fromVoid(h)};
 }

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -68,6 +68,7 @@ LedgerFormats::LedgerFormats()
             {sfGovernanceMarks,      soeOPTIONAL},
             {sfAccountIndex,         soeOPTIONAL},
             {sfTouchCount,           soeOPTIONAL},
+            {sfCron,                 soeOPTIONAL},
         },
         commonFields);
 
@@ -363,6 +364,15 @@ LedgerFormats::LedgerFormats()
             {sfDestination,          soeOPTIONAL},
             {sfPreviousTxnID,        soeREQUIRED},
             {sfPreviousTxnLgrSeq,    soeREQUIRED}
+        },
+        commonFields);
+
+    add(jss::Cron,
+        ltCRON,
+        {
+            {sfOwner,                soeREQUIRED},
+            {sfDelaySeconds,         soeREQUIRED},
+            {sfRepeatCount,          soeREQUIRED}
         },
         commonFields);
 

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -372,7 +372,8 @@ LedgerFormats::LedgerFormats()
         {
             {sfOwner,                soeREQUIRED},
             {sfDelaySeconds,         soeREQUIRED},
-            {sfRepeatCount,          soeREQUIRED}
+            {sfRepeatCount,          soeREQUIRED},
+            {sfOwnerNode,            soeREQUIRED},
         },
         commonFields);
 

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -157,6 +157,8 @@ CONSTRUCT_TYPED_SFIELD(sfLockCount,             "LockCount",            UINT32, 
 
 CONSTRUCT_TYPED_SFIELD(sfFirstNFTokenSequence,  "FirstNFTokenSequence", UINT32,    50);
 
+CONSTRUCT_TYPED_SFIELD(sfRepeatCount,           "RepeatCount",          UINT32,    94);
+CONSTRUCT_TYPED_SFIELD(sfDelaySeconds,          "DelaySeconds",         UINT32,    95);
 CONSTRUCT_TYPED_SFIELD(sfXahauActivationLgrSeq, "XahauActivationLgrSeq",UINT32,    96);
 CONSTRUCT_TYPED_SFIELD(sfImportSequence,        "ImportSequence",       UINT32,    97);
 CONSTRUCT_TYPED_SFIELD(sfRewardTime,            "RewardTime",           UINT32,    98);
@@ -239,6 +241,7 @@ CONSTRUCT_TYPED_SFIELD(sfGovernanceFlags,       "GovernanceFlags",      UINT256,
 CONSTRUCT_TYPED_SFIELD(sfGovernanceMarks,       "GovernanceMarks",      UINT256,   98);
 CONSTRUCT_TYPED_SFIELD(sfEmittedTxnID,          "EmittedTxnID",         UINT256,   97);
 CONSTRUCT_TYPED_SFIELD(sfHookCanEmit,           "HookCanEmit",          UINT256,   96);
+CONSTRUCT_TYPED_SFIELD(sfCron,                  "Cron",                 UINT256,   95);
 
 // currency amount (common)
 CONSTRUCT_TYPED_SFIELD(sfAmount,                "Amount",               AMOUNT,     1);

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -615,7 +615,7 @@ isPseudoTx(STObject const& tx)
 
     auto tt = safe_cast<TxType>(*t);
     return tt == ttAMENDMENT || tt == ttFEE || tt == ttUNL_MODIFY ||
-        tt == ttEMIT_FAILURE || tt == ttUNL_REPORT;
+        tt == ttEMIT_FAILURE || tt == ttUNL_REPORT || tt == ttCRON;
 }
 
 }  // namespace ripple

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -472,6 +472,22 @@ TxFormats::TxFormats()
             {sfTicketSequence, soeOPTIONAL},
         },
         commonFields);
+
+    add(jss::Cron,
+        ttCRON,
+        {
+            {sfOwner, soeREQUIRED},
+            {sfLedgerSequence, soeREQUIRED},
+        },
+        commonFields);
+
+    add(jss::SetCron,
+        ttCRON_SET,
+        {
+            {sfDelaySeconds, soeOPTIONAL},
+            {sfRepeatCount, soeOPTIONAL},
+        },
+        commonFields);
 }
 
 TxFormats const&

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -481,7 +481,7 @@ TxFormats::TxFormats()
         },
         commonFields);
 
-    add(jss::SetCron,
+    add(jss::CronSet,
         ttCRON_SET,
         {
             {sfDelaySeconds, soeOPTIONAL},

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -61,6 +61,7 @@ JSS(Clawback);     // transaction type.
 JSS(ClearFlag);    // field.
 JSS(CreateCode);   // field.
 JSS(Cron);
+JSS(CronSet);
 JSS(DeliverMin);         // in: TransactionSign
 JSS(DepositPreauth);     // transaction and ledger type.
 JSS(Destination);        // in: TransactionSign; field.
@@ -132,7 +133,6 @@ JSS(SettleDelay);           // in: TransactionSign
 JSS(SendMax);               // in: TransactionSign
 JSS(Sequence);              // in/out: TransactionSign; field.
 JSS(SetAlarm);
-JSS(SetCron);
 JSS(SetFlag);                  // field.
 JSS(SetRegularKey);            // transaction type.
 JSS(SetHook);                  // transaction type.

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -131,7 +131,6 @@ JSS(UNLReport);             // transaction type.
 JSS(SettleDelay);           // in: TransactionSign
 JSS(SendMax);               // in: TransactionSign
 JSS(Sequence);              // in/out: TransactionSign; field.
-JSS(SetAlarm);
 JSS(SetFlag);                  // field.
 JSS(SetRegularKey);            // transaction type.
 JSS(SetHook);                  // transaction type.

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -97,40 +97,40 @@ JSS(isSigningField);      // out: RPC server_definitions
 JSS(isVLEncoded);         // out: RPC server_definitions
 JSS(Import);
 JSS(ImportVLSequence);
-JSS(Invalid);               //
-JSS(Invoke);                // transaction type
-JSS(InvoiceID);             // field
-JSS(LastLedgerSequence);    // in: TransactionSign; field
-JSS(LedgerHashes);          // ledger type.
-JSS(LimitAmount);           // field.
-JSS(NetworkID);             // field.
-JSS(NFTokenBurn);           // transaction type.
-JSS(NFTokenMint);           // transaction type.
-JSS(NFTokenOffer);          // ledger type.
-JSS(NFTokenAcceptOffer);    // transaction type.
-JSS(NFTokenCancelOffer);    // transaction type.
-JSS(NFTokenCreateOffer);    // transaction type.
-JSS(NFTokenPage);           // ledger type.
-JSS(Offer);                 // ledger type.
-JSS(OfferCancel);           // transaction type.
-JSS(OfferCreate);           // transaction type.
-JSS(OfferSequence);         // field.
-JSS(Paths);                 // in/out: TransactionSign
-JSS(PayChannel);            // ledger type.
-JSS(Payment);               // transaction type.
-JSS(PaymentChannelClaim);   // transaction type.
-JSS(PaymentChannelCreate);  // transaction type.
-JSS(PaymentChannelFund);    // transaction type.
-JSS(Remit);                 // transaction type.
-JSS(RippleState);           // ledger type.
-JSS(SLE_hit_rate);          // out: GetCounts.
-JSS(SetFee);                // transaction type.
-JSS(SetRemarks);            // transaction type
-JSS(UNLModify);             // transaction type.
-JSS(UNLReport);             // transaction type.
-JSS(SettleDelay);           // in: TransactionSign
-JSS(SendMax);               // in: TransactionSign
-JSS(Sequence);              // in/out: TransactionSign; field.
+JSS(Invalid);                  //
+JSS(Invoke);                   // transaction type
+JSS(InvoiceID);                // field
+JSS(LastLedgerSequence);       // in: TransactionSign; field
+JSS(LedgerHashes);             // ledger type.
+JSS(LimitAmount);              // field.
+JSS(NetworkID);                // field.
+JSS(NFTokenBurn);              // transaction type.
+JSS(NFTokenMint);              // transaction type.
+JSS(NFTokenOffer);             // ledger type.
+JSS(NFTokenAcceptOffer);       // transaction type.
+JSS(NFTokenCancelOffer);       // transaction type.
+JSS(NFTokenCreateOffer);       // transaction type.
+JSS(NFTokenPage);              // ledger type.
+JSS(Offer);                    // ledger type.
+JSS(OfferCancel);              // transaction type.
+JSS(OfferCreate);              // transaction type.
+JSS(OfferSequence);            // field.
+JSS(Paths);                    // in/out: TransactionSign
+JSS(PayChannel);               // ledger type.
+JSS(Payment);                  // transaction type.
+JSS(PaymentChannelClaim);      // transaction type.
+JSS(PaymentChannelCreate);     // transaction type.
+JSS(PaymentChannelFund);       // transaction type.
+JSS(Remit);                    // transaction type.
+JSS(RippleState);              // ledger type.
+JSS(SLE_hit_rate);             // out: GetCounts.
+JSS(SetFee);                   // transaction type.
+JSS(SetRemarks);               // transaction type
+JSS(UNLModify);                // transaction type.
+JSS(UNLReport);                // transaction type.
+JSS(SettleDelay);              // in: TransactionSign
+JSS(SendMax);                  // in: TransactionSign
+JSS(Sequence);                 // in/out: TransactionSign; field.
 JSS(SetFlag);                  // field.
 JSS(SetRegularKey);            // transaction type.
 JSS(SetHook);                  // transaction type.

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -50,15 +50,17 @@ JSS(AccountSet);     // transaction type.
 JSS(Amendments);     // ledger type.
 JSS(Amount);         // in: TransactionSign; field.
 JSS(Authorize);      // field
+JSS(Alarm);
 JSS(Blob);
-JSS(Check);              // ledger type.
-JSS(CheckCancel);        // transaction type.
-JSS(CheckCash);          // transaction type.
-JSS(CheckCreate);        // transaction type.
-JSS(ClaimReward);        // transaction type.
-JSS(Clawback);           // transaction type.
-JSS(ClearFlag);          // field.
-JSS(CreateCode);         // field.
+JSS(Check);        // ledger type.
+JSS(CheckCancel);  // transaction type.
+JSS(CheckCash);    // transaction type.
+JSS(CheckCreate);  // transaction type.
+JSS(ClaimReward);  // transaction type.
+JSS(Clawback);     // transaction type.
+JSS(ClearFlag);    // field.
+JSS(CreateCode);   // field.
+JSS(Cron);
 JSS(DeliverMin);         // in: TransactionSign
 JSS(DepositPreauth);     // transaction and ledger type.
 JSS(Destination);        // in: TransactionSign; field.
@@ -95,40 +97,42 @@ JSS(isSigningField);      // out: RPC server_definitions
 JSS(isVLEncoded);         // out: RPC server_definitions
 JSS(Import);
 JSS(ImportVLSequence);
-JSS(Invalid);                  //
-JSS(Invoke);                   // transaction type
-JSS(InvoiceID);                // field
-JSS(LastLedgerSequence);       // in: TransactionSign; field
-JSS(LedgerHashes);             // ledger type.
-JSS(LimitAmount);              // field.
-JSS(NetworkID);                // field.
-JSS(NFTokenBurn);              // transaction type.
-JSS(NFTokenMint);              // transaction type.
-JSS(NFTokenOffer);             // ledger type.
-JSS(NFTokenAcceptOffer);       // transaction type.
-JSS(NFTokenCancelOffer);       // transaction type.
-JSS(NFTokenCreateOffer);       // transaction type.
-JSS(NFTokenPage);              // ledger type.
-JSS(Offer);                    // ledger type.
-JSS(OfferCancel);              // transaction type.
-JSS(OfferCreate);              // transaction type.
-JSS(OfferSequence);            // field.
-JSS(Paths);                    // in/out: TransactionSign
-JSS(PayChannel);               // ledger type.
-JSS(Payment);                  // transaction type.
-JSS(PaymentChannelClaim);      // transaction type.
-JSS(PaymentChannelCreate);     // transaction type.
-JSS(PaymentChannelFund);       // transaction type.
-JSS(Remit);                    // transaction type.
-JSS(RippleState);              // ledger type.
-JSS(SLE_hit_rate);             // out: GetCounts.
-JSS(SetFee);                   // transaction type.
-JSS(SetRemarks);               // transaction type
-JSS(UNLModify);                // transaction type.
-JSS(UNLReport);                // transaction type.
-JSS(SettleDelay);              // in: TransactionSign
-JSS(SendMax);                  // in: TransactionSign
-JSS(Sequence);                 // in/out: TransactionSign; field.
+JSS(Invalid);               //
+JSS(Invoke);                // transaction type
+JSS(InvoiceID);             // field
+JSS(LastLedgerSequence);    // in: TransactionSign; field
+JSS(LedgerHashes);          // ledger type.
+JSS(LimitAmount);           // field.
+JSS(NetworkID);             // field.
+JSS(NFTokenBurn);           // transaction type.
+JSS(NFTokenMint);           // transaction type.
+JSS(NFTokenOffer);          // ledger type.
+JSS(NFTokenAcceptOffer);    // transaction type.
+JSS(NFTokenCancelOffer);    // transaction type.
+JSS(NFTokenCreateOffer);    // transaction type.
+JSS(NFTokenPage);           // ledger type.
+JSS(Offer);                 // ledger type.
+JSS(OfferCancel);           // transaction type.
+JSS(OfferCreate);           // transaction type.
+JSS(OfferSequence);         // field.
+JSS(Paths);                 // in/out: TransactionSign
+JSS(PayChannel);            // ledger type.
+JSS(Payment);               // transaction type.
+JSS(PaymentChannelClaim);   // transaction type.
+JSS(PaymentChannelCreate);  // transaction type.
+JSS(PaymentChannelFund);    // transaction type.
+JSS(Remit);                 // transaction type.
+JSS(RippleState);           // ledger type.
+JSS(SLE_hit_rate);          // out: GetCounts.
+JSS(SetFee);                // transaction type.
+JSS(SetRemarks);            // transaction type
+JSS(UNLModify);             // transaction type.
+JSS(UNLReport);             // transaction type.
+JSS(SettleDelay);           // in: TransactionSign
+JSS(SendMax);               // in: TransactionSign
+JSS(Sequence);              // in/out: TransactionSign; field.
+JSS(SetAlarm);
+JSS(SetCron);
 JSS(SetFlag);                  // field.
 JSS(SetRegularKey);            // transaction type.
 JSS(SetHook);                  // transaction type.

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -50,7 +50,6 @@ JSS(AccountSet);     // transaction type.
 JSS(Amendments);     // ledger type.
 JSS(Amount);         // in: TransactionSign; field.
 JSS(Authorize);      // field
-JSS(Alarm);
 JSS(Blob);
 JSS(Check);        // ledger type.
 JSS(CheckCancel);  // transaction type.

--- a/src/ripple/rpc/handlers/ServerDefinitions.cpp
+++ b/src/ripple/rpc/handlers/ServerDefinitions.cpp
@@ -423,6 +423,7 @@ private:
         addFlagsToJson<NFTokenMintFlags>(ret, "NFTokenMint");
         addFlagsToJson<NFTokenCreateOfferFlags>(ret, "NFTokenCreateOffer");
         addFlagsToJson<ClaimRewardFlags>(ret, "ClaimReward");
+        addFlagsToJson<CronSetFlags>(ret, "CronSet");
         struct FlagData
         {
             std::string name;

--- a/src/test/app/Cron_test.cpp
+++ b/src/test/app/Cron_test.cpp
@@ -1,0 +1,278 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2025 XRPL Labs
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/LedgerMaster.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/jss.h>
+#include "ripple/protocol/Indexes.h"
+#include "ripple/protocol/TER.h"
+#include "ripple/protocol/TxFlags.h"
+#include "test/jtx/TestHelpers.h"
+#include "test/jtx/cron.h"
+#include <test/jtx.h>
+
+namespace ripple {
+namespace test {
+struct Cron_test : public beast::unit_test::suite
+{
+    void
+    testEnabled(FeatureBitset features)
+    {
+        testcase("enabled");
+        using namespace jtx;
+        using namespace std::literals::chrono_literals;
+
+        // setup env
+        auto const alice = Account("alice");
+        auto const issuer = Account("issuer");
+
+        for (bool const withCron : {false, true})
+        {
+            // If the BalanceRewards amendment is not enabled, you should not be
+            // able to claim rewards.
+            auto const amend = withCron ? features : features - featureCron;
+            Env env{*this, amend};
+
+            env.fund(XRP(1000), alice, issuer);
+            env.close();
+
+            auto const expectResult =
+                withCron ? ter(tesSUCCESS) : ter(temDISABLED);
+
+            auto tx = cron::set(alice);
+            // CLAIM
+            env(cron::set(alice), fee(XRP(1)), expectResult);
+            env.close();
+        }
+    }
+
+    void
+    testFee(FeatureBitset features)
+    {
+        testcase("fee");
+        using namespace jtx;
+        using namespace std::literals::chrono_literals;
+
+        auto const alice = Account("alice");
+        Env env{*this, features | featureCron};
+
+        auto const baseFee = env.current()->fees().base;
+
+        env.fund(XRP(1000), alice);
+        env.close();
+
+        // create with RepeatCount
+        auto expected = baseFee * 2 + baseFee * 256;
+        env(cron::set(alice),
+            cron::delay(356 * 24 * 60 * 60),
+            cron::repeat(256),
+            fee(expected - 1),
+            ter(telINSUF_FEE_P));
+        env.close();
+
+        env(cron::set(alice),
+            cron::delay(356 * 24 * 60 * 60),
+            cron::repeat(256),
+            fee(expected),
+            ter(tesSUCCESS));
+        env.close();
+
+        // create with no RepeatCount
+        expected = baseFee * 2;
+        env(cron::set(alice),
+            cron::delay(356 * 24 * 60 * 60),
+            fee(expected - 1),
+            ter(telINSUF_FEE_P));
+        env.close();
+
+        env(cron::set(alice),
+            cron::delay(356 * 24 * 60 * 60),
+            fee(expected),
+            ter(tesSUCCESS));
+        env.close();
+
+        // delete
+        expected = baseFee;
+        env(cron::set(alice), fee(expected - 1), ter(telINSUF_FEE_P));
+        env.close();
+
+        env(cron::set(alice), fee(expected), ter(tesSUCCESS));
+        env.close();
+    }
+
+    void
+    testInvalidPreflight(FeatureBitset features)
+    {
+        testcase("invalid preflight");
+        using namespace test::jtx;
+        using namespace std::literals;
+
+        auto const alice = Account("alice");
+
+        test::jtx::Env env{
+            *this, network::makeNetworkConfig(21337), features | featureCron};
+
+        env.fund(XRP(1000), alice);
+        env.close();
+
+        //----------------------------------------------------------------------
+        // preflight
+
+        // temINVALID_FLAG
+        // can have flag 1 set to opt-out of rewards
+        {
+            env(cron::set(alice), txflags(tfClose), ter(temINVALID_FLAG));
+            env(cron::set(alice),
+                txflags(tfUniversalMask),
+                ter(temINVALID_FLAG));
+        }
+
+        // temMALFORMED
+        {
+            // Invalid DelaySeconds and RepeatCount combination
+            // (only RepeatCount specified)
+            env(cron::set(alice), cron::repeat(256), ter(temMALFORMED));
+            env.close();
+
+            // Invalid DelaySeconds
+            env(cron::set(alice),
+                cron::delay(365 * 24 * 60 * 60 + 1),
+                cron::repeat(256),
+                ter(temMALFORMED));
+            env.close();
+
+            // Invalid RepeatCount
+            env(cron::set(alice),
+                cron::delay(365 * 24 * 60 * 60),
+                cron::repeat(257),
+                ter(temMALFORMED));
+            env.close();
+        }
+    }
+
+    void
+    testInvalidPreclaim(FeatureBitset features)
+    {
+        testcase("invalid preclaim");
+        using namespace test::jtx;
+        using namespace std::literals;
+
+        // no preclaim checks exists
+        BEAST_EXPECT(true);
+    }
+
+    void
+    testDoApply(FeatureBitset features)
+    {
+        testcase("doApply");
+        using namespace jtx;
+        using namespace std::literals::chrono_literals;
+        auto const alice = Account("alice");
+        Env env{*this, features | featureCron};
+
+        env.fund(XRP(1000), alice);
+        env.close();
+
+        auto const aliceOwnerCount = ownerCount(env, alice);
+
+        // create cron
+        env(cron::set(alice),
+            cron::delay(356 * 24 * 60 * 60),
+            cron::repeat(256),
+            fee(XRP(1)),
+            ter(tesSUCCESS));
+        env.close();
+
+        // increment owner count
+        BEAST_EXPECT(ownerCount(env, alice) == aliceOwnerCount + 1);
+
+        auto const accSle = env.le(keylet::account(alice.id()));
+        BEAST_EXPECT(accSle);
+        BEAST_EXPECT(accSle->isFieldPresent(sfCron));
+
+        auto const cronKey = keylet::child(accSle->getFieldH256(sfCron));
+        auto const cronSle = env.le(cronKey);
+        BEAST_EXPECT(cronSle);
+        BEAST_EXPECT(
+            cronSle->getFieldU32(sfDelaySeconds) == 356 * 24 * 60 * 60);
+        BEAST_EXPECT(cronSle->getFieldU32(sfRepeatCount) == 256);
+
+        // update cron
+        env(cron::set(alice),
+            cron::delay(100),
+            cron::repeat(10),
+            fee(XRP(1)),
+            ter(tesSUCCESS));
+        env.close();
+
+        // owner count does not change
+        BEAST_EXPECT(ownerCount(env, alice) == aliceOwnerCount + 1);
+
+        auto const accSle2 = env.le(keylet::account(alice.id()));
+        BEAST_EXPECT(accSle2);
+        BEAST_EXPECT(accSle2->isFieldPresent(sfCron));
+
+        // old cron sle is deleted
+        BEAST_EXPECT(!env.le(cronKey));
+
+        auto const cronKey2 = keylet::child(accSle2->getFieldH256(sfCron));
+        auto const cronSle2 = env.le(cronKey2);
+        BEAST_EXPECT(cronSle2);
+        BEAST_EXPECT(cronSle2->getFieldU32(sfDelaySeconds) == 100);
+        BEAST_EXPECT(cronSle2->getFieldU32(sfRepeatCount) == 10);
+
+        // delete cron
+        env(cron::set(alice), fee(XRP(1)), ter(tesSUCCESS));
+        env.close();
+
+        // owner count decremented
+        BEAST_EXPECT(ownerCount(env, alice) == aliceOwnerCount);
+
+        auto const accSle3 = env.le(keylet::account(alice.id()));
+        BEAST_EXPECT(accSle3);
+        BEAST_EXPECT(!accSle3->isFieldPresent(sfCron));
+
+        // old cron sle is deleted
+        BEAST_EXPECT(!env.le(cronKey2));
+    }
+
+    void
+    testWithFeats(FeatureBitset features)
+    {
+        testEnabled(features);
+        testFee(features);
+        testInvalidPreflight(features);
+        testInvalidPreclaim(features);
+        testDoApply(features);
+    }
+
+public:
+    void
+    run() override
+    {
+        using namespace test::jtx;
+        auto const sa = supported_amendments();
+        testWithFeats(sa);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Cron, app, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/app/Cron_test.cpp
+++ b/src/test/app/Cron_test.cpp
@@ -20,11 +20,6 @@
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/jss.h>
-#include "ripple/protocol/Indexes.h"
-#include "ripple/protocol/TER.h"
-#include "ripple/protocol/TxFlags.h"
-#include "test/jtx/TestHelpers.h"
-#include "test/jtx/cron.h"
 #include <test/jtx.h>
 
 namespace ripple {
@@ -44,8 +39,6 @@ struct Cron_test : public beast::unit_test::suite
 
         for (bool const withCron : {false, true})
         {
-            // If the BalanceRewards amendment is not enabled, you should not be
-            // able to claim rewards.
             auto const amend = withCron ? features : features - featureCron;
             Env env{*this, amend};
 
@@ -135,7 +128,6 @@ struct Cron_test : public beast::unit_test::suite
         // preflight
 
         // temINVALID_FLAG
-        // can have flag 1 set to opt-out of rewards
         {
             env(cron::set(alice), txflags(tfClose), ter(temINVALID_FLAG));
             env(cron::set(alice),
@@ -253,6 +245,170 @@ struct Cron_test : public beast::unit_test::suite
     }
 
     void
+    testCronExecution(FeatureBitset features)
+    {
+        testcase("cron execution");
+        using namespace jtx;
+        using namespace std::literals::chrono_literals;
+        auto const alice = Account("alice");
+
+        {
+            // test ttCron execution and repeatCount
+            Env env{*this, features | featureCron};
+
+            env.fund(XRP(1000), alice);
+            env.close();
+
+            auto baseTime = env.timeKeeper().now().time_since_epoch().count();
+
+            auto repeatCount = 10;
+
+            env(cron::set(alice),
+                cron::delay(100),
+                cron::repeat(repeatCount),
+                fee(XRP(1)));
+            env.close(10s);
+
+            auto lastCronKeylet =
+                keylet::child(env.le(alice)->getFieldH256(sfCron));
+
+            while (repeatCount >= 0)
+            {
+                // close ledger until 100 seconds has passed
+                while (env.timeKeeper().now().time_since_epoch().count() -
+                           baseTime <
+                       100)
+                {
+                    env.close(10s);
+                    auto txns = env.closed()->txs;
+                    auto size = std::distance(txns.begin(), txns.end());
+                    BEAST_EXPECT(size == 0);
+                }
+
+                // close after 100 seconds passed
+                env.close();
+
+                auto txns = env.closed()->txs;
+                auto size = std::distance(txns.begin(), txns.end());
+                BEAST_EXPECT(size == 1);
+                for (auto it = txns.begin(); it != txns.end(); ++it)
+                {
+                    auto const& tx = *it->first;
+                    // check pseudo txn format
+                    BEAST_EXPECT(tx.getTxnType() == ttCRON);
+                    BEAST_EXPECT(tx.getAccountID(sfAccount) == AccountID());
+                    BEAST_EXPECT(tx.getAccountID(sfOwner) == alice.id());
+                    BEAST_EXPECT(
+                        tx.getFieldU32(sfLedgerSequence) ==
+                        env.closed()->info().seq);
+                    BEAST_EXPECT(tx.getFieldAmount(sfFee) == XRP(0));
+                    BEAST_EXPECT(tx.getFieldVL(sfSigningPubKey).size() == 0);
+
+                    // check old Cron object is deleted
+                    BEAST_EXPECT(!env.le(lastCronKeylet));
+
+                    if (repeatCount > 0)
+                    {
+                        // check new Cron object
+                        auto const cronKeylet =
+                            keylet::child(env.le(alice)->getFieldH256(sfCron));
+                        auto const cronSle = env.le(cronKeylet);
+                        BEAST_EXPECT(cronSle);
+                        BEAST_EXPECT(
+                            cronSle->getFieldU32(sfDelaySeconds) == 100);
+                        BEAST_EXPECT(
+                            cronSle->getFieldU32(sfRepeatCount) ==
+                            --repeatCount);
+                        BEAST_EXPECT(
+                            cronSle->getAccountID(sfOwner) == alice.id());
+
+                        // set new base time
+                        baseTime =
+                            env.timeKeeper().now().time_since_epoch().count();
+                        lastCronKeylet = cronKeylet;
+                    }
+                    else
+                    {
+                        // after all executions, the cron object should be
+                        // deleted
+                        BEAST_EXPECT(!env.le(alice)->isFieldPresent(sfCron));
+                        BEAST_EXPECT(!env.le(lastCronKeylet));
+                        --repeatCount;  // decrement for break double loop
+                    }
+                }
+            }
+        }
+
+        {
+            // test ttCron limit in a ledger
+            Env env{*this, features | featureCron};
+            std::vector<Account> accounts;
+            accounts.reserve(300);
+            for (int i = 0; i < 300; ++i)
+            {
+                auto const& account = accounts.emplace_back(
+                    Account("account_" + std::to_string(i)));
+                accounts.emplace_back(account);
+                env.fund(XRP(10000), account);
+            }
+            env.close();
+
+            for (auto const& account : accounts)
+            {
+                env(cron::set(account), cron::delay(0), fee(XRP(1)));
+            }
+            env.close();
+
+            // proceed ledger
+            env.close();
+            {
+                auto const txns = env.closed()->txs;
+                auto size = std::distance(txns.begin(), txns.end());
+                BEAST_EXPECT(size == 128);
+                for (auto it = txns.begin(); it != txns.end(); ++it)
+                {
+                    auto const& tx = *it->first;
+                    BEAST_EXPECT(tx.getTxnType() == ttCRON);
+                }
+            }
+
+            // proceed ledger
+            env.close();
+            {
+                auto const txns = env.closed()->txs;
+                auto size = std::distance(txns.begin(), txns.end());
+                BEAST_EXPECT(size == 128);
+                for (auto it = txns.begin(); it != txns.end(); ++it)
+                {
+                    auto const& tx = *it->first;
+                    BEAST_EXPECT(tx.getTxnType() == ttCRON);
+                }
+            }
+
+            // proceed ledger
+            env.close();
+            {
+                auto const txns = env.closed()->txs;
+                auto size = std::distance(txns.begin(), txns.end());
+                BEAST_EXPECT(size == 44);
+                for (auto it = txns.begin(); it != txns.end(); ++it)
+                {
+                    auto const& tx = *it->first;
+                    BEAST_EXPECT(tx.getTxnType() == ttCRON);
+                }
+            }
+
+            // proceed ledger
+            env.close();
+            {
+                auto const txns = env.closed()->txs;
+                auto size = std::distance(txns.begin(), txns.end());
+                BEAST_EXPECT(size == 0);
+            }
+        }
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnabled(features);
@@ -260,6 +416,8 @@ struct Cron_test : public beast::unit_test::suite
         testInvalidPreflight(features);
         testInvalidPreclaim(features);
         testDoApply(features);
+
+        testCronExecution(features);
     }
 
 public:

--- a/src/test/app/Cron_test.cpp
+++ b/src/test/app/Cron_test.cpp
@@ -180,12 +180,8 @@ struct Cron_test : public beast::unit_test::suite
         auto const alice = Account("alice");
         Env env{*this, features | featureCron};
 
-        env.fund(XRP(1000), alice);
-        env.close();
-
-        // Cron does not set
-        env(cron::set(alice), txflags(tfCronUnset), ter(tecNO_ENTRY));
-        env.close();
+        // there is no check in preclaim
+        BEAST_EXPECT(true);
     }
 
     void
@@ -264,6 +260,13 @@ struct Cron_test : public beast::unit_test::suite
 
         // old cron sle is deleted
         BEAST_EXPECT(!env.le(cronKey2));
+
+        // delete cron without object will succeed
+        env(cron::set(alice),
+            fee(XRP(1)),
+            txflags(tfCronUnset),
+            ter(tesSUCCESS));
+        env.close();
     }
 
     void

--- a/src/test/app/Cron_test.cpp
+++ b/src/test/app/Cron_test.cpp
@@ -140,21 +140,24 @@ struct Cron_test : public beast::unit_test::suite
             // Invalid DelaySeconds and RepeatCount combination
             // (only RepeatCount specified)
             env(cron::set(alice), cron::repeat(256), ter(temMALFORMED));
-            env.close();
 
             // Invalid DelaySeconds
             env(cron::set(alice),
                 cron::delay(365 * 24 * 60 * 60 + 1),
                 cron::repeat(256),
                 ter(temMALFORMED));
-            env.close();
 
             // Invalid RepeatCount
             env(cron::set(alice),
                 cron::delay(365 * 24 * 60 * 60),
                 cron::repeat(257),
                 ter(temMALFORMED));
-            env.close();
+
+            // Invalid tfCronUnset flag
+            env(cron::set(alice),
+                cron::delay(365 * 24 * 60 * 60),
+                txflags(tfCronUnset),
+                ter(temMALFORMED));
         }
     }
 
@@ -165,8 +168,15 @@ struct Cron_test : public beast::unit_test::suite
         using namespace test::jtx;
         using namespace std::literals;
 
-        // no preclaim checks exists
-        BEAST_EXPECT(true);
+        auto const alice = Account("alice");
+        Env env{*this, features | featureCron};
+
+        env.fund(XRP(1000), alice);
+        env.close();
+
+        // Cron does not set
+        env(cron::set(alice), txflags(tfCronUnset), ter(tecNO_ENTRY));
+        env.close();
     }
 
     void
@@ -230,7 +240,10 @@ struct Cron_test : public beast::unit_test::suite
         BEAST_EXPECT(cronSle2->getFieldU32(sfRepeatCount) == 10);
 
         // delete cron
-        env(cron::set(alice), fee(XRP(1)), ter(tesSUCCESS));
+        env(cron::set(alice),
+            fee(XRP(1)),
+            txflags(tfCronUnset),
+            ter(tesSUCCESS));
         env.close();
 
         // owner count decremented

--- a/src/test/app/Cron_test.cpp
+++ b/src/test/app/Cron_test.cpp
@@ -50,7 +50,7 @@ struct Cron_test : public beast::unit_test::suite
 
             auto tx = cron::set(alice);
             // CLAIM
-            env(cron::set(alice), fee(XRP(1)), expectResult);
+            env(cron::set(alice), cron::delay(100), fee(XRP(1)), expectResult);
             env.close();
         }
     }
@@ -102,10 +102,16 @@ struct Cron_test : public beast::unit_test::suite
 
         // delete
         expected = baseFee;
-        env(cron::set(alice), fee(expected - 1), ter(telINSUF_FEE_P));
+        env(cron::set(alice),
+            txflags(tfCronUnset),
+            fee(expected - 1),
+            ter(telINSUF_FEE_P));
         env.close();
 
-        env(cron::set(alice), fee(expected), ter(tesSUCCESS));
+        env(cron::set(alice),
+            txflags(tfCronUnset),
+            fee(expected),
+            ter(tesSUCCESS));
         env.close();
     }
 
@@ -137,6 +143,9 @@ struct Cron_test : public beast::unit_test::suite
 
         // temMALFORMED
         {
+            // Invalid both DelaySeconds and RepeatCount are not specified
+            env(cron::set(alice), ter(temMALFORMED));
+
             // Invalid DelaySeconds and RepeatCount combination
             // (only RepeatCount specified)
             env(cron::set(alice), cron::repeat(256), ter(temMALFORMED));

--- a/src/test/app/SetHookTSH_test.cpp
+++ b/src/test/app/SetHookTSH_test.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/TxQ.h>
 #include <ripple/app/tx/apply.h>
+#include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/PayChan.h>
 #include <ripple/protocol/jss.h>
@@ -749,9 +750,21 @@ private:
         int const& expected,
         uint64_t const& lineno)
     {
+        auto const hashStr =
+            env.tx()->getJson(JsonOptions::none)[jss::hash].asString();
+        uint256 const txHash = uint256::fromVoid(strUnHex(hashStr)->data());
+        testTSHStrongWeak(env, txHash, expected, lineno);
+    }
+
+    void
+    testTSHStrongWeak(
+        jtx::Env& env,
+        uint256 const& txHash,
+        int const& expected,
+        uint64_t const& lineno)
+    {
         Json::Value params;
-        params[jss::transaction] =
-            env.tx()->getJson(JsonOptions::none)[jss::hash];
+        params[jss::transaction] = strHex(txHash);
         auto const jrr = env.rpc("json", "tx", to_string(params));
         auto const meta = jrr[jss::result][jss::meta];
         validateTSHStrongWeak(meta, expected, lineno);
@@ -6251,6 +6264,103 @@ private:
         }
     }
 
+    // CronSet
+    // | otxn | tsh | cset |
+    // |   A  |  A  |  S   |
+    void
+    testCronSetTSH(FeatureBitset features)
+    {
+        testcase("cron set tsh");
+
+        using namespace test::jtx;
+        using namespace std::literals;
+
+        // otxn: account
+        // tsh account
+        // w/s: strong
+        for (bool const testStrong : {true, false})
+        {
+            test::jtx::Env env{
+                *this,
+                network::makeNetworkConfig(21337, "10", "1000000", "200000"),
+                features};
+
+            auto const account = Account("alice");
+            env.fund(XRP(1000), account);
+            env.close();
+
+            if (!testStrong)
+                addWeakTSH(env, account);
+
+            // set tsh hook
+            setTSHHook(env, account, testStrong);
+
+            // cron set
+            env(cron::set(account),
+                cron::delay(100),
+                cron::repeat(1),
+                fee(XRP(1)),
+                ter(tesSUCCESS));
+            env.close();
+
+            // verify tsh hook triggered
+            testTSHStrongWeak(env, tshSTRONG, __LINE__);
+        }
+    }
+
+    // | otxn | tsh | cron |
+    // |   -  |  O  |  W   |
+    void
+    testCronTSH(FeatureBitset features)
+    {
+        testcase("cron tsh");
+
+        using namespace test::jtx;
+        using namespace std::literals;
+
+        // otxn: -
+        // tsh owner
+        // w/s: weak
+        for (bool const testStrong : {true, false})
+        {
+            test::jtx::Env env{
+                *this,
+                network::makeNetworkConfig(21337, "10", "1000000", "200000"),
+                features};
+
+            auto const account = Account("alice");
+            env.fund(XRP(1000), account);
+            env.close();
+
+            // cron set
+            env(cron::set(account),
+                cron::delay(100),
+                cron::repeat(1),
+                fee(XRP(1)),
+                ter(tesSUCCESS));
+            env.close();
+
+            if (!testStrong)
+                addWeakTSH(env, account);
+
+            // set tsh hook
+            setTSHHook(env, account, testStrong);
+
+            // proceed ledger
+            env.close(100s);
+
+            // close ledger
+            env.close();
+
+            // verify tsh hook triggered
+            auto const expected = testStrong ? tshNONE : tshWEAK;
+            auto const txs = env.closed()->txs;
+            BEAST_EXPECT(std::distance(txs.begin(), txs.end()) == 1);
+            auto const tx = txs.begin()->first;
+            BEAST_EXPECT(tx->getTxnType() == ttCRON);
+            testTSHStrongWeak(env, tx->getTransactionID(), expected, __LINE__);
+        }
+    }
     void
     testEmissionOrdering(FeatureBitset features)
     {
@@ -6398,6 +6508,8 @@ private:
         testURITokenCancelSellOfferTSH(features);
         testURITokenCreateSellOfferTSH(features);
         testRemitTSH(features);
+        testCronSetTSH(features);
+        testCronTSH(features);
     }
 
     void

--- a/src/test/jtx.h
+++ b/src/test/jtx.h
@@ -33,6 +33,7 @@
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>
 #include <test/jtx/check.h>
+#include <test/jtx/cron.h>
 #include <test/jtx/delivermin.h>
 #include <test/jtx/deposit.h>
 #include <test/jtx/escrow.h>

--- a/src/test/jtx/cron.h
+++ b/src/test/jtx/cron.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2024 XRPL-Labs
+    Copyright (c) 2025 XRPL Labs
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -17,40 +17,58 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_TX_SETCRON_H_INCLUDED
-#define RIPPLE_TX_SETCRON_H_INCLUDED
+#ifndef RIPPLE_TEST_JTX_CRON_H_INCLUDED
+#define RIPPLE_TEST_JTX_CRON_H_INCLUDED
 
-#include <ripple/app/tx/impl/Transactor.h>
-#include <ripple/basics/Log.h>
-#include <ripple/protocol/Indexes.h>
+#include <test/jtx/Account.h>
+#include <test/jtx/Env.h>
 
 namespace ripple {
+namespace test {
+namespace jtx {
 
-class SetCron : public Transactor
+/** Cron operations. */
+namespace cron {
+
+/** Set a cron. */
+Json::Value
+set(jtx::Account const& account);
+
+/** Sets the optional DelaySeconds on a JTx. */
+class delay
 {
-public:
-    static constexpr ConsequencesFactoryType ConsequencesFactory{Custom};
+private:
+    uint32_t delay_;
 
-    explicit SetCron(ApplyContext& ctx) : Transactor(ctx)
+public:
+    explicit delay(uint32_t delay) : delay_(delay)
     {
     }
 
-    static XRPAmount
-    calculateBaseFee(ReadView const& view, STTx const& tx);
-
-    static TxConsequences
-    makeTxConsequences(PreflightContext const& ctx);
-
-    static NotTEC
-    preflight(PreflightContext const& ctx);
-
-    static TER
-    preclaim(PreclaimContext const&);
-
-    TER
-    doApply() override;
+    void
+    operator()(Env&, JTx& jtx) const;
 };
 
+/** Sets the optional RepeatCount on a JTx. */
+class repeat
+{
+private:
+    uint32_t repeat_;
+
+public:
+    explicit repeat(uint32_t repeat) : repeat_(repeat)
+    {
+    }
+
+    void
+    operator()(Env&, JTx& jtx) const;
+};
+
+}  // namespace cron
+
+}  // namespace jtx
+
+}  // namespace test
 }  // namespace ripple
 
-#endif
+#endif  // RIPPLE_TEST_JTX_CRON_H_INCLUDED

--- a/src/test/jtx/impl/cron.cpp
+++ b/src/test/jtx/impl/cron.cpp
@@ -32,7 +32,7 @@ set(jtx::Account const& account)
 {
     using namespace jtx;
     Json::Value jv;
-    jv[jss::TransactionType] = jss::SetCron;
+    jv[jss::TransactionType] = jss::CronSet;
     jv[jss::Account] = account.human();
     return jv;
 }

--- a/src/test/jtx/impl/cron.cpp
+++ b/src/test/jtx/impl/cron.cpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2024 XRPL-Labs
+    Copyright (c) 2025 XRPL Labs
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -17,40 +17,40 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_TX_SETCRON_H_INCLUDED
-#define RIPPLE_TX_SETCRON_H_INCLUDED
-
-#include <ripple/app/tx/impl/Transactor.h>
-#include <ripple/basics/Log.h>
-#include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/jss.h>
+#include <test/jtx/cron.h>
 
 namespace ripple {
+namespace test {
+namespace jtx {
 
-class SetCron : public Transactor
+namespace cron {
+
+// Set a cron.
+Json::Value
+set(jtx::Account const& account)
 {
-public:
-    static constexpr ConsequencesFactoryType ConsequencesFactory{Custom};
+    using namespace jtx;
+    Json::Value jv;
+    jv[jss::TransactionType] = jss::SetCron;
+    jv[jss::Account] = account.human();
+    return jv;
+}
 
-    explicit SetCron(ApplyContext& ctx) : Transactor(ctx)
-    {
-    }
+void
+delay::operator()(Env& env, JTx& jt) const
+{
+    jt.jv[sfDelaySeconds.jsonName] = delay_;
+}
 
-    static XRPAmount
-    calculateBaseFee(ReadView const& view, STTx const& tx);
+void
+repeat::operator()(Env& env, JTx& jt) const
+{
+    jt.jv[sfRepeatCount.jsonName] = repeat_;
+}
 
-    static TxConsequences
-    makeTxConsequences(PreflightContext const& ctx);
+}  // namespace cron
 
-    static NotTEC
-    preflight(PreflightContext const& ctx);
-
-    static TER
-    preclaim(PreclaimContext const&);
-
-    TER
-    doApply() override;
-};
-
+}  // namespace jtx
+}  // namespace test
 }  // namespace ripple
-
-#endif


### PR DESCRIPTION
This feature allows each Account to set up an `ltCRON` object (using txn `SetCron`) which contains a delay and repeat count.

When the delay is satisfied the validators attempt to insert a pseudo `ttCron` into the end of the ledger (up to 128 of these.) This is achieved by iterating sequential keys in the range of valid Cron keylets.

A Cron keylet has an 8 byte namespace prefix, followed by 4 bytes of BE timestamp (when the Cron is to be executed) followed by 20 bytes of Account ID (for whom it is to be executed.)

When a `ttCRON` is applied, it self-deletes the `ltCRON` object that spawned it. The `sfOwner` of the `ltCRON` object becomes the `sfOwner` in the `ttCRON` and is a weak transactional stakeholder.

This allows hooks to request a wakeup call up to 1 year in advance and up to 256 times before needing to call `SetCron` again.

To remove an existing Cron submit a SetCron with both DelaySeconds and RepeatCount absent. Submitting a txn with only DelaySeconds implies a 0 repeat count, which is allowed for one-off transactions. A delay of 0 is also allowed and means apply as soon as it can be (in the next ledger typically).

The validators will always iterate from the oldest cron toward the end of the cron namespace, executing 128 per ledger until the next available cron (if any) exceeds the current last closed ledger timestamp.