### PR TITLE
fix: use OIDC token for Codecov uploads from fork PRs

### DIFF
--- a/.github/workflows/xahau-ga-nix.yml
+++ b/.github/workflows/xahau-ga-nix.yml
@@ -335,7 +335,7 @@ jobs:
           # Install gcovr for coverage jobs
           if [ "${{ matrix.job_type }}" = "coverage" ]; then
             pipx install "gcovr>=7,<9"
-            apt-get install -y lcov
+            apt-get install -y curl lcov
           fi
 
       - name: Check environment

--- a/.github/workflows/xahau-ga-nix.yml
+++ b/.github/workflows/xahau-ga-nix.yml
@@ -230,6 +230,9 @@ jobs:
   build:
     needs: matrix-setup
     runs-on: ${{ fromJSON(matrix.runs_on) }}
+    permissions:
+      id-token: write
+      contents: read
     container:
       image: ubuntu:24.04
       volumes:
@@ -454,13 +457,13 @@ jobs:
         if: matrix.job_type == 'coverage'
         uses: wandalen/wretry.action/main@v3
         with:
-          action: codecov/codecov-action@v4.3.0
+          action: codecov/codecov-action@v5
           with: |
             files: coverage.xml
             fail_ci_if_error: true
             disable_search: true
             verbose: true
             plugin: noop
-            token: ${{ secrets.CODECOV_TOKEN }}
+            use_oidc: true
           attempt_limit: 5
           attempt_delay: 210000 # in milliseconds

--- a/.github/workflows/xahau-ga-nix.yml
+++ b/.github/workflows/xahau-ga-nix.yml
@@ -464,7 +464,7 @@ jobs:
             fail_ci_if_error: true
             disable_search: true
             verbose: true
-            plugin: noop
+            plugins: noop
             use_oidc: true
           attempt_limit: 5
           attempt_delay: 210000 # in milliseconds

--- a/.github/workflows/xahau-ga-nix.yml
+++ b/.github/workflows/xahau-ga-nix.yml
@@ -456,15 +456,11 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.job_type == 'coverage'
-        uses: wandalen/wretry.action/main@v3
+        uses: codecov/codecov-action@v5
         with:
-          action: codecov/codecov-action@v5
-          with: |
-            files: coverage.xml
-            fail_ci_if_error: true
-            disable_search: true
-            verbose: true
-            plugins: noop
-            use_oidc: true
-          attempt_limit: 5
-          attempt_delay: 210000 # in milliseconds
+          files: coverage.xml
+          fail_ci_if_error: true
+          disable_search: true
+          verbose: true
+          plugins: noop
+          use_oidc: true

--- a/.github/workflows/xahau-ga-nix.yml
+++ b/.github/workflows/xahau-ga-nix.yml
@@ -410,7 +410,8 @@ jobs:
           cache_version: ${{ env.CACHE_VERSION }}
           main_branch: ${{ env.MAIN_BRANCH_NAME }}
           stdlib: ${{ matrix.stdlib }}
-          cmake-args: '-Dcoverage=ON -Dcoverage_format=xml -DCODE_COVERAGE_VERBOSE=ON -DCMAKE_CXX_FLAGS="-O0" -DCMAKE_C_FLAGS="-O0"'
+          # Coverage builds are slower due to instrumentation; use fewer parallel jobs to avoid flakiness
+          cmake-args: '-Dcoverage=ON -Dcoverage_format=xml -Dcoverage_test_parallelism=$(($(nproc)/2)) -DCODE_COVERAGE_VERBOSE=ON -DCMAKE_CXX_FLAGS="-O0" -DCMAKE_C_FLAGS="-O0"'
           cmake-target: 'coverage'
           ccache_max_size: '100G'
 


### PR DESCRIPTION
## High Level Overview of Change                                                                                                                                                                                                                           
                                                                 
Fix coverage upload failures on pull requests from forked repositories.
GitHub does not pass repository secrets to fork PR workflows, causing `secrets.CODECOV_TOKEN` to be empty and Codecov to reject uploads with HTTP 400 "Token required because branch is protected".

  ### Context of Change

When a fork PR triggered the coverage job, `secrets.CODECOV_TOKEN` was unavailable, so Codecov's API rejected the upload. Switching to GitHub OIDC authentication removes the dependency on a static secret: the Fix coverage upload failures on pull requests from forked repositories.
GitHub does not pass repository secrets to fork PR workflows, causing `secrets.CODECOV_TOKEN` to be empty and Codecov to reject uploads with HTTP 400 "Token required because branch is protected".

### Context of Change

When a fork PR triggered the coverage job, `secrets.CODECOV_TOKEN` was unavailable, so Codecov's API rejected the upload. Switching to GitHub OIDC authentication removes the dependency on a static secret: the runner requests an ID token from GitHub's OIDC provider, and Codecov exchanges it for its own credential. This works for both fork and non-fork PRs.

Changes:
- Add `permissions: id-token: write` to the `build` job
- Upgrade `codecov/codecov-action` v4.3.0 → v5
- Replace `token: ${{ secrets.CODECOV_TOKEN }}` with `use_oidc: true`

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

