### PR TITLE
Add per-account signing policy for nested multi-sign

### DIFF
--- a/hook/sfcodes.h
+++ b/hook/sfcodes.h
@@ -72,6 +72,7 @@
 #define sfLockCount ((2U << 16U) + 49U)
 #define sfFirstNFTokenSequence ((2U << 16U) + 50U)
 #define sfOracleDocumentID ((2U << 16U) + 51U)
+#define sfSigningPolicy ((2U << 16U) + 52U)
 #define sfStartTime ((2U << 16U) + 93U)
 #define sfRepeatCount ((2U << 16U) + 94U)
 #define sfDelaySeconds ((2U << 16U) + 95U)

--- a/include/xrpl/protocol/SigningPolicy.h
+++ b/include/xrpl/protocol/SigningPolicy.h
@@ -1,0 +1,106 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2026 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_SIGNINGPOLICY_H_INCLUDED
+#define RIPPLE_PROTOCOL_SIGNINGPOLICY_H_INCLUDED
+
+#include <cstdint>
+
+namespace ripple {
+
+/** Per-account opt-in policy bits stored in the optional sfSigningPolicy
+    field on AccountRoot. Governs participation in nested multi-sign.
+
+    Two-sided consent model:
+    - acceptsBelow*: what proofs an account accepts when being signed for
+                     (the account whose SignerList is being evaluated).
+    - permitsSelf* : what an account permits when delegated to as a signer
+                     (the account named in another account's SignerList).
+
+    Effective policy at each tree edge (parent A -> signer B) is the
+    intersection of inherited path cap, A.acceptsBelow*, and B.permitsSelf*.
+    Authority can only narrow as the proof descends.
+
+    The meta toggle pfApplyPoliciesAllMultiSign lives only on the txn
+    account; when set, the policy intersection applies even at depth 1
+    (flat multi-sign). When clear (default), depth 1 follows legacy
+    flat-multisign behavior unconditionally.
+ */
+enum SigningPolicyFlags : std::uint32_t {
+    pfApplyPoliciesAllMultiSign = 0x00000001,
+
+    pfAcceptsBelowNested = 0x00000010,
+    pfAcceptsBelowCycleAdjustedQuorum = 0x00000020,
+    pfAcceptsBelowDisabledMaster = 0x00000040,
+
+    pfPermitsSelfNested = 0x00000100,
+    pfPermitsSelfCycleAdjustedQuorum = 0x00000200,
+    pfPermitsSelfDisabledMaster = 0x00000400,
+};
+
+namespace sigpol {
+
+constexpr std::uint32_t acceptsBelowMask = pfAcceptsBelowNested |
+    pfAcceptsBelowCycleAdjustedQuorum | pfAcceptsBelowDisabledMaster;
+
+constexpr std::uint32_t permitsSelfMask = pfPermitsSelfNested |
+    pfPermitsSelfCycleAdjustedQuorum | pfPermitsSelfDisabledMaster;
+
+/** Capability axes, expressed in the permitsSelf bit positions so a single
+    uint32 can carry the path's effective capabilities. The acceptsBelow
+    bits (0x10..0x40) at parents are translated to these axes
+    (0x100..0x400) by left-shifting 4 bits.
+ */
+enum CapabilityAxis : std::uint32_t {
+    capNested = pfPermitsSelfNested,
+    capCycleAdjustedQuorum = pfPermitsSelfCycleAdjustedQuorum,
+    capDisabledMaster = pfPermitsSelfDisabledMaster,
+};
+
+constexpr std::uint32_t capAllMask =
+    capNested | capCycleAdjustedQuorum | capDisabledMaster;
+
+/** Translate a parent account's acceptsBelow bits into the common
+    capability axes (permitsSelf bit positions) so they can be intersected
+    with a child's permitsSelf bits.
+ */
+constexpr std::uint32_t
+acceptsBelowToCapabilities(std::uint32_t policy)
+{
+    return (policy & acceptsBelowMask) << 4;
+}
+
+/** Extract the permitsSelf bits as capability axes (identity). */
+constexpr std::uint32_t
+permitsSelfToCapabilities(std::uint32_t policy)
+{
+    return policy & permitsSelfMask;
+}
+
+constexpr bool
+hasCapability(std::uint32_t cap, CapabilityAxis axis)
+{
+    return (cap & axis) != 0;
+}
+
+}  // namespace sigpol
+
+}  // namespace ripple
+
+#endif

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -262,6 +262,7 @@ LEDGER_ENTRY(ltACCOUNT_ROOT, 0x0061, AccountRoot, account, ({
     {sfHookStateScale,       soeOPTIONAL},
     {sfCron,                 soeOPTIONAL},
     {sfAMMID,                soeOPTIONAL},
+    {sfSigningPolicy,        soeOPTIONAL},
 }))
 
 /** A ledger object which contains a list of object identifiers.

--- a/include/xrpl/protocol/detail/sfields.macro
+++ b/include/xrpl/protocol/detail/sfields.macro
@@ -114,6 +114,7 @@ TYPED_SFIELD(sfVoteWeight,               UINT32,    48)
 TYPED_SFIELD(sfLockCount,                UINT32,    49)
 TYPED_SFIELD(sfFirstNFTokenSequence,     UINT32,    50)
 TYPED_SFIELD(sfOracleDocumentID,         UINT32,    51)
+TYPED_SFIELD(sfSigningPolicy,            UINT32,    52)
 
 TYPED_SFIELD(sfStartTime,                UINT32,    93)
 TYPED_SFIELD(sfRepeatCount,              UINT32,    94)

--- a/include/xrpl/protocol/detail/transactions.macro
+++ b/include/xrpl/protocol/detail/transactions.macro
@@ -74,6 +74,7 @@ TRANSACTION(ttACCOUNT_SET, 3, AccountSet, ({
     {sfTickSize, soeOPTIONAL},
     {sfNFTokenMinter, soeOPTIONAL},
     {sfHookStateScale, soeOPTIONAL},
+    {sfSigningPolicy, soeOPTIONAL},
 }))
 
 /** This transaction type cancels an existing escrow. */

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -123,6 +123,7 @@ JSS(Signers);                  // field.
 JSS(HookStateData);            // field.
 JSS(HookStateKey);             // field.
 JSS(EmitDetails);              // field.
