### PR TITLE
RNG Patches

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -228,8 +228,8 @@ RCLConsensus::Adaptor::propose(RCLCxPeerPos::Proposal const& proposal)
     prop.set_signature(sig.data(), sig.size());
 
     // Only inject shuffle for initial proposals - one sig per validator is
-    // sufficient entropy, and initial proposals have ~1950ms (ledgerMIN_CONSENSUS)
-    // to propagate before the next round
+    // sufficient entropy, and initial proposals have ~1950ms
+    // (ledgerMIN_CONSENSUS) to propagate before the next round
     if (proposal.isInitial())
         injectShuffleTxn(app_, sig);
 

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -227,7 +227,11 @@ RCLConsensus::Adaptor::propose(RCLCxPeerPos::Proposal const& proposal)
 
     prop.set_signature(sig.data(), sig.size());
 
-    injectShuffleTxn(app_, sig);
+    // Only inject shuffle for initial proposals - one sig per validator is
+    // sufficient entropy, and initial proposals have ~1950ms (ledgerMIN_CONSENSUS)
+    // to propagate before the next round
+    if (proposal.isInitial())
+        injectShuffleTxn(app_, sig);
 
     auto const suppression = proposalUniqueId(
         proposal.position(),

--- a/src/ripple/app/hook/Enum.h
+++ b/src/ripple/app/hook/Enum.h
@@ -460,8 +460,6 @@ static const APIWhitelist import_whitelist{
     HOOK_API_DEFINITION(I64, otxn_slot, (I32)),
     HOOK_API_DEFINITION(I64, otxn_param, (I32, I32, I32, I32)),
     HOOK_API_DEFINITION(I64, meta_slot, (I32)),
-    HOOK_API_DEFINITION(I64, dice, (I32)),
-    HOOK_API_DEFINITION(I64, random, (I32, I32)),
     // clang-format on
 };
 
@@ -469,6 +467,14 @@ static const APIWhitelist import_whitelist{
 static const APIWhitelist import_whitelist_1{
     // clang-format off
     HOOK_API_DEFINITION(I64, xpop_slot, (I32, I32)),
+    // clang-format on
+};
+
+// featureRNG
+static const APIWhitelist import_whitelist_rng{
+    // clang-format off
+    HOOK_API_DEFINITION(I64, dice, (I32)),
+    HOOK_API_DEFINITION(I64, random, (I32, I32)),
     // clang-format on
 };
 

--- a/src/ripple/app/hook/Guard.h
+++ b/src/ripple/app/hook/Guard.h
@@ -1034,6 +1034,13 @@ validateGuards(
                     {
                         // PASS, this is a version 1 api
                     }
+                    else if (
+                        (rulesVersion & 0x04U) &&
+                        hook_api::import_whitelist_rng.find(import_name) !=
+                            hook_api::import_whitelist_rng.end())
+                    {
+                        // PASS, this is an RNG api (featureRNG)
+                    }
                     else
                     {
                         GUARDLOG(hook::log::IMPORT_ILLEGAL)
@@ -1262,8 +1269,12 @@ validateGuards(
                             hook_api::import_whitelist.find(api_name) !=
                                 hook_api::import_whitelist.end()
                             ? hook_api::import_whitelist.find(api_name)->second
-                            : hook_api::import_whitelist_1.find(api_name)
-                                  ->second;
+                            : hook_api::import_whitelist_1.find(api_name) !=
+                                    hook_api::import_whitelist_1.end()
+                                ? hook_api::import_whitelist_1.find(api_name)
+                                      ->second
+                                : hook_api::import_whitelist_rng.find(api_name)
+                                      ->second;
 
                         if (!first_signature)
                         {

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -674,7 +674,8 @@ Change::activateXahauGenesis()
                 loggerStream,
                 "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
                 (ctx_.view().rules().enabled(featureHooksUpdate1) ? 1 : 0) +
-                    (ctx_.view().rules().enabled(fix20250131) ? 2 : 0));
+                    (ctx_.view().rules().enabled(fix20250131) ? 2 : 0) +
+                    (ctx_.view().rules().enabled(featureRNG) ? 4 : 0));
 
             if (!result)
             {

--- a/src/ripple/app/tx/impl/SetHook.cpp
+++ b/src/ripple/app/tx/impl/SetHook.cpp
@@ -491,7 +491,8 @@ SetHook::validateHookSetEntry(SetHookCtx& ctx, STObject const& hookSetObj)
                     logger,
                     hsacc,
                     (ctx.rules.enabled(featureHooksUpdate1) ? 1 : 0) +
-                        (ctx.rules.enabled(fix20250131) ? 2 : 0));
+                        (ctx.rules.enabled(fix20250131) ? 2 : 0) +
+                        (ctx.rules.enabled(featureRNG) ? 4 : 0));
 
                 if (ctx.j.trace())
                 {

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1956,9 +1956,10 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
     if (!isTrusted && app_.config().RELAY_UNTRUSTED_PROPOSALS == -1)
         return;
 
-    // ttSHUFFLE is injected as part of featureRNG, based on the proposal
-    // signature
-    injectShuffleTxn(app_, makeSlice(set.signature()));
+    // ttSHUFFLE: only from UNL validators, initial proposals only - one sig per
+    // validator suffices, ~1950ms to propagate (ledgerMIN_CONSENSUS)
+    if (isTrusted && set.proposeseq() == 0)
+        injectShuffleTxn(app_, makeSlice(set.signature()));
 
     uint256 const proposeHash{set.currenttxhash()};
     uint256 const prevLedger{set.previousledger()};


### PR DESCRIPTION
## Summary

- Restrict ttSHUFFLE injection to initial proposals (proposeSeq=0) only
- Only inject ttSHUFFLE for trusted (UNL) validators
- Guard `dice`/`random` hook APIs behind featureRNG amendment

## Rationale

One signature per validator provides sufficient entropy. Initial proposals have ~1950ms (`ledgerMIN_CONSENSUS`) to propagate before the next consensus round begins, giving all nodes time to receive and inject the same shuffles.

By front-loading shuffle injection into the initial proposal window:
- The shuffle set stabilizes early in the consensus round
- Remaining rounds focus on reaching agreement on a stable transaction set
- Open ledger results become authoritative sooner
- Less churn interfering with avalanche convergence

## Results (7-node testnet)

| Mode | Transactions/ledger |
|------|---------------------|
| All proposals | 18-20 |
| Initial only | 14 (steady) |

The expected count is `n × 2` (one ttENTROPY + one ttSHUFFLE per validator).