### PR TITLE
Merge dev (c3e8039c5) into sync-2.4.0: fixXahauGenesisOwnerCount + docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ docs/html_doc
 # Xcode
 .DS_Store
 */build/*
+!/docs/build/
 *.pbxuser
 !default.pbxuser
 *.mode1v3

--- a/BUILD.md
+++ b/BUILD.md
@@ -10,7 +10,7 @@
 ## Branches
 
 For a stable release, choose the `master` branch or one of the [tagged
-releases](https://github.com/ripple/rippled/releases).
+releases](https://github.com/Xahau/xahaud/releases).
 
 ```
 git checkout master
@@ -36,7 +36,7 @@ git checkout develop
 - [Conan 2.x](https://conan.io/downloads)
 - [CMake 3.16](https://cmake.org/download/)
 
-`rippled` is written in the C++20 dialect and includes the `<concepts>` header.
+`xahaud` is written in the C++20 dialect and includes the `<concepts>` header.
 The [minimum compiler versions][2] required are:
 
 | Compiler    | Version |
@@ -46,11 +46,11 @@ The [minimum compiler versions][2] required are:
 | Apple Clang | 13.1.6  |
 | MSVC        | 19.23   |
 
-We don't recommend Windows for `rippled` production at this time. As of
-January 2023, Ubuntu has the highest level of quality assurance, testing,
+We don't recommend Windows for `xahaud` production at this time. As of
+November 2025, Ubuntu has the highest level of quality assurance, testing,
 and support.
 
-Windows developers should use Visual Studio 2019. `rippled` isn't
+Windows developers should use Visual Studio 2019. `xahaud` isn't
 compatible with [Boost](https://www.boost.org/) 1.78 or 1.79, and Conan
 can't build earlier Boost versions.
 
@@ -100,7 +100,7 @@ can't build earlier Boost versions.
    An easy way to do that is to run the shortcut "x64 Native Tools Command
    Prompt" for the version of Visual Studio that you have installed.
 
-   Windows developers must also build `rippled` and its dependencies for the x64
+   Windows developers must also build `xahaud` and its dependencies for the x64
    architecture.
 
    ```
@@ -218,13 +218,14 @@ can't build earlier Boost versions.
     cmake -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake ..
     ```
 
-    **Note:** You can pass build options for `rippled` in this step.
+    **Note:** You can pass build options for `xahaud` in this step.
 
-4. Build `rippled`.
+4. Build `xahaud`.
 
    For a single-configuration generator, it will build whatever configuration
    you passed for `CMAKE_BUILD_TYPE`. For a multi-configuration generator,
    you must pass the option `--config` to select the build configuration. 
+   The output file is currently named 'rippled'.
 
    Single-config generators:
 
@@ -239,7 +240,7 @@ can't build earlier Boost versions.
    cmake --build . --config Debug
    ```
 
-5. Test rippled.
+5. Test xahaud.
 
    Single-config generators:
 
@@ -254,7 +255,7 @@ can't build earlier Boost versions.
    ./Debug/rippled --unittest
    ```
 
-   The location of `rippled` in your build directory depends on your CMake
+   The location of `xahaud` in your build directory depends on your CMake
    generator. Pass `--help` to see the rest of the command line options.
 
 

--- a/cfg/xahaud-example.cfg
+++ b/cfg/xahaud-example.cfg
@@ -1710,26 +1710,14 @@ secure_gateway = 127.0.0.1
 #    when the node has approximately two times the "online_delete" value of
 #    ledgers. No external administrative command is required to initiate
 #    deletion.
+[ledger_history]
+256
+
 [node_db]
 type=NuDB
 path=/opt/xahaud/db/nudb
-online_delete=512
+online_delete=256
 advisory_delete=0
-
-# This is the persistent datastore for shards. It is important for the health
-# of the Xahau Network that xahaud operators shard as much as practical.
-# NuDB requires SSD storage. Helpful information can be found at
-# https://xrpl.org/history-sharding.html
-#[shard_db]
-#path=/opt/xahaud/db/shards/nudb
-#max_historical_shards=50
-#
-# This optional section can be configured with a list
-# of paths to use for storing historical shards. Each
-# path must correspond to a unique filesystem.
-#[historical_shard_paths]
-#/path/1
-#/path/2
 
 [database_path]
 /opt/xahaud/db
@@ -1754,6 +1742,11 @@ time.windows.com
 time.apple.com
 time.nist.gov
 pool.ntp.org
+
+# Use the following [ips] section for the main network:
+[ips]
+bacab.alloy.ee 21337
+hubs.xahau.as16089.net 21337
 
 # To use the Xahau Test Network
 # (see https://xahau.network/docs/infrastructure/installing-xahaud),
@@ -1781,6 +1774,13 @@ validators-xahau.txt
 # set to ssl_verify to 0.
 [ssl_verify]
 1
+
+# Define which network xahaud is connecting to
+# 21337 for the Main Xahau Network
+# 21338 for the Test Xahau Network
+[network_id]
+21337
+# 21338
 
 
 # To run in Reporting Mode, uncomment this section and fill in the appropriate

--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -11,11 +11,11 @@ platforms: Linux, macOS, or Windows.
 Package ecosystems vary across Linux distributions,
 so there is no one set of instructions that will work for every Linux user.
 These instructions are written for Ubuntu 22.04.
-They are largely copied from the [script][1] used to configure our Docker
+They are largely copied from the [script][1] used to configure a Docker
 container for continuous integration.
 That script handles many more responsibilities.
 These instructions are just the bare minimum to build one configuration of
-rippled.
+xahaud.
 You can check that codebase for other Linux distributions and versions.
 If you cannot find yours there,
 then we hope that these instructions can at least guide you in the right

--- a/docs/build/install.md
+++ b/docs/build/install.md
@@ -1,159 +1,30 @@
-This document contains instructions for installing rippled.
-The APT package manager is common on Debian-based Linux distributions like
-Ubuntu,
-while the YUM package manager is common on Red Hat-based Linux distributions
-like CentOS.
-Installing from source is an option for all platforms,
-and the only supported option for installing custom builds.
+Comprehensive instructions for installing and running xahaud are available on the [https://Xahau.Network](https://xahau.network/docs/infrastructure/installing-xahaud) documentation website.
 
+## Create the Runtime Environment
+xahaud can be [built from source](../../BUILD.md) or installed using the binary files available from [https://build.xahau.tech](https://build.xahau.tech/). After obtaining a working xahaud binary, users will need to provide a suitable runtime environment. The following setup can be used for Linux or Docker environments.
 
-## From source
+1. Create or download two configuration files: the main xahaud.cfg configuration file and a second validators-xahau.txt file defining which validators or UNL list publishers are trusted. The default location for these files in this xahaud repository is `cfg/`.
+2. Provide a directory structure that is congruent with the contents of xahaud.cfg. This will include a location for logfiles, such as `/var/log/xahaud/`, as well as database files, `/opt/xahaud/db/`. Configuration files are, by default, sourced from `/etc/xahaud/`. It is possible to provide a symbolic link, if users wish to store configuration files elsewhere.
+3. If desired, created a xahaud user and group, and change ownership of the binary and directories. Servers used for validating nodes should use the most restrictive permissions possible for `xahaud.cfg`, as the validation token is stored therein.
+4. If desired, create a systemd service file: `/etc/systemd/system/xahaud.service`, enabling xahaud to run as a daemon. Alternately, run: `/path/to/binary/xahaud --conf=/path/to/xahaud.cfg`.
 
-From a source build, you can install rippled and libxrpl using CMake's
-`--install` mode:
-
+## Example systemd Service File
 ```
-cmake --install . --prefix /opt/local
+[Unit]
+Description=Xahaud Daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/path/to/xahaud --silent --conf /path/to/xahaud.cfg
+Restart=on-failure
+User=xahaud
+Group=xahaud
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
 ```
 
-The default [prefix][1] is typically `/usr/local` on Linux and macOS and
-`C:/Program Files/rippled` on Windows.
-
-[1]: https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html
-
-
-## With the APT package manager
-
-1. Update repositories:
-
-        sudo apt update -y
-
-2. Install utilities:
-
-        sudo apt install -y apt-transport-https ca-certificates wget gnupg
-
-3. Add Ripple's package-signing GPG key to your list of trusted keys:
-
-        sudo mkdir /usr/local/share/keyrings/
-        wget -q -O - "https://repos.ripple.com/repos/api/gpg/key/public" | gpg --dearmor > ripple-key.gpg
-        sudo mv ripple-key.gpg /usr/local/share/keyrings
-
-
-4. Check the fingerprint of the newly-added key:
-
-        gpg /usr/local/share/keyrings/ripple-key.gpg
-
-    The output should include an entry for Ripple such as the following:
-
-        gpg: WARNING: no command supplied.  Trying to guess what you mean ...
-        pub   rsa3072 2019-02-14 [SC] [expires: 2026-02-17]
-            C0010EC205B35A3310DC90DE395F97FFCCAFD9A2
-        uid           TechOps Team at Ripple <techops+rippled@ripple.com>
-        sub   rsa3072 2019-02-14 [E] [expires: 2026-02-17]
-
-
-    In particular, make sure that the fingerprint matches. (In the above example, the fingerprint is on the third line, starting with `C001`.)
-
-4. Add the appropriate Ripple repository for your operating system version:
-
-        echo "deb [signed-by=/usr/local/share/keyrings/ripple-key.gpg] https://repos.ripple.com/repos/rippled-deb focal stable" | \
-            sudo tee -a /etc/apt/sources.list.d/ripple.list
-
-    The above example is appropriate for **Ubuntu 20.04 Focal Fossa**. For other operating systems, replace the word `focal` with one of the following:
-
-    - `jammy` for **Ubuntu 22.04 Jammy Jellyfish**
-    - `bionic` for **Ubuntu 18.04 Bionic Beaver**
-    - `bullseye` for **Debian 11 Bullseye**
-    - `buster` for **Debian 10 Buster**
-
-    If you want access to development or pre-release versions of `rippled`, use one of the following instead of `stable`:
-
-    - `unstable` - Pre-release builds ([`release` branch](https://github.com/ripple/rippled/tree/release))
-    - `nightly` - Experimental/development builds ([`develop` branch](https://github.com/ripple/rippled/tree/develop))
-
-    **Warning:** Unstable and nightly builds may be broken at any time. Do not use these builds for production servers.
-
-5. Fetch the Ripple repository.
-
-        sudo apt -y update
-
-6. Install the `rippled` software package:
-
-        sudo apt -y install rippled
-
-7. Check the status of the `rippled` service:
-
-        systemctl status rippled.service
-
-    The `rippled` service should start automatically. If not, you can start it manually:
-
-        sudo systemctl start rippled.service
-
-8. Optional: allow `rippled` to bind to privileged ports.
-
-    This allows you to serve incoming API requests on port 80 or 443. (If you want to do so, you must also update the config file's port settings.)
-
-        sudo setcap 'cap_net_bind_service=+ep' /opt/ripple/bin/rippled
-
-
-## With the YUM package manager
-
-1. Install the Ripple RPM repository:
-
-    Choose the appropriate RPM repository for the stability of releases you want:
-
-    - `stable` for the latest production release (`master` branch)
-    - `unstable` for pre-release builds (`release` branch)
-    - `nightly` for experimental/development builds (`develop` branch)
-
-    *Stable*
-
-        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
-        [ripple-stable]
-        name=XRP Ledger Packages
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=1
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/stable/
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/stable/repodata/repomd.xml.key
-        REPOFILE
-
-    *Unstable*
-
-        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
-        [ripple-unstable]
-        name=XRP Ledger Packages
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=1
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/unstable/
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/unstable/repodata/repomd.xml.key
-        REPOFILE
-
-    *Nightly*
-
-        cat << REPOFILE | sudo tee /etc/yum.repos.d/ripple.repo
-        [ripple-nightly]
-        name=XRP Ledger Packages
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=1
-        baseurl=https://repos.ripple.com/repos/rippled-rpm/nightly/
-        gpgkey=https://repos.ripple.com/repos/rippled-rpm/nightly/repodata/repomd.xml.key
-        REPOFILE
-
-2. Fetch the latest repo updates:
-
-        sudo yum -y update
-
-3. Install the new `rippled` package:
-
-        sudo yum install -y rippled
-
-4. Configure the `rippled` service to start on boot:
-
-        sudo systemctl enable rippled.service
-
-5. Start the `rippled` service:
-
-        sudo systemctl start rippled.service
+After the systemd service file is installed, it must be loaded with: `systemctl daemon-reload`. xahaud can then be enabled: `systemctl enable --now xahaud`.

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -25,6 +25,7 @@
 #include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/tx/impl/Change.h>
+#include <ripple/app/tx/impl/SetHook.h>
 #include <ripple/app/tx/impl/SetSignerList.h>
 #include <ripple/app/tx/impl/XahauGenesis.h>
 #include <ripple/basics/Log.h>
@@ -584,10 +585,6 @@ Change::activateXahauGenesis()
         SetSignerList::removeFromLedger(ctx_.app, sb, accid, j_);
 
     // Step 4: install genesis hooks
-    sle->setFieldU32(
-        sfOwnerCount, sle->getFieldU32(sfOwnerCount) + genesis_hooks.size());
-    sb.update(sle);
-
     if (sb.exists(keylet::hook(accid)))
     {
         JLOG(j_.warn()) << "featureXahauGenesis genesis account already has "
@@ -598,6 +595,7 @@ Change::activateXahauGenesis()
     {
         ripple::STArray hooks{sfHooks, static_cast<int>(genesis_hooks.size())};
         int hookCount = 0;
+        uint32_t hookReserve = 0;
 
         for (auto const& [hookOn, wasmBytes, params] : genesis_hooks)
         {
@@ -703,7 +701,13 @@ Change::activateXahauGenesis()
             }
 
             hooks.push_back(hookObj);
+
+            hookReserve += SetHook::computeHookReserve(hookObj);
         }
+
+        sle->setFieldU32(
+            sfOwnerCount, sle->getFieldU32(sfOwnerCount) + hookReserve);
+        sb.update(sle);
 
         auto sle = std::make_shared<SLE>(keylet::hook(accid));
         sle->setFieldArray(sfHooks, hooks);
@@ -745,6 +749,8 @@ Change::activateXahauGenesis()
         ripple::STArray hooks{sfHooks, 1};
         STObject hookObj{sfHook};
         hookObj.setFieldH256(sfHookHash, governHash);
+
+        uint32_t hookReserve = 0;
         // parameters
         {
             std::vector<STObject> vec;
@@ -760,6 +766,7 @@ Change::activateXahauGenesis()
                 sfHookParameters, STArray(vec, sfHookParameters));
         }
 
+        hookReserve += SetHook::computeHookReserve(hookObj);
         hooks.push_back(hookObj);
 
         auto sle = std::make_shared<SLE>(hookKL);
@@ -786,7 +793,8 @@ Change::activateXahauGenesis()
 
             sle->setAccountID(sfRegularKey, noAccount());
             sle->setFieldU32(sfFlags, lsfDisableMaster);
-            sle->setFieldU32(sfOwnerCount, sle->getFieldU32(sfOwnerCount) + 1);
+            sle->setFieldU32(
+                sfOwnerCount, sle->getFieldU32(sfOwnerCount) + hookReserve);
             sb.update(sle);
         }
     }

--- a/src/ripple/app/tx/impl/SetHook.cpp
+++ b/src/ripple/app/tx/impl/SetHook.cpp
@@ -1221,6 +1221,29 @@ updateHookParameters(
     return tesSUCCESS;
 }
 
+/**
+ * Compute the reserve required for a hook object.
+ * @param hookObj The hook object to compute the reserve for.(not Transaction
+ *        field, use the Hook object inside the ltHook object.)
+ * @return The reserve required for the hook object.
+ */
+uint32_t
+SetHook::computeHookReserve(STObject const& hookObj)
+{
+    if (!hookObj.isFieldPresent(sfHookHash))
+        return 0;
+
+    int reserve{1};
+
+    if (hookObj.isFieldPresent(sfHookParameters))
+        reserve += hookObj.getFieldArray(sfHookParameters).size();
+
+    if (hookObj.isFieldPresent(sfHookGrants))
+        reserve += hookObj.getFieldArray(sfHookGrants).size();
+
+    return reserve;
+};
+
 struct KeyletComparator
 {
     bool
@@ -1972,28 +1995,14 @@ SetHook::setHook()
         int oldHookReserve = 0;
         int newHookReserve = 0;
 
-        auto const computeHookReserve = [](STObject const& hookObj) -> int {
-            if (!hookObj.isFieldPresent(sfHookHash))
-                return 0;
-
-            int reserve{1};
-
-            if (hookObj.isFieldPresent(sfHookParameters))
-                reserve += hookObj.getFieldArray(sfHookParameters).size();
-
-            if (hookObj.isFieldPresent(sfHookGrants))
-                reserve += hookObj.getFieldArray(sfHookGrants).size();
-
-            return reserve;
-        };
-
         for (int i = 0; i < hook::maxHookChainLength(); ++i)
         {
             if (oldHooks && i < oldHookCount)
-                oldHookReserve += computeHookReserve(((*oldHooks).get())[i]);
+                oldHookReserve +=
+                    SetHook::computeHookReserve(((*oldHooks).get())[i]);
 
             if (i < newHooks.size())
-                newHookReserve += computeHookReserve(newHooks[i]);
+                newHookReserve += SetHook::computeHookReserve(newHooks[i]);
         }
 
         reserveDelta = newHookReserve - oldHookReserve;

--- a/src/ripple/app/tx/impl/SetHook.h
+++ b/src/ripple/app/tx/impl/SetHook.h
@@ -91,6 +91,9 @@ public:
     static HookSetValidation
     validateHookSetEntry(SetHookCtx& ctx, STObject const& hookSetObj);
 
+    static uint32_t
+    computeHookReserve(STObject const& hookObj);
+
 private:
     TER
     setHook();

--- a/src/test/app/XahauGenesis_test.cpp
+++ b/src/test/app/XahauGenesis_test.cpp
@@ -139,7 +139,9 @@ struct XahauGenesis_test : public beast::unit_test::suite
             false,  // means the calling test already burned some of the genesis
         bool skipTests = false,
         bool const testFlag = false,
-        bool const badNetID = false)
+        bool const badNetID = false,
+        uint32_t const expectedOwnerCount =
+            10 /** testFlag ? 10 : 14 (default) */)
     {
         using namespace jtx;
 
@@ -247,7 +249,10 @@ struct XahauGenesis_test : public beast::unit_test::suite
         BEAST_EXPECT(
             genesisAccRoot->getFieldAmount(sfBalance) ==
             XahauGenesis::GenesisAmount);
-        BEAST_EXPECT(genesisAccRoot->getFieldU32(sfOwnerCount) == 2);
+        BEAST_EXPECT(
+            genesisAccRoot->getFieldU32(sfOwnerCount) == !testFlag
+                ? expectedOwnerCount
+                : 14);
 
         // ensure the definitions are correctly set
         {
@@ -583,7 +588,14 @@ struct XahauGenesis_test : public beast::unit_test::suite
                 toBase58(t), membersStr);
         }
 