+JSS(SigningPolicy);            // field.
 JSS(SigningPubKey);            // field.
 JSS(Subject);                  // in: Credential transactions
 JSS(TakerGets);                // field.

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -18,6 +18,7 @@
 #include <test/jtx.h>
 #include <xrpld/core/ConfigSections.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/SigningPolicy.h>
 #include <xrpl/protocol/jss.h>
 
 namespace ripple {
@@ -1736,6 +1737,43 @@ public:
             acc12);
         env.close();
 
+        // Default opt-in helper for nested-multisign scenarios. Sets nested
+        // + cycle bits in both directions. The existing nested tests were
+        // written assuming nested + cycle handling are available; they were
+        // NOT written assuming master-disabled-in-nested-context is
+        // available -- that's a new capability covered by test_signingPolicy
+        // and intentionally NOT enabled here. Likewise no
+        // pfApplyPoliciesAllMultiSign (depth-1 signers retain legacy
+        // flat behavior).
+        constexpr std::uint32_t kNestedWithCycling = pfAcceptsBelowNested |
+            pfAcceptsBelowCycleAdjustedQuorum | pfPermitsSelfNested |
+            pfPermitsSelfCycleAdjustedQuorum;
+        auto optInNestedWithCycling = [&env](auto const&... accts) {
+            (env(signing_policy(accts, kNestedWithCycling)), ...);
+            env.close();
+        };
+
+        if (features[featureNestedMultiSign])
+        {
+            optInNestedWithCycling(
+                alice,
+                becky,
+                cheri,
+                daria,
+                edgar,
+                fiona,
+                grace,
+                henry,
+                f1,
+                f2,
+                f3,
+                phase,
+                jinni,
+                acc10,
+                acc11,
+                acc12);
+        }
+
         auto const baseFee = env.current()->fees().base;
 
         if (!features[featureNestedMultiSign])
@@ -2167,6 +2205,7 @@ public:
 
             env.fund(XRP(1000), onyx, nova, ruby);
             env.close();
+            optInNestedWithCycling(onyx, nova, ruby);
 
             // Set up signer lists FIRST (before disabling master keys)
             // ruby: {jade, nova} with quorum 2
@@ -2225,6 +2264,7 @@ public:
 
             env.fund(XRP(1000), alpha, beta, gamma);
             env.close();
+            optInNestedWithCycling(alpha, beta, gamma);
 
             // Set up pure cycle signer lists FIRST
             env(signers(alpha, 1, {{beta, 1}}));
@@ -2429,6 +2469,7 @@ public:
 
             env.fund(XRP(1000), omega, sigma);
             env.close();
+            optInNestedWithCycling(omega, sigma);
 
             // Reset alice and becky signer lists
             env(signers(alice, jtx::none));
@@ -2634,6 +2675,16 @@ public:
         Account const fiona{"fiona", KeyType::ed25519};
         env.fund(XRP(1000), alice, becky, cheri, daria, edgar, fiona);
         env.close();
+
+        // Default opt-in for nested + cycle bits (see test_nestedMultiSign).
+        constexpr std::uint32_t kNestedWithCycling = pfAcceptsBelowNested |
+            pfAcceptsBelowCycleAdjustedQuorum | pfPermitsSelfNested |
+            pfPermitsSelfCycleAdjustedQuorum;
+        auto optInNestedWithCycling = [&env](auto const&... accts) {
+            (env(signing_policy(accts, kNestedWithCycling)), ...);
+            env.close();
+        };
+        optInNestedWithCycling(alice, becky, cheri, daria, edgar, fiona);
 
         auto const baseFee = env.current()->fees().base;
 
@@ -3021,6 +3072,7 @@ public:
             Account const wren{"wren", KeyType::ed25519};
             env.fund(XRP(1000), zara, yara, xena, wren);
             env.close();
