### PR TITLE
fix: ci build action and coverage workflow fixes

### DIFF
--- a/.github/actions/xahau-ga-build/action.yml
+++ b/.github/actions/xahau-ga-build/action.yml
@@ -53,10 +53,11 @@ inputs:
     required: false
     default: 'dev'
   stdlib:
-    description: 'C++ standard library to use'
+    description: 'C++ standard library to use (default = compiler default, e.g. GCC always uses libstdc++)'
     required: true
     type: choice
     options:
+      - default
       - libstdcxx
       - libcxx
   clang_gcc_toolchain:
@@ -99,11 +100,6 @@ runs:
         export CCACHE_CONFIGPATH="$HOME/.config/ccache/ccache.conf"
         echo "CCACHE_CONFIGPATH=$CCACHE_CONFIGPATH" >> $GITHUB_ENV
 
-        # Keep config separate from cache_dir so configs aren't swapped when CCACHE_DIR changes between steps
-        mkdir -p ~/.config/ccache
-        export CCACHE_CONFIGPATH="$HOME/.config/ccache/ccache.conf"
-        echo "CCACHE_CONFIGPATH=$CCACHE_CONFIGPATH" >> $GITHUB_ENV
-
         # Configure ccache settings AFTER cache restore (prevents stale cached config)
         ccache --set-config=max_size=${{ inputs.ccache_max_size }}
         ccache --set-config=hash_dir=${{ inputs.ccache_hash_dir }}
@@ -136,7 +132,6 @@ runs:
 
         if [ -n "${{ inputs.gcov }}" ]; then
           ln -sf /usr/bin/${{ inputs.gcov }} /usr/local/bin/gcov
-          export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
         fi
 
         # Create wrapper toolchain that overlays ccache on top of Conan's toolchain
@@ -225,7 +220,7 @@ runs:
           VERBOSE_FLAG="-- -v"
         fi
 
-        cmake --build . --config ${{ inputs.configuration }} --parallel $(nproc) ${VERBOSE_FLAG} --target ${{ inputs.cmake-target }}
+        cmake --build . --config ${{ inputs.configuration }} --parallel $(nproc) --target ${{ inputs.cmake-target }} ${VERBOSE_FLAG}
 
     - name: Show ccache statistics
       if: inputs.ccache_enabled == 'true'

--- a/.github/workflows/xahau-ga-nix.yml
+++ b/.github/workflows/xahau-ga-nix.yml
@@ -46,7 +46,7 @@ jobs:
                   "cc": "gcc-11",
                   "cxx": "g++-11",
                   "compiler_version": 11,
-                  "stdlib": "libstdcxx",
+                  "stdlib": "default",
                   "configuration": "Debug",
                   "job_type": "build"
               },
@@ -56,6 +56,7 @@ jobs:
                   "cc": "gcc-13",
                   "cxx": "g++-13",
                   "compiler_version": 13,
+                  "stdlib": "default",
                   "configuration": "Debug",
                   "job_type": "build"
               },
@@ -66,7 +67,7 @@ jobs:
                   "cxx": "g++-13",
                   "gcov": "gcov-13",
                   "compiler_version": 13,
-                  "stdlib": "libstdcxx",
+                  "stdlib": "default",
                   "configuration": "Debug",
                   "job_type": "coverage"
               },
@@ -377,6 +378,7 @@ jobs:
           compiler-id: ${{ matrix.compiler_id }}
           cache_version: ${{ env.CACHE_VERSION }}
           main_branch: ${{ env.MAIN_BRANCH_NAME }}
+          stdlib: ${{ matrix.stdlib }}
           cmake-args: '-Dcoverage=ON -Dcoverage_format=xml -DCODE_COVERAGE_VERBOSE=ON -DCMAKE_CXX_FLAGS="-O0" -DCMAKE_C_FLAGS="-O0"'
           cmake-target: 'coverage'
           ccache_max_size: '100G'


### PR DESCRIPTION
## Summary
- Move `--target` before `${VERBOSE_FLAG}` so `[ci-ga-cmake-verbose]` doesn't swallow the target argument (everything after `-- -v` gets passed to the native build tool, not CMake)
- Add `stdlib: default` option for GCC entries (GCC doesn't support the `-stdlib` flag, so `libstdcxx` was misleading)
- Pass `stdlib` explicitly to coverage build step (was missing despite being `required: true`)
- Remove dead `CMAKE_BUILD_PARALLEL_LEVEL` export (doesn't persist across run steps, and the build step already uses `--parallel $(nproc)`)
- Remove duplicate ccache config block (copy-paste artifact)

## Test plan
- [ ] CI coverage job passes with `stdlib: default`
- [ ] `[ci-ga-cmake-verbose]` still works correctly with `--target` reordered