### PR TITLE
fix: make subscription webhook delivery synchronous to prevent connection exhaustion

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1805,6 +1805,7 @@ rpcClient(
             }
 
             {
+                //@@start blocking-request
                 boost::asio::io_service isService;
                 RPCCall::fromNetwork(
                     isService,
@@ -1828,6 +1829,7 @@ rpcClient(
                     headers);
                 isService.run();  // This blocks until there are no more
                                   // outstanding async calls.
+                //@@end blocking-request
             }
             if (jvOutput.isMember("result"))
             {
@@ -1946,6 +1948,7 @@ fromNetwork(
     // HTTP call?
     auto constexpr RPC_NOTIFY = 30s;
 
+    //@@start async-request
     HTTPClient::request(
         bSSL,
         io_service,
@@ -1970,6 +1973,7 @@ fromNetwork(
             std::placeholders::_3,
             j),
         j);
+    //@@end async-request
 }
 
 }  // namespace RPCCall

--- a/src/ripple/net/impl/RPCSub.cpp
+++ b/src/ripple/net/impl/RPCSub.cpp
@@ -156,13 +156,19 @@ private:
             // Send outside of the lock.
             if (bSend)
             {
-                // XXX Might not need this in a try.
                 try
                 {
                     JLOG(j_.info()) << "RPCCall::fromNetwork: " << mIp;
 
+                    // Use a local io_service so the HTTP call blocks
+                    // until completion (or timeout). Without this,
+                    // fromNetwork() posts async ops to the app's
+                    // io_service and returns immediately, causing
+                    // unbounded concurrent connections that exhaust
+                    // file descriptors when endpoints are failing.
+                    boost::asio::io_service io_service;
                     RPCCall::fromNetwork(
-                        m_io_service,
+                        io_service,
                         mIp,
                         mPort,
                         mUsername,
@@ -173,11 +179,16 @@ private:
                         mSSL,
                         true,
                         logs_);
+                    io_service.run();
                 }
                 catch (const std::exception& e)
                 {
-                    JLOG(j_.info())
+                    JLOG(j_.warn())
                         << "RPCCall::fromNetwork exception: " << e.what();
+                }
+                catch (...)
+                {
+                    JLOG(j_.warn()) << "RPCCall::fromNetwork unknown exception";
                 }
             }
         } while (bSend);


### PR DESCRIPTION
## Summary

Fix subscription webhook (HTTP `url`) delivery choking when endpoints return
errors (500, 404, etc.), causing **all** subscribers to stop receiving events.

**Upstream issue:** [XRPLF/rippled#6341](https://github.com/XRPLF/rippled/issues/6341)

## Root Cause

`RPCSub::sendThread()` calls `RPCCall::fromNetwork()` passing the
application's main `io_service`. This posts async HTTP operations and
**returns immediately** — it never waits for the response:

📍 [`src/ripple/net/impl/RPCCall.cpp:1952-1975`](https://github.com/Xahau/xahaud/blob/12e1afb694826625d1979374b10a71c7fd90e784/src/ripple/net/impl/RPCCall.cpp#L1949-L1972)
```cpp
1952     HTTPClient::request(
1953         bSSL,
1954         io_service,
1955         strIp,
1956         iPort,
1957         std::bind(
1958             &RPCCallImp::onRequest,
1959             strMethod,
1960             jvParams,
1961             headers,
1962             strPath,
1963             std::placeholders::_1,
1964             std::placeholders::_2,
1965             j),
1966         RPC_REPLY_MAX_BYTES,
1967         RPC_NOTIFY,
1968         std::bind(
1969             &RPCCallImp::onResponse,
1970             callbackFuncP,
1971             std::placeholders::_1,
1972             std::placeholders::_2,
1973             std::placeholders::_3,
1974             j),
1975         j);
```

This means `sendThread()` fires off one async connection per queued event
at full speed, then exits. Under high throughput with a failing endpoint,
hundreds of concurrent connections accumulate (each held open for up to
30s), exhausting OS file descriptors and poisoning delivery for all
subscribers.

## Fix

Use a **local `io_service`** with `.run()` — the same pattern already used
by `rpcClient()` for CLI commands — so each HTTP delivery blocks until
completion or timeout.

This ensures:
- One delivery at a time, in order — no connection pileup
- Failed deliveries complete and release resources immediately
- The loop continues to the next event after any error
- `catch (...)` prevents `mSending` from getting stuck on unexpected exceptions
- Errors logged at `warn` level (was `info`)

## Test Plan

- [x] Build succeeds
- [x] Connected to Xahau mainnet with `x-testnet create-config --network mainnet --hooks-server`
- [x] Ran `x-testnet hooks-server --error 500:0.5` (50% HTTP 500 responses)
- [x] Confirmed events continue flowing through errors (11 deliveries: 5x 200, 6x 500)
- [ ] Review: consider adding backoff/limit for repeatedly failing endpoints (follow-up)