+            optInNestedWithCycling(zara, yara, xena, wren);
 
             env(signers(zara, 1, {{yara, 1}}));
             env(signers(yara, 2, {{xena, 1}, {wren, 1}}));
@@ -3145,6 +3197,401 @@ public:
                     jrr[jss::result][jss::error_message] ==
                     "Signers array may only contain valid Signer entries.");
             }
+        }
+    }
+
+    void
+    test_signingPolicy(FeatureBitset features)
+    {
+        // Per-account signing policy gates new nested-multisign behaviors.
+        // The matrix covers:
+        //  (a) pre-amendment: setting sfSigningPolicy must fail temDISABLED
+        //  (b) post-amendment, default policy (zero):
+        //      flat multisign still works, nested attempt fails for lack
+        //      of consent on either side
+        //  (c) one-sided opt-in (parent accepts, child doesn't, or vice
+        //      versa): nested still fails
+        //  (d) two-sided opt-in: nested succeeds
+        //  (e) cycle requires cycle-handling consent: a cyclic edge in the
+        //      proof without it fails tefBAD_SIGNATURE
+        //  (f) master-disabled signer in nested context requires
+        //      disabled-master consent on the path
+        //  (g) pfApplyPoliciesAllMultiSign on the txn account: depth-1
+        //      flat-multisign signers also become subject to the policy
+        //      intersection (e.g. master-disabled signers at depth 1 are
+        //      now rejected unless disabled-master is permitted)
+        //  (h) unknown bits in SigningPolicy => temINVALID_FLAG
+
+        using namespace jtx;
+
+        // (a) Pre-amendment: SigningPolicy must be rejected.
+        {
+            testcase("SigningPolicy pre-amendment is temDISABLED");
+            Env env{*this, features - featureNestedMultiSign};
+            Account const alice{"alice", KeyType::secp256k1};
+            env.fund(XRP(1000), alice);
+            env.close();
+            env(signing_policy(alice, pfPermitsSelfNested), ter(temDISABLED));
+            env.close();
+        }
+
+        if (!features[featureNestedMultiSign])
+            return;
+
+        // (h) Unknown bits => temINVALID_FLAG.
+        {
+            testcase("SigningPolicy unknown bits are temINVALID_FLAG");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            env.fund(XRP(1000), alice);
+            env.close();
+            constexpr std::uint32_t bogusBit = 0x80000000;
+            env(signing_policy(alice, bogusBit), ter(temINVALID_FLAG));
+            env.close();
+        }
+
+        // SigningPolicy=0 must remove the field from AccountRoot (not
+        // persist as a zero-valued field).
+        {
+            testcase("SigningPolicy=0 removes the field");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            env.fund(XRP(1000), alice);
+            env.close();
+
+            // Set a nonzero policy, then clear it.
+            env(signing_policy(alice, pfPermitsSelfNested));
+            env.close();
+            {
+                auto const sle = env.le(alice);
+                BEAST_EXPECT(sle && sle->isFieldPresent(sfSigningPolicy));
+                BEAST_EXPECT(
+                    sle &&
+                    sle->getFieldU32(sfSigningPolicy) == pfPermitsSelfNested);
+            }
+
+            env(signing_policy(alice, 0));
+            env.close();
+            {
+                auto const sle = env.le(alice);
+                BEAST_EXPECT(sle && !sle->isFieldPresent(sfSigningPolicy));
+            }
+        }
+
+        // Setting SigningPolicy twice replaces the value (no OR-merge with
+        // any prior bits). This is the atomic-bitmask contract.
+        {
+            testcase("SigningPolicy is replacement, not OR-merge");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            env.fund(XRP(1000), alice);
+            env.close();
+
+            // First set: nested only.
+            env(signing_policy(alice, pfPermitsSelfNested));
+            env.close();
+
+            // Second set: cycle only. Result must be exactly cycle, not
+            // nested|cycle.
+            env(signing_policy(alice, pfPermitsSelfCycleAdjustedQuorum));
+            env.close();
+
+            auto const sle = env.le(alice);
+            BEAST_EXPECT(sle && sle->isFieldPresent(sfSigningPolicy));
+            BEAST_EXPECT(
+                sle &&
+                sle->getFieldU32(sfSigningPolicy) ==
+                    pfPermitsSelfCycleAdjustedQuorum);
+        }
+
+        constexpr std::uint32_t kNested =
+            pfAcceptsBelowNested | pfPermitsSelfNested;
+        constexpr std::uint32_t kCycle = pfAcceptsBelowCycleAdjustedQuorum |
+            pfPermitsSelfCycleAdjustedQuorum;
+        constexpr std::uint32_t kDisabledMaster =
+            pfAcceptsBelowDisabledMaster | pfPermitsSelfDisabledMaster;
+
+        // (b) Default policy: flat works, nested rejected.
+        {
+            testcase("Default policy: flat works, nested rejected");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            env.fund(XRP(1000), alice, becky);
+            env.close();
+
+            // flat multisign with becky as signer (default policy) works
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{bogie, 1}}));
+            env.close();
+            auto const baseFee = env.current()->fees().base;
+            env(noop(alice), msig(becky), fee(2 * baseFee));
+            env.close();
+
+            // nested attempt fails: neither alice nor becky have consented
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(becky, msigner(bogie))}),
+                fee(3 * baseFee),
+                ter(tefBAD_SIGNATURE));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq);
+        }
+
+        // (c) One-sided opt-in: nested still rejected.
+        {
+            testcase("One-sided opt-in: parent only");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            env.fund(XRP(1000), alice, becky);
+            env.close();
+            env(signing_policy(alice, kNested));  // alice acceptsBelowNested,
+                                                  // but no permitsSelf...
+            // and becky has no permitsSelfNested.
+            env.close();
+
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{bogie, 1}}));
+            env.close();
+
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(becky, msigner(bogie))}),
+                fee(3 * baseFee),
+                ter(tefBAD_SIGNATURE));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq);
+        }
+
+        {
+            testcase("One-sided opt-in: child only");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            env.fund(XRP(1000), alice, becky);
+            env.close();
+            env(signing_policy(becky, kNested));  // child permits, but parent
+                                                  // doesn't accept
+            env.close();
+
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{bogie, 1}}));
+            env.close();
+
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(becky, msigner(bogie))}),
+                fee(3 * baseFee),
+                ter(tefBAD_SIGNATURE));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq);
+        }
+
+        // (d) Two-sided opt-in succeeds.
+        {
+            testcase("Two-sided opt-in: nested succeeds");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            env.fund(XRP(1000), alice, becky);
+            env.close();
+            env(signing_policy(alice, kNested));
+            env(signing_policy(becky, kNested));
+            env.close();
+
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{bogie, 1}}));
+            env.close();
+
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(becky, msigner(bogie))}),
+                fee(3 * baseFee));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+        }
+
+        // (e) Cycle without cycle-handling consent => tefBAD_SIGNATURE.
+        // Use a 3-account chain so the cycle is between non-txn-account
+        // signers (STTx rejects the txn account appearing in any proof
+        // entry, so the cycle itself cannot include alice directly).
+        // Structure: alice -> becky -> cheri -> becky (cycle).
+        {
+            testcase("Cyclic edge without cycle consent => tefBAD_SIGNATURE");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            Account const cheri{"cheri", KeyType::secp256k1};
+            env.fund(XRP(1000), alice, becky, cheri);
+            env.close();
+
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{cheri, 1}}));
+            // cheri's signer list includes becky (cycle) and bogie (escape).
+            env(signers(cheri, 1, {{becky, 1}, {bogie, 1}}));
+            env.close();
+
+            // Two-sided nested consent everywhere, but no cycle consent.
+            env(signing_policy(alice, kNested));
+            env(signing_policy(becky, kNested));
+            env(signing_policy(cheri, kNested));
+            env.close();
+
+            // Proof includes becky (cyclic) under cheri. Without cycle
+            // policy consent the cyclic edge is rejected.
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(
+                    becky, msigner(cheri, msigner(becky), msigner(bogie)))}),
+                fee(5 * baseFee),
+                ter(tefBAD_SIGNATURE));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq);
+        }
+
+        // Same setup, but now everyone consents to cycle handling. becky
+        // is skipped as cyclic, bogie satisfies cheri's cycle-adjusted
+        // quorum, becky satisfies alice's quorum.
+        {
+            testcase("Cyclic edge with cycle consent succeeds (skip)");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            Account const cheri{"cheri", KeyType::secp256k1};
+            env.fund(XRP(1000), alice, becky, cheri);
+            env.close();
+
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{cheri, 1}}));
+            env(signers(cheri, 1, {{becky, 1}, {bogie, 1}}));
+            env.close();
+
+            env(signing_policy(alice, kNested | kCycle));
+            env(signing_policy(becky, kNested | kCycle));
+            env(signing_policy(cheri, kNested | kCycle));
+            env.close();
+
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(
+                    becky, msigner(cheri, msigner(becky), msigner(bogie)))}),
+                fee(5 * baseFee));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+        }
+
+        // (f) Master-disabled signer in nested context requires
+        // disabled-master consent.
+        // Note: disabling master on an account requires the account to have
+        // an alternative signing path first (regular key or signer list);
+        // we give cheri a phantom signer list before disabling master.
+        {
+            testcase(
+                "Nested master-disabled signer without disabled-master "
+                "consent => tefMASTER_DISABLED");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            Account const cheri{"cheri", KeyType::secp256k1};
+            env.fund(XRP(1000), alice, becky, cheri);
+            env.close();
+
+            // Set up signer lists FIRST (so cheri's master can be disabled).
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{cheri, 1}}));
+            env(signers(cheri, 1, {{bogie, 1}}));
+            env.close();
+
+            // Two-sided nested consent everywhere, but no disabled-master.
+            env(signing_policy(alice, kNested));
+            env(signing_policy(becky, kNested));
+            env(signing_policy(cheri, kNested));
+            env.close();
+
+            // Disable cheri's master.
+            env(fset(cheri, asfDisableMaster), sig(cheri));
+            env.close();
+
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(becky, msigner(cheri))}),
+                fee(3 * baseFee),
+                ter(tefMASTER_DISABLED));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq);
+        }
+
+        {
+            testcase(
+                "Nested master-disabled signer with disabled-master consent "
+                "succeeds");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            Account const cheri{"cheri", KeyType::secp256k1};
+            env.fund(XRP(1000), alice, becky, cheri);
+            env.close();
+
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{cheri, 1}}));
+            env(signers(cheri, 1, {{bogie, 1}}));
+            env.close();
+
+            env(signing_policy(alice, kNested | kDisabledMaster));
+            env(signing_policy(becky, kNested | kDisabledMaster));
+            env(signing_policy(cheri, kNested | kDisabledMaster));
+            env.close();
+
+            env(fset(cheri, asfDisableMaster), sig(cheri));
+            env.close();
+
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice),
+                msig({msigner(becky, msigner(cheri))}),
+                fee(3 * baseFee));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+        }
+
+        // (g) pfApplyPoliciesAllMultiSign extends policy enforcement to
+        // depth 1. Without it, depth-1 master-disabled signers behave per
+        // legacy (rejected). With it, they need disabled-master consent.
+        {
+            testcase(
+                "applyPoliciesAllMultiSign + disabled-master consent "
+                "permits flat master-disabled signer");
+            Env env{*this, features};
+            Account const alice{"alice", KeyType::secp256k1};
+            Account const becky{"becky", KeyType::ed25519};
+            env.fund(XRP(1000), alice, becky);
+            env.close();
+
+            // Set up signer lists FIRST (so becky's master can be disabled).
+            env(signers(alice, 1, {{becky, 1}}));
+            env(signers(becky, 1, {{bogie, 1}}));
+            env.close();
+
+            env(signing_policy(
+                alice, pfApplyPoliciesAllMultiSign | kDisabledMaster));
+            env(signing_policy(becky, kDisabledMaster));
+            env.close();
+
+            env(fset(becky, asfDisableMaster), sig(becky));
+            env.close();
+
+            auto const baseFee = env.current()->fees().base;
+            std::uint32_t aliceSeq = env.seq(alice);
+            env(noop(alice), msig(becky), fee(2 * baseFee));
+            env.close();
+            BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
         }
     }
 
