### PR TITLE
fix: remove .mise.toml that conflicts with CI mise-action

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,0 @@
-[tools]
-clang-format = "18"


### PR DESCRIPTION
## Summary

Removes `.mise.toml` from the repo. It declares `clang-format = "18"` which causes the macOS CI build to fail.

## Problem

The `jdx/mise-action` writes its own `mise.toml` (no dot) with build tools (cmake, python, conan, etc). Mise picks up **both** files and tries to install clang-format via the `mise-llvm` plugin, which attempts to build from source using cmake — but cmake isn't available yet because mise is still installing it. This creates a circular dependency that crashes the CI step.

## Fix

Remove `.mise.toml` from the repo. Developers who want clang-format managed by mise locally can add their own `.mise.toml` and exclude it via `.git/info/exclude`.