-        activate(__LINE__, env, true, false, true);
+        activate(
+            __LINE__,
+            env,
+            true,
+            false,
+            true,
+            {},
+            3 /* IRR,IRD,IMC */ + members.size() + tables.size());
 
         env.close();
         env.close();
@@ -2235,12 +2247,17 @@ struct XahauGenesis_test : public beast::unit_test::suite
             BEAST_EXPECT(!!hookLE);
             uint256 const ns = beast::zero;
             uint8_t mc = 0;
+            uint8_t paramsCount = 0;
+
             if (hookLE)
             {
                 auto const hooksArray = hookLE->getFieldArray(sfHooks);
                 BEAST_EXPECT(
                     hooksArray.size() == 1 &&
                     hooksArray[0].getFieldH256(sfHookHash) == governHookHash);
+
+                paramsCount =
+                    hooksArray[0].getFieldArray(sfHookParameters).size();
 
                 for (Account const* m : members)
                 {
@@ -2308,7 +2325,9 @@ struct XahauGenesis_test : public beast::unit_test::suite
             BEAST_EXPECT(!!root);
             if (root)
             {
-                BEAST_EXPECT(root->getFieldU32(sfOwnerCount) == mc * 2 + 2);
+                BEAST_EXPECT(
+                    root->getFieldU32(sfOwnerCount) ==
+                    mc * 2 + 2 + paramsCount);
                 BEAST_EXPECT(root->getFieldU32(sfFlags) & lsfDisableMaster);
                 BEAST_EXPECT(root->getAccountID(sfRegularKey) == noAccount());
             }


### PR DESCRIPTION
## Summary

Merges `dev` (top commit `c3e8039c5`) into `sync-2.4.0`, bringing in 2 commits:

- **PR #666 `fixXahauGenesisOwnerCount`** — Bug fix: replaces hardcoded owner count increments with `SetHook::computeHookReserve()` in `Change::activateXahauGenesis()`. Promotes the `computeHookReserve` lambda to a public static method on `SetHook`.
- **PR #655 `Update Build Instructions and Example Configuration File`** — Docs: renames `rippled` → `xahaud` in BUILD.md, adds `[ips]` mainnet peers and `[network_id]` to `cfg/xahaud-example.cfg`.

## Conflict Resolution

3 conflicts resolved:
- `src/xrpld/app/tx/detail/Change.cpp` — Include path rename (dev uses old `src/ripple/` paths). Took ours (new `xrpld/xrpl` paths), added new `#include <xrpld/app/tx/detail/SetHook.h>` from dev.
- `BUILD.md` — Took dev's version (xahaud naming).
- `cfg/xahaud-example.cfg` — Took dev's version (mainnet peers + network_id).

## Known Issue

- Ternary precedence bug in `XahauGenesis_test.cpp:253` from PR #666 — tracked in #686. Should be fixed in a PR to `dev`.

## Merge Instructions

Please merge using a **merge commit** (not squash) to preserve git ancestry for future dev syncs.