@@ -3292,6 +3739,7 @@ public:
         testAll(all);
 
         test_nestedMultiSignEdgeCases(all);
+        test_signingPolicy(all);
         test_signerListSetFlags(all);
         test_countPresentFields();
 

--- a/src/test/jtx/flags.h
+++ b/src/test/jtx/flags.h
@@ -42,6 +42,12 @@ fclear(Account const& account, std::uint32_t off)
     return fset(account, 0, off);
 }
 
+/** AccountSet that atomically replaces sfSigningPolicy with `policy`.
+    A value of 0 will cause the field to be removed from AccountRoot.
+ */
+Json::Value
+signing_policy(Account const& account, std::uint32_t policy);
+
 namespace detail {
 
 class flags_helper

--- a/src/test/jtx/impl/flags.cpp
+++ b/src/test/jtx/impl/flags.cpp
@@ -37,6 +37,16 @@ fset(Account const& account, std::uint32_t on, std::uint32_t off)
     return jv;
 }
 
+Json::Value
+signing_policy(Account const& account, std::uint32_t policy)
+{
+    Json::Value jv;
+    jv[jss::Account] = account.human();
+    jv[jss::TransactionType] = jss::AccountSet;
+    jv[jss::SigningPolicy] = policy;
+    return jv;
+}
+
 void
 flags::operator()(Env& env) const
 {

--- a/src/xrpld/app/tx/detail/SetAccount.cpp
+++ b/src/xrpld/app/tx/detail/SetAccount.cpp
@@ -25,6 +25,7 @@
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/Quality.h>
+#include <xrpl/protocol/SigningPolicy.h>
 #include <xrpl/protocol/st.h>
 
 namespace ripple {
@@ -195,6 +196,23 @@ SetAccount::preflight(PreflightContext const& ctx)
             scale > hook::maxHookStateScale())  // Min: 1, Max: 16 (256
                                                 // * 16 = 4096 bytes)
             return temMALFORMED;
+    }
+
+    // SigningPolicy is settable as a single atomic bitmask field on
+    // AccountSet, gated on featureNestedMultiSign.
+    if (tx.isFieldPresent(sfSigningPolicy))
+    {
+        if (!ctx.rules.enabled(featureNestedMultiSign))
+            return temDISABLED;
+
+        std::uint32_t const policy = tx.getFieldU32(sfSigningPolicy);
+        constexpr std::uint32_t kValidMask = pfApplyPoliciesAllMultiSign |
+            sigpol::acceptsBelowMask | sigpol::permitsSelfMask;
+        if (policy & ~kValidMask)
+        {
+            JLOG(j.trace()) << "SetAccount: SigningPolicy has unknown bits.";
+            return temINVALID_FLAG;
+        }
     }
 
     return preflight2(ctx);
@@ -651,6 +669,25 @@ SetAccount::doApply()
     {
         JLOG(j_.trace()) << "set allow clawback";
         uFlagsOut |= lsfAllowTrustLineClawback;
+    }
+
+    //
+    // SigningPolicy: atomic full-bitmask replacement. Caller supplies the
+    // desired final mask; zero clears the field. Gated on
+    // featureNestedMultiSign (preflight already enforced this).
+    //
+    if (tx.isFieldPresent(sfSigningPolicy))
+    {
+        std::uint32_t const policy = tx.getFieldU32(sfSigningPolicy);
+        if (policy == 0)
+        {
+            if (sle->isFieldPresent(sfSigningPolicy))
+                sle->makeFieldAbsent(sfSigningPolicy);
+        }
+        else
+        {
+            sle->setFieldU32(sfSigningPolicy, policy);
+        }
     }
 
     if (uFlagsIn != uFlagsOut)

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -39,6 +39,7 @@
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/STAccount.h>
 #include <xrpl/protocol/STTx.h>
+#include <xrpl/protocol/SigningPolicy.h>
 #include <xrpl/protocol/UintTypes.h>
 #include <functional>
 #include <limits>
@@ -1009,25 +1010,52 @@ Transactor::checkMultiSign(PreclaimContext const& ctx)
     int const maxDepth =
         allowNested ? nestedMultiSignMaxDepth : legacyMultiSignMaxDepth;
 
+    // Per-account signing policy. Read the txn account's policy to seed the
+    // path. Default-zero (or amendment off) means no new behaviors are
+    // permitted: legacy flat multi-sign holds and any nested-only mechanism
+    // (cycles, nested intermediaries, master-disabled signers in nested
+    // context) requires explicit opt-in by every participant.
+    auto const sleRoot = ctx.view.read(keylet::account(id));
+    std::uint32_t const rootPolicy =
+        (allowNested && sleRoot && sleRoot->isFieldPresent(sfSigningPolicy))
+        ? sleRoot->getFieldU32(sfSigningPolicy)
+        : 0u;
+    bool const applyAtDepth1 = (rootPolicy & pfApplyPoliciesAllMultiSign) != 0;
+    std::uint32_t const initialPathCap =
+        sigpol::permitsSelfToCapabilities(rootPolicy);
+    std::uint32_t const rootAcceptsBelowCaps =
+        sigpol::acceptsBelowToCapabilities(rootPolicy);
+
     // Nested multi-sign is dynamic account delegation: a parent SignerList
     // authorizes signer accounts, not a frozen set of leaf keys. A nested
     // signer contributes when that signer account's current on-ledger
     // SignerList is satisfied by the transaction evidence.
     //
-    // ancestors tracks the current proof path. An authorized signer entry that
-    // points back to an ancestor is unavailable on that path and may cause the
-    // local quorum to be cycle-adjusted below.
+    // The proof tree is bounded by a per-edge policy intersection model:
+    //   pathCap_root  = root.permitsSelf
+    //   pathCap_child = pathCap_parent
+    //                 ∩ (parent.acceptsBelow ∩ child.permitsSelf)
+    // capability is gated at each edge by pathCap.
+    //
+    // ancestors tracks the current proof path. An authorized signer entry
+    // that points back to an ancestor is unavailable on that path and may
+    // cause the local quorum to be cycle-adjusted below; both behaviors
+    // require explicit policy consent on the cycle axis.
     std::function<NotTEC(
-        AccountID const&, STArray const&, int, std::set<AccountID>)>
+        AccountID const&,
+        std::uint32_t,
+        STArray const&,
+        int,
+        std::set<AccountID>,
+        std::uint32_t)>
         validateSigners;
 
     validateSigners = [&](AccountID const& acc,
+                          std::uint32_t accAcceptsBelowCaps,
                           STArray const& signers,
                           int depth,
-                          std::set<AccountID> ancestors) -> NotTEC {
-        // Cycle detection is handled per authorized edge in the loop below,
-        // rather than by failing the delegated account outright.
-
+                          std::set<AccountID> ancestors,
+                          std::uint32_t pathCap) -> NotTEC {
         if (depth > maxDepth)
         {
             JLOG(ctx.j.trace())
@@ -1106,11 +1134,55 @@ Transactor::checkMultiSign(PreclaimContext const& ctx)
                 return tefBAD_SIGNATURE;
             }
 
+            // Read the signer's account and policy. Phantom signers have no
+            // AccountRoot and therefore no permitsSelf policy; setting
+            // signerPermitsSelfCaps to capAllMask means "phantom adds no
+            // additional restriction at this edge." It does NOT mean the
+            // phantom opted into anything -- the inherited path cap and
+            // parent's acceptsBelow consent still govern. (Phantoms cannot
+            // create cycles -- no SignerList -- and have no master to
+            // disable, so the cycle and disabled-master axes don't apply
+            // to them as leaves either.)
+            auto sleTxSignerRoot = ctx.view.read(keylet::account(signer));
+            std::uint32_t const signerPolicy =
+                (allowNested && sleTxSignerRoot &&
+                 sleTxSignerRoot->isFieldPresent(sfSigningPolicy))
+                ? sleTxSignerRoot->getFieldU32(sfSigningPolicy)
+                : 0u;
+            std::uint32_t const signerPermitsSelfCaps = sleTxSignerRoot
+                ? sigpol::permitsSelfToCapabilities(signerPolicy)
+                : sigpol::capAllMask;
+            std::uint32_t const signerAcceptsBelowCaps =
+                sigpol::acceptsBelowToCapabilities(signerPolicy);
+
+            // Per-edge effective capability cap.
+            std::uint32_t const edgeCap =
+                accAcceptsBelowCaps & signerPermitsSelfCaps;
+            std::uint32_t const newPathCap = pathCap & edgeCap;
+
+            // Whether the leaf-shape policy gates apply at this edge.
+            // Always true at depth >= 2 (nested context). At depth 1 only
+            // when the txn account explicitly opted in via
+            // pfApplyPoliciesAllMultiSign.
+            bool const policyEnforced = (depth >= 2) || applyAtDepth1;
+
             // The signer is authorized by acc, but is already in the current
             // proof path. Treat that cyclic ancestor edge as unavailable for
             // this path; do not recurse into it and do not count its weight.
+            // Including a cyclic edge requires explicit policy consent on
+            // the cycle axis (otherwise the proof relies on undisclosed
+            // semantics).
             if (ancestors.count(signer))
             {
+                if (allowNested &&
+                    !sigpol::hasCapability(
+                        newPathCap, sigpol::capCycleAdjustedQuorum))
+                {
+                    JLOG(ctx.j.trace())
+                        << "checkMultiSign: Cyclic signer " << signer
+                        << " requires cycle-handling policy consent.";
+                    return tefBAD_SIGNATURE;
+                }
                 JLOG(ctx.j.trace())
                     << "checkMultiSign: Skipping cyclic signer: " << signer;
                 continue;
@@ -1119,10 +1191,28 @@ Transactor::checkMultiSign(PreclaimContext const& ctx)
 
             if (isNestedSigner(signerEntry))
             {
+                // Nested intermediaries are a feature introduced by
+                // featureNestedMultiSign. They are always policy-gated at
+                // every depth -- the mechanism cannot be silently invoked.
+                if (!sigpol::hasCapability(newPathCap, sigpol::capNested))
+                {
+                    JLOG(ctx.j.trace())
+                        << "checkMultiSign: Nested signer " << signer
+                        << " requires nested-multisign policy consent "
+                           "(parent.acceptsBelowNested ∩ "
+                           "child.permitsSelfNested at this edge).";
+                    return tefBAD_SIGNATURE;
+                }
+
                 STArray const& nestedSigners =
                     signerEntry.getFieldArray(sfSigners);
                 NotTEC result = validateSigners(
-                    signer, nestedSigners, depth + 1, ancestors);
+                    signer,
+                    signerAcceptsBelowCaps,
+                    nestedSigners,
+                    depth + 1,
+                    ancestors,
+                    newPathCap);
                 if (!isTesSuccess(result))
                     return result;
 
@@ -1155,24 +1245,31 @@ Transactor::checkMultiSign(PreclaimContext const& ctx)
                     ? signer
                     : calcAccountID(PublicKey(makeSlice(spk)));
 
-                auto sleTxSignerRoot = ctx.view.read(keylet::account(signer));
-
                 if (signingAcctIDFromPubKey == signer)
                 {
-                    // Either Phantom or Master. Phantoms automatically pass.
+                    // Either Phantom or Master. Phantoms (no on-ledger
+                    // record) are unconditionally allowed at any depth --
+                    // they have no master to disable, so the
+                    // disabled-master capability axis does not apply.
                     if (sleTxSignerRoot)
                     {
                         // Master Key. Account may not have asfDisableMaster
-                        // set.
+                        // set unless the policy at this edge explicitly
+                        // allows disabled-master signers in this context.
                         std::uint32_t const signerAccountFlags =
                             sleTxSignerRoot->getFieldU32(sfFlags);
 
                         if (signerAccountFlags & lsfDisableMaster)
                         {
-                            JLOG(ctx.j.trace())
-                                << "checkMultiSign: Signer " << signer
-                                << " has lsfDisableMaster set.";
-                            return tefMASTER_DISABLED;
+                            if (!(policyEnforced &&
+                                  sigpol::hasCapability(
+                                      newPathCap, sigpol::capDisabledMaster)))
+                            {
+                                JLOG(ctx.j.trace())
+                                    << "checkMultiSign: Signer " << signer
+                                    << " has lsfDisableMaster set.";
+                                return tefMASTER_DISABLED;
+                            }
                         }
                     }
                 }
@@ -1226,15 +1323,17 @@ Transactor::checkMultiSign(PreclaimContext const& ctx)
             return tefINTERNAL;
         }
 
-        // Dynamic delegation still requires the delegated account's own policy
-        // to be satisfied. The only adjustment is for authorized ancestor edges
-        // that cannot be used without circular proof. If those cyclic edges
-        // make the configured quorum unreachable, require all remaining
-        // non-cyclic weight.
+        // Dynamic delegation still requires the delegated account's own
+        // policy to be satisfied. The only adjustment is for authorized
+        // ancestor edges that cannot be used without circular proof.
+        // Adjusting the configured quorum requires explicit consent (acc's
+        // permitsSelf, already incorporated into pathCap when the parent
+        // descended into acc); without it, the original quorum stands.
         uint32_t cycleAdjustedQuorum = quorum;
         uint32_t const maxAchievable = totalWeight - cyclicWeight;
 
-        if (cyclicWeight > 0 && maxAchievable < quorum)
+        if (allowNested && cyclicWeight > 0 && maxAchievable < quorum &&
+            sigpol::hasCapability(pathCap, sigpol::capCycleAdjustedQuorum))
         {
             JLOG(ctx.j.warn()) << "checkMultiSign: Cycle-adjusted quorum for "
                                << acc << ": " << quorum << " -> "
@@ -1263,7 +1362,8 @@ Transactor::checkMultiSign(PreclaimContext const& ctx)
 
     STArray const& entries(ctx.tx.getFieldArray(sfSigners));
 
-    NotTEC result = validateSigners(id, entries, 1, {});
+    NotTEC result = validateSigners(
+        id, rootAcceptsBelowCaps, entries, 1, {}, initialPathCap);
     if (!isTesSuccess(result))
     {
         JLOG(ctx.j.trace())


### PR DESCRIPTION
## Summary

Targets the [PR #675 NestedMultiSign branch](https://github.com/Xahau/xahaud/pull/675).

Introduces `sfSigningPolicy` on `AccountRoot` and an opt-in policy engine that gates the new behaviors of `featureNestedMultiSign` behind explicit per-account consent. Default-zero (or amendment off) means existing `SignerList`s keep legacy flat-multisign semantics; participation in nesting, cycle handling, or disabled-master-in-nested-context requires deliberate opt-in by every participant.

### Why

The current `featureNestedMultiSign` is a single global switch. Once activated, **every existing account** with a `SignerList` is implicitly re-interpreted under richer rules — accounts that designed flat-only multi-sign get conscripted into a delegation model they never opted into. This PR makes activation enable the *capability*; *participation* is per-account-gated.

### Design

Two-sided consent model with three capability axes:

- `acceptsBelow{Nested,CycleAdjustedQuorum,DisabledMaster}` — what proofs an account accepts when being signed for
- `permitsSelf{Nested,CycleAdjustedQuorum,DisabledMaster}` — what an account permits when delegated to as a signer
- `applyPoliciesAllMultiSign` — meta toggle on the txn account that extends policy enforcement to depth-1 (flat) signers too

Effective policy at each tree edge is the intersection of inherited path cap, `parent.acceptsBelow`, and `child.permitsSelf`. Authority can only narrow as the proof descends. Phantom signers (no on-ledger record) cannot express `permitsSelf` and are treated as adding no restriction at the edge — the parent's `acceptsBelow` consent governs.

### Setter API

`sfSigningPolicy` is a directly settable optional `UINT32` field on `AccountSet` (atomic full-bitmask replacement; value of 0 removes the field) gated on `featureNestedMultiSign`.

Choosing a settable field rather than seven `asf*`/`asf-clear` codes keeps the protocol clean: every existing `asf*` targets `sfFlags`, and burning seven of the remaining `sfFlags` bits on one feature is disproportionate.

### Tests

9 new `test_signingPolicy` testcases cover:
- Pre-amendment `temDISABLED` rejection
- Unknown bits → `temINVALID_FLAG`
- Persistence sanity (`SigningPolicy=0` removes the field; setting twice is replacement, not OR-merge)
- Default-zero rejection of nested attempts
- One-sided / two-sided opt-in
- Cycle without/with consent
- Master-disabled-in-nested-context without/with consent
- `applyPoliciesAllMultiSign` at depth 1

Existing nested tests get a single `optInNestedWithCycling` helper applied to all funded participants. The disabled-master capability is intentionally absent from the default opt-in, so tests like Total Lockout that pre-date this capability keep their `tefMASTER_DISABLED` expectations.

## Test plan

- [x] `x-run-tests -- ripple.app.MultiSign` — 117 cases / 5816 tests / 0 failures
- [x] `x-run-tests -- ripple.protocol` — 97 cases / 31887 tests / 0 failures
- [x] Patch coverage (llvm-cov diff): 95.5% lines / 84.9% branches; remaining gaps are defensive paths (assertions, defense-in-depth duplicating STTx checks) and structurally-unreachable edges (`sleRoot` non-null in multi-sign context, cycles in legacy mode)
- [x] `git clang-format origin/dev` clean