### PR TITLE
NamedHooks selectors: multi-name trigger support and cron-targeted hooks

### DIFF
--- a/hook/sfcodes.h
+++ b/hook/sfcodes.h
@@ -297,6 +297,7 @@
 #define sfRemark ((14U << 16U) + 97U)
 #define sfHighReward ((14U << 16U) + 98U)
 #define sfLowReward ((14U << 16U) + 99U)
+#define sfNamedHook ((14U << 16U) + 100U)
 #define sfSigners ((15U << 16U) + 3U)
 #define sfSignerEntries ((15U << 16U) + 4U)
 #define sfTemplate ((15U << 16U) + 5U)
@@ -325,3 +326,4 @@
 #define sfActiveValidators ((15U << 16U) + 95U)
 #define sfGenesisMints ((15U << 16U) + 96U)
 #define sfRemarks ((15U << 16U) + 97U)
+#define sfHookNames ((15U << 16U) + 98U)

--- a/include/xrpl/hook/Enum.h
+++ b/include/xrpl/hook/Enum.h
@@ -116,6 +116,18 @@ maxNamespaceDelete(void)
     return 256;
 }
 
+// maximum number of HookName selectors carried in a transaction's sfHookNames
+// array (featureNamedHooks). Kept small: at most maxHookChainLength() named
+// hooks can exist on any one account, and a cron re-emits its carried selector
+// array on every execution, so an oversized array would amplify pseudo-txn
+// size. 32 leaves ample headroom for selecting across a sender + several TSH
+// accounts in a single transaction.
+inline uint32_t
+maxNamedHookSelectors(void)
+{
+    return 32;
+}
+
 enum TSHFlags : uint8_t {
     tshNONE = 0b000,
     tshROLLBACK = 0b001,

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -66,6 +66,8 @@ LEDGER_ENTRY_DUPLICATE(ltCRON, 0x0041, Cron, cron, ({
     {sfOwnerNode,            soeREQUIRED},
     {sfPreviousTxnID,        soeREQUIRED},
     {sfPreviousTxnLgrSeq,    soeREQUIRED},
+    {sfHookName,             soeOPTIONAL},
+    {sfHookNames,            soeOPTIONAL},
 }))
 
 /** A ledger object which describes a check.

--- a/include/xrpl/protocol/detail/sfields.macro
+++ b/include/xrpl/protocol/detail/sfields.macro
@@ -391,6 +391,7 @@ UNTYPED_SFIELD(sfGenesisMint,            OBJECT,    96)
 UNTYPED_SFIELD(sfRemark,                 OBJECT,    97)
 UNTYPED_SFIELD(sfHighReward,             OBJECT,    98)
 UNTYPED_SFIELD(sfLowReward,              OBJECT,    99)
+UNTYPED_SFIELD(sfNamedHook,              OBJECT,   100)
 
 // array of objects (common)
 // ARRAY/1 is reserved for end of array
@@ -427,3 +428,4 @@ UNTYPED_SFIELD(sfImportVLKeys,           ARRAY,     94)
 UNTYPED_SFIELD(sfActiveValidators,       ARRAY,     95)
 UNTYPED_SFIELD(sfGenesisMints,           ARRAY,     96)
 UNTYPED_SFIELD(sfRemarks,                ARRAY,     97)
+UNTYPED_SFIELD(sfHookNames,              ARRAY,     98)

--- a/include/xrpl/protocol/detail/transactions.macro
+++ b/include/xrpl/protocol/detail/transactions.macro
@@ -500,10 +500,12 @@ TRANSACTION(ttPERMISSIONED_DOMAIN_DELETE, 72, PermissionedDomainDelete, ({
     {sfDomainID, soeREQUIRED},
 }))
 
-/* A pseudo-txn alarm signal for invoking a hook, emitted by validators after alarm set conditions are met */
+/* A pseudo-txn alarm signal for invoking a hook, emitted by validators after alarm set conditions are met.
+   The optional sfHookName / sfHookNames selector(s) it carries come from the common transaction fields. */
 TRANSACTION(ttCRON, 92, Cron, ({
     {sfOwner, soeREQUIRED},
     {sfLedgerSequence, soeREQUIRED},
+    {sfCron, soeOPTIONAL},
 }))
 
 /* Sechedule an alarm for later */

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -77,6 +77,7 @@ JSS(HookApiVersion);      // field
 JSS(HookCanEmit);         // field
 JSS(HookHash);            // field
 JSS(HookName);            // field
+JSS(HookNames);           // field
 JSS(HookNamespace);       // field
 JSS(HookOn);              // field
 JSS(HookOnIncoming);      // field
@@ -102,6 +103,7 @@ JSS(FirstLedgerSequence);      // in: TransactionSign; field
 JSS(LastUpdateTime);           // field.
 JSS(LimitAmount);              // field.
 JSS(NetworkID);                // field.
+JSS(NamedHook);                // field.
 JSS(LPTokenOut);               // in: AMM Liquidity Provider deposit tokens
 JSS(LPTokenIn);                // in: AMM Liquidity Provider withdraw tokens
 JSS(LPToken);                  // out: AMM Liquidity Provider tokens info

--- a/src/libxrpl/protocol/InnerObjectFormats.cpp
+++ b/src/libxrpl/protocol/InnerObjectFormats.cpp
@@ -108,6 +108,10 @@ InnerObjectFormats::InnerObjectFormats()
          {sfAuthorize, soeOPTIONAL},
          {sfFlags, soeOPTIONAL}});
 
+    add(sfNamedHook.jsonName,
+        sfNamedHook.getCode(),
+        {{sfHookName, soeREQUIRED}});
+
     add(sfHookParameter.jsonName,
         sfHookParameter.getCode(),
         {{sfHookParameterName, soeREQUIRED},

--- a/src/libxrpl/protocol/TxFormats.cpp
+++ b/src/libxrpl/protocol/TxFormats.cpp
@@ -49,6 +49,7 @@ TxFormats::TxFormats()
         {sfNetworkID, soeOPTIONAL},
         {sfHookParameters, soeOPTIONAL},
         {sfHookName, soeOPTIONAL},
+        {sfHookNames, soeOPTIONAL},
     };
 
 #pragma push_macro("UNWRAP")

--- a/src/test/app/Cron_test.cpp
+++ b/src/test/app/Cron_test.cpp
@@ -469,6 +469,307 @@ struct Cron_test : public beast::unit_test::suite
     }
 
     void
+    testCronHookName(FeatureBitset features)
+    {
+        testcase("cron hook name");
+        using namespace jtx;
+        using namespace std::literals::chrono_literals;
+        auto const alice = Account("alice");
+
+        auto namesArray = [](std::vector<std::string> const& names) {
+            Json::Value arr{Json::arrayValue};
+            for (auto const& n : names)
+            {
+                Json::Value e;
+                e[jss::NamedHook][jss::HookName] = n;
+                arr.append(e);
+            }
+            return arr;
+        };
+
+        // validation + storage of the selector on the cron ledger object
+        {
+            Env env{*this, features | featureCron};
+            env.fund(XRP(1000), alice);
+            env.close();
+
+            auto const baseTime =
+                env.current()->parentCloseTime().time_since_epoch().count();
+
+            // single HookName stored on the cron object
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                cs[jss::HookName] = "41424344";
+                env(cs, fee(XRP(1)), ter(tesSUCCESS));
+                env.close();
+
+                auto const accSle = env.le(keylet::account(alice.id()));
+                BEAST_EXPECT(accSle && accSle->isFieldPresent(sfCron));
+                auto const cronSle =
+                    env.le(keylet::child(accSle->getFieldH256(sfCron)));
+                BEAST_EXPECT(cronSle && cronSle->isFieldPresent(sfHookName));
+                BEAST_EXPECT(
+                    strHex(cronSle->getFieldVL(sfHookName)) == "41424344");
+                BEAST_EXPECT(!cronSle->isFieldPresent(sfHookNames));
+            }
+
+            //@@start named-hooks-test-cron-array-storage
+            // HookNames array stored on the cron object
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                cs[jss::HookNames] = namesArray({"41424344", "41424345"});
+                env(cs, fee(XRP(1)), ter(tesSUCCESS));
+                env.close();
+
+                auto const accSle = env.le(keylet::account(alice.id()));
+                auto const cronSle =
+                    env.le(keylet::child(accSle->getFieldH256(sfCron)));
+                BEAST_EXPECT(cronSle && cronSle->isFieldPresent(sfHookNames));
+                BEAST_EXPECT(cronSle->getFieldArray(sfHookNames).size() == 2);
+                BEAST_EXPECT(!cronSle->isFieldPresent(sfHookName));
+            }
+            //@@end named-hooks-test-cron-array-storage
+
+            // empty HookName is accepted as the legacy "unnamed" value, but
+            // is not persisted as a cron selector
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                cs[jss::HookName] = "";
+                env(cs, fee(XRP(1)), ter(tesSUCCESS));
+                env.close();
+
+                auto const accSle = env.le(keylet::account(alice.id()));
+                auto const cronSle =
+                    env.le(keylet::child(accSle->getFieldH256(sfCron)));
+                BEAST_EXPECT(cronSle && !cronSle->isFieldPresent(sfHookName));
+                BEAST_EXPECT(cronSle && !cronSle->isFieldPresent(sfHookNames));
+            }
+
+            // sfHookName and sfHookNames are mutually exclusive
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                cs[jss::HookName] = "41424344";
+                cs[jss::HookNames] = namesArray({"41424345"});
+                env(cs, fee(XRP(1)), ter(temMALFORMED));
+            }
+
+            // invalid name
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                cs[jss::HookName] = "DEADBEEF";  // not valid utf-8
+                env(cs, fee(XRP(1)), ter(temMALFORMED));
+            }
+
+            //@@start named-hooks-test-cron-array-validation
+            // malformed HookNames arrays are rejected for CronSet too
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                cs[jss::HookNames] = Json::Value{Json::arrayValue};
+                env(cs, fee(XRP(1)), ter(temMALFORMED));
+            }
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                cs[jss::HookNames] = namesArray({"41424344", "41424344"});
+                env(cs, fee(XRP(1)), ter(temMALFORMED));
+            }
+            {
+                auto cs = cron::set(alice);
+                cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+                Json::Value arr{Json::arrayValue};
+                Json::Value entry;
+                entry[sfHook.jsonName][jss::HookName] = "41424344";
+                arr.append(entry);
+                cs[jss::HookNames] = arr;
+                env(cs, fee(XRP(1)), ter(temMALFORMED));
+            }
+            //@@end named-hooks-test-cron-array-validation
+
+            // a selector may accompany a tfCronUnset: it only acts as a v1
+            // selector for this transaction's own hook chain, nothing is
+            // persisted on delete
+            {
+                auto cs = cron::set(alice);
+                cs[jss::HookName] = "41424344";
+                env(cs, fee(XRP(1)), txflags(tfCronUnset), ter(tesSUCCESS));
+                env.close();
+                auto const accSle = env.le(keylet::account(alice.id()));
+                BEAST_EXPECT(accSle && !accSle->isFieldPresent(sfCron));
+            }
+        }
+
+        // without featureNamedHooks both selector forms are rejected outright
+        // by preflight1
+        {
+            Env env{*this, (features | featureCron) - featureNamedHooks};
+            env.fund(XRP(1000), alice);
+            env.close();
+            auto const baseTime =
+                env.current()->parentCloseTime().time_since_epoch().count();
+
+            auto csSingle = cron::set(alice);
+            csSingle[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+            csSingle[jss::HookName] = "41424344";
+            env(csSingle, fee(XRP(1)), ter(temMALFORMED));
+
+            auto csArray = cron::set(alice);
+            csArray[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
+            csArray[jss::HookNames] = namesArray({"41424344"});
+            env(csArray, fee(XRP(1)), ter(temMALFORMED));
+        }
+
+        //@@start named-hooks-test-cron-pseudo-carry
+        // the emitted Cron pseudo-txn carries the selector
+        {
+            Env env{*this, features | featureCron};
+            env.fund(XRP(1000), alice);
+            env.close();
+            auto const baseTime =
+                env.current()->parentCloseTime().time_since_epoch().count();
+            auto cs = cron::set(alice);
+            cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
+            cs[jss::HookName] = "41424344";
+            env(cs, fee(XRP(1)), ter(tesSUCCESS));
+            env.close();
+
+            bool fired = false;
+            for (int i = 0; i < 40 && !fired; ++i)
+            {
+                env.close(10s);
+                auto const& txs = env.closed()->txs;
+                for (auto it = txs.begin(); it != txs.end(); ++it)
+                {
+                    if (it->first->getTxnType() != ttCRON)
+                        continue;
+                    fired = true;
+                    BEAST_EXPECT(it->first->isFieldPresent(sfHookName));
+                    BEAST_EXPECT(
+                        strHex(it->first->getFieldVL(sfHookName)) ==
+                        "41424344");
+                }
+            }
+            BEAST_EXPECT(fired);
+        }
+        //@@end named-hooks-test-cron-pseudo-carry
+
+        // a recurring cron keeps its selector across executions
+        {
+            Env env{*this, features | featureCron};
+            env.fund(XRP(1000), alice);
+            env.close();
+            auto const baseTime =
+                env.timeKeeper().now().time_since_epoch().count();
+            auto cs = cron::set(alice);
+            cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
+            cs[sfDelaySeconds.jsonName] = 100;
+            cs[sfRepeatCount.jsonName] = 3;
+            cs[jss::HookName] = "41424344";
+            env(cs, fee(XRP(1)), ter(tesSUCCESS));
+            env.close(10s);
+
+            // advance until the first execution fires
+            bool fired = false;
+            for (int i = 0; i < 40 && !fired; ++i)
+            {
+                env.close(10s);
+                auto const& txs = env.closed()->txs;
+                for (auto it = txs.begin(); it != txs.end(); ++it)
+                    if (it->first->getTxnType() == ttCRON)
+                        fired = true;
+            }
+            BEAST_EXPECT(fired);
+
+            // the recreated cron object still carries the selector
+            auto const accSle = env.le(keylet::account(alice.id()));
+            BEAST_EXPECT(accSle && accSle->isFieldPresent(sfCron));
+            auto const cronSle =
+                env.le(keylet::child(accSle->getFieldH256(sfCron)));
+            BEAST_EXPECT(cronSle && cronSle->isFieldPresent(sfHookName));
+            BEAST_EXPECT(cronSle && cronSle->getFieldU32(sfRepeatCount) == 2);
+            if (cronSle && cronSle->isFieldPresent(sfHookName))
+                BEAST_EXPECT(
+                    strHex(cronSle->getFieldVL(sfHookName)) == "41424344");
+        }
+
+        //@@start named-hooks-test-cron-array-recurrence
+        // a recurring cron keeps its array selector across executions
+        {
+            Env env{*this, features | featureCron};
+            env.fund(XRP(1000), alice);
+            env.close();
+            auto const baseTime =
+                env.timeKeeper().now().time_since_epoch().count();
+            auto cs = cron::set(alice);
+            cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
+            cs[sfDelaySeconds.jsonName] = 100;
+            cs[sfRepeatCount.jsonName] = 3;
+            cs[jss::HookNames] = namesArray({"41424344", "41424345"});
+            env(cs, fee(XRP(1)), ter(tesSUCCESS));
+            env.close(10s);
+
+            bool fired = false;
+            for (int i = 0; i < 40 && !fired; ++i)
+            {
+                env.close(10s);
+                auto const& txs = env.closed()->txs;
+                for (auto it = txs.begin(); it != txs.end(); ++it)
+                    if (it->first->getTxnType() == ttCRON)
+                        fired = true;
+            }
+            BEAST_EXPECT(fired);
+
+            auto const accSle = env.le(keylet::account(alice.id()));
+            BEAST_EXPECT(accSle && accSle->isFieldPresent(sfCron));
+            auto const cronSle =
+                env.le(keylet::child(accSle->getFieldH256(sfCron)));
+            BEAST_EXPECT(cronSle && cronSle->isFieldPresent(sfHookNames));
+            BEAST_EXPECT(cronSle && !cronSle->isFieldPresent(sfHookName));
+            if (cronSle && cronSle->isFieldPresent(sfHookNames))
+            {
+                auto const& hookNames = cronSle->getFieldArray(sfHookNames);
+                BEAST_EXPECT(hookNames.size() == 2);
+                BEAST_EXPECT(cronSle->getFieldU32(sfRepeatCount) == 2);
+            }
+        }
+        //@@end named-hooks-test-cron-array-recurrence
+
+        // a nameless cron carries no selector (regression)
+        {
+            Env env{*this, features | featureCron};
+            env.fund(XRP(1000), alice);
+            env.close();
+            auto const baseTime =
+                env.current()->parentCloseTime().time_since_epoch().count();
+            auto cs = cron::set(alice);
+            cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
+            env(cs, fee(XRP(1)), ter(tesSUCCESS));
+            env.close();
+
+            bool fired = false;
+            for (int i = 0; i < 40 && !fired; ++i)
+            {
+                env.close(10s);
+                auto const& txs = env.closed()->txs;
+                for (auto it = txs.begin(); it != txs.end(); ++it)
+                {
+                    if (it->first->getTxnType() != ttCRON)
+                        continue;
+                    fired = true;
+                    BEAST_EXPECT(!it->first->isFieldPresent(sfHookName));
+                    BEAST_EXPECT(!it->first->isFieldPresent(sfHookNames));
+                }
+            }
+            BEAST_EXPECT(fired);
+        }
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnabled(features);
@@ -478,6 +779,7 @@ struct Cron_test : public beast::unit_test::suite
         testDoApply(features);
 
         testCronExecution(features);
+        testCronHookName(features);
     }
 
 public:

--- a/src/test/app/SetHook_test.cpp
+++ b/src/test/app/SetHook_test.cpp
@@ -2032,6 +2032,574 @@ public:
         }
     }
 
+    // Build an sfHookNames JSON array from a list of hex name strings:
+    //   [ { "NamedHook": { "HookName": "<hex>" } }, ... ]
+    static Json::Value
+    hookNamesArray(std::vector<std::string> const& names)
+    {
+        Json::Value arr{Json::arrayValue};
+        for (auto const& n : names)
+        {
+            Json::Value entry;
+            entry[jss::NamedHook][jss::HookName] = n;
+            arr.append(entry);
+        }
+        return arr;
+    }
+
+    void
+    testHookNamesArray(FeatureBitset features)
+    {
+        testcase("Test hook names array (multiple named hooks per txn)");
+        using namespace jtx;
+
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const USD = alice["USD"];
+
+        bool const namedHooks =
+            features[featureHooks] && features[featureNamedHooks];
+
+        // sfHookNames requires featureNamedHooks
+        {
+            Env env{*this, features};
+            env.fund(XRP(10000), alice);
+            env.close();
+
+            auto jv = invoke::invoke(alice);
+            jv[jss::HookNames] = hookNamesArray({"41424344"});
+            env(jv,
+                M("HookNames requires featureNamedHooks"),
+                HSFEE,
+                namedHooks ? ter(tesSUCCESS) : ter(temMALFORMED));
+            env.close();
+        }
+
+        if (!namedHooks)
+            return;
+
+        // Malformed selector arrays
+        {
+            Env env{*this, features};
+            env.fund(XRP(10000), alice);
+            env.close();
+
+            // sfHookName and sfHookNames are mutually exclusive
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookName] = "41424344";
+                jv[jss::HookNames] = hookNamesArray({"41424345"});
+                env(jv,
+                    M("HookName + HookNames are mutually exclusive"),
+                    HSFEE,
+                    ter(temMALFORMED));
+            }
+            // empty array
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = Json::Value{Json::arrayValue};
+                env(jv, M("empty HookNames"), HSFEE, ter(temMALFORMED));
+            }
+            // duplicate names
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = hookNamesArray({"41424344", "41424344"});
+                env(jv, M("duplicate HookNames"), HSFEE, ter(temMALFORMED));
+            }
+            // invalid name (too short)
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = hookNamesArray({"414243"});
+                env(jv,
+                    M("invalid HookNames entry (too short)"),
+                    HSFEE,
+                    ter(temMALFORMED));
+            }
+            // empty name in entry
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = hookNamesArray({""});
+                env(jv, M("empty name in HookNames"), HSFEE, ter(temMALFORMED));
+            }
+            // entry too long (17 bytes / 34 hex)
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] =
+                    hookNamesArray({"4142434445464748494A4B4C4D4E4F5051"});
+                env(jv,
+                    M("HookNames entry too long"),
+                    HSFEE,
+                    ter(temMALFORMED));
+            }
+            // entry not valid utf-8
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = hookNamesArray({"DEADBEEF"});
+                env(jv,
+                    M("HookNames entry not utf-8"),
+                    HSFEE,
+                    ter(temMALFORMED));
+            }
+            // entry wrapped in the wrong inner object (sfHook can also carry
+            // sfHookName) rather than the canonical sfNamedHook
+            {
+                auto jv = invoke::invoke(alice);
+                Json::Value arr{Json::arrayValue};
+                Json::Value entry;
+                entry[sfHook.jsonName][jss::HookName] = "41424344";
+                arr.append(entry);
+                jv[jss::HookNames] = arr;
+                env(jv,
+                    M("HookNames entry must be a NamedHook"),
+                    HSFEE,
+                    ter(temMALFORMED));
+            }
+
+            // selector-count boundary around maxNamedHookSelectors()
+            {
+                // distinct, valid 4-byte (8 hex) ASCII names: "HK??"
+                auto nthName = [](uint32_t i) {
+                    char const buf[4] = {
+                        'H',
+                        'K',
+                        static_cast<char>('A' + (i / 26)),
+                        static_cast<char>('A' + (i % 26))};
+                    return strHex(std::string(buf, 4));
+                };
+                auto buildN = [&](uint32_t n) {
+                    std::vector<std::string> v;
+                    v.reserve(n);
+                    for (uint32_t i = 0; i < n; ++i)
+                        v.push_back(nthName(i));
+                    return hookNamesArray(v);
+                };
+                // exactly the max is accepted
+                {
+                    auto jv = invoke::invoke(alice);
+                    jv[jss::HookNames] = buildN(hook::maxNamedHookSelectors());
+                    env(jv,
+                        M("max selectors accepted"),
+                        HSFEE,
+                        ter(tesSUCCESS));
+                    env.close();
+                }
+                // one over the max is malformed
+                {
+                    auto jv = invoke::invoke(alice);
+                    jv[jss::HookNames] =
+                        buildN(hook::maxNamedHookSelectors() + 1);
+                    env(jv, M("too many selectors"), HSFEE, ter(temMALFORMED));
+                }
+            }
+        }
+
+        // Two distinct NAMED hooks, selected individually and together
+        {
+            Env env{*this, features};
+            env.fund(XRP(10000), alice, bob);
+            env.close();
+
+            // accept  -> named "AAAA" (41414141)
+            // accept2 -> named "BBBB" (42424242)
+            auto jvh = hso(accept_wasm);
+            jvh[jss::HookName] = "41414141";
+            jvh[jss::Flags] = hsfCOLLECT;
+            auto jvh2 = hso(accept2_wasm);
+            jvh2[jss::HookName] = "42424242";
+            jvh2[jss::Flags] = hsfCOLLECT;
+            env(ripple::test::jtx::hook(alice, {{jvh, jvh2}}, 0),
+                M("Install two distinct named hooks"),
+                HSFEE);
+            env.close();
+
+            auto execCount = [&]() -> std::size_t {
+                if (!env.meta()->isFieldPresent(sfHookExecutions))
+                    return 0;
+                return env.meta()->getFieldArray(sfHookExecutions).size();
+            };
+
+            // No selector: neither named hook fires
+            {
+                auto jv = invoke::invoke(alice);
+                env(jv, M("no selector -> no named hooks"), HSFEE);
+                env.close();
+                BEAST_EXPECT(execCount() == 0);
+            }
+
+            //@@start named-hooks-test-array-selection
+            // Array with one name: only that hook fires
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = hookNamesArray({"41414141"});
+                env(jv, M("array selects AAAA only"), HSFEE);
+                env.close();
+                auto const ex = env.meta()->getFieldArray(sfHookExecutions);
+                BEAST_EXPECT(ex.size() == 1);
+                BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept_hash);
+            }
+
+            // Array with the other name
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = hookNamesArray({"42424242"});
+                env(jv, M("array selects BBBB only"), HSFEE);
+                env.close();
+                auto const ex = env.meta()->getFieldArray(sfHookExecutions);
+                BEAST_EXPECT(ex.size() == 1);
+                BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept2_hash);
+            }
+
+            // Array with both names: both hooks fire (in install order)
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookNames] = hookNamesArray({"41414141", "42424242"});
+                env(jv, M("array selects both AAAA and BBBB"), HSFEE);
+                env.close();
+                auto const ex = env.meta()->getFieldArray(sfHookExecutions);
+                BEAST_EXPECT(ex.size() == 2);
+                BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept_hash);
+                BEAST_EXPECT(ex[1].getFieldH256(sfHookHash) == accept2_hash);
+            }
+            //@@end named-hooks-test-array-selection
+
+            // Single sfHookName still selects exactly one named hook
+            {
+                auto jv = invoke::invoke(alice);
+                jv[jss::HookName] = "42424242";
+                env(jv, M("single selector still works"), HSFEE);
+                env.close();
+                auto const ex = env.meta()->getFieldArray(sfHookExecutions);
+                BEAST_EXPECT(ex.size() == 1);
+                BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept2_hash);
+            }
+
+            //@@start named-hooks-test-fee-identity
+            // The fee gate uses the same selector logic as execution, so the
+            // per-hook cost is additive: fee(both) - fee(none) == the sum of
+            // each hook's individual incremental cost.
+            {
+                auto feeFor = [&](Json::Value const& jv) {
+                    return calculateBaseFee(*env.current(), *env.jt(jv).stx);
+                };
+                auto jvNone = invoke::invoke(alice);
+                auto jvA = invoke::invoke(alice);
+                jvA[jss::HookNames] = hookNamesArray({"41414141"});
+                auto jvB = invoke::invoke(alice);
+                jvB[jss::HookNames] = hookNamesArray({"42424242"});
+                auto jvBoth = invoke::invoke(alice);
+                jvBoth[jss::HookNames] =
+                    hookNamesArray({"41414141", "42424242"});
+                BEAST_EXPECT(feeFor(jvA) > feeFor(jvNone));
+                BEAST_EXPECT(feeFor(jvB) > feeFor(jvNone));
+                BEAST_EXPECT(feeFor(jvBoth) > feeFor(jvA));
+                BEAST_EXPECT(
+                    feeFor(jvBoth) + feeFor(jvNone) ==
+                    feeFor(jvA) + feeFor(jvB));
+                // a selector matching no installed hook costs the same as no
+                // selector at all
+                auto jvNon = invoke::invoke(alice);
+                jvNon[jss::HookNames] = hookNamesArray({"5A5A5A5A"});
+                BEAST_EXPECT(feeFor(jvNon) == feeFor(jvNone));
+            }
+            //@@end named-hooks-test-fee-identity
+
+            // Weak (collect) execution: alice is a weak TSH on bob's trustline.
+            // The selector gates the weak chain too.
+            env(fset(alice, asfTshCollect), fee(XRP(1)));
+            env.close();
+            {
+                // selecting only AAAA fires only accept
+                auto jv = trust(bob, USD(1000));
+                jv[jss::HookNames] = hookNamesArray({"41414141"});
+                env(jv, M("weak: array selects AAAA only"), HSFEE);
+                env.close();
+                auto const ex = env.meta()->getFieldArray(sfHookExecutions);
+                BEAST_EXPECT(ex.size() == 1);
+                BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept_hash);
+            }
+            {
+                // selecting both fires both
+                auto jv = trust(bob, USD(1001));
+                jv[jss::HookNames] = hookNamesArray({"41414141", "42424242"});
+                env(jv, M("weak: array selects both"), HSFEE);
+                env.close();
+                auto const ex = env.meta()->getFieldArray(sfHookExecutions);
+                BEAST_EXPECT(ex.size() == 2);
+                BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept_hash);
+                BEAST_EXPECT(ex[1].getFieldH256(sfHookHash) == accept2_hash);
+            }
+        }
+    }
+
+    void
+    testCronHookName(FeatureBitset features)
+    {
+        using namespace jtx;
+        using namespace std::literals::chrono_literals;
+
+        // end-to-end execution needs hooks + named hooks + cron. Guard before
+        // testcase() so we never open a testcase with no expectations.
+        if (!(features[featureHooks] && features[featureNamedHooks] &&
+              features[featureCron]))
+            return;
+
+        testcase("Test cron-targeted named hook execution");
+
+        // Set a one-time cron on `owner` carrying `cs` selector fields, advance
+        // until it fires, and return the hook-execution hashes from the cron
+        // pseudo-txn's metadata.
+        auto runCron = [this](Env& env, Account const& owner, Json::Value cs)
+            -> std::vector<uint256> {
+            using namespace std::literals::chrono_literals;
+            auto const baseTime =
+                env.current()->parentCloseTime().time_since_epoch().count();
+            cs[jss::TransactionType] = jss::CronSet;
+            cs[jss::Account] = owner.human();
+            cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
+            env(cs, fee(XRP(1)), ter(tesSUCCESS));
+            env.close();
+
+            std::vector<uint256> hashes;
+            bool fired = false;
+            for (int i = 0; i < 40 && !fired; ++i)
+            {
+                env.close(10s);
+                auto const& txs = env.closed()->txs;
+                for (auto it = txs.begin(); it != txs.end(); ++it)
+                {
+                    if (it->first->getTxnType() != ttCRON)
+                        continue;
+                    fired = true;
+                    if (it->second &&
+                        it->second->isFieldPresent(sfHookExecutions))
+                        for (auto const& e :
+                             it->second->getFieldArray(sfHookExecutions))
+                            hashes.push_back(e.getFieldH256(sfHookHash));
+                }
+            }
+            BEAST_EXPECT(fired);
+            return hashes;
+        };
+
+        // A named hook coexisting with an unnamed hook
+        {
+            auto const alice = Account{"alice"};
+            Env env{*this, features};
+            env.fund(XRP(10000), alice);
+            env.close();
+
+            // accept -> named "AAAA"; accept2 -> unnamed; both collect
+            auto jvh = hso(accept_wasm);
+            jvh[jss::HookName] = "41414141";
+            jvh[jss::Flags] = hsfCOLLECT;
+            auto jvh2 = hso(accept2_wasm);
+            jvh2[jss::Flags] = hsfCOLLECT;
+            env(ripple::test::jtx::hook(alice, {{jvh, jvh2}}, 0),
+                M("install named + unnamed cron hooks"),
+                HSFEE);
+            env.close();
+            env(fset(alice, asfTshCollect), fee(XRP(1)));
+            env.close();
+
+            // nameless cron: only the unnamed hook fires (existing behaviour)
+            {
+                auto const h = runCron(env, alice, Json::Value{});
+                BEAST_EXPECT(h.size() == 1);
+                if (h.size() == 1)
+                    BEAST_EXPECT(h[0] == accept2_hash);
+            }
+            // named cron "AAAA": the named hook fires alongside the unnamed one
+            {
+                Json::Value cs;
+                cs[jss::HookName] = "41414141";
+                auto const h = runCron(env, alice, cs);
+                BEAST_EXPECT(h.size() == 2);
+                if (h.size() == 2)
+                {
+                    BEAST_EXPECT(h[0] == accept_hash);
+                    BEAST_EXPECT(h[1] == accept2_hash);
+                }
+            }
+            // non-matching name: only the unnamed hook fires
+            {
+                Json::Value cs;
+                cs[jss::HookName] = "5A5A5A5A";
+                auto const h = runCron(env, alice, cs);
+                BEAST_EXPECT(h.size() == 1);
+                if (h.size() == 1)
+                    BEAST_EXPECT(h[0] == accept2_hash);
+            }
+        }
+
+        // A cron carrying an array selects multiple distinct named hooks
+        {
+            auto const bob = Account{"bob"};
+            Env env{*this, features};
+            env.fund(XRP(10000), bob);
+            env.close();
+
+            // accept -> named "AAAA"; accept2 -> named "BBBB"; both collect
+            auto jvh = hso(accept_wasm);
+            jvh[jss::HookName] = "41414141";
+            jvh[jss::Flags] = hsfCOLLECT;
+            auto jvh2 = hso(accept2_wasm);
+            jvh2[jss::HookName] = "42424242";
+            jvh2[jss::Flags] = hsfCOLLECT;
+            env(ripple::test::jtx::hook(bob, {{jvh, jvh2}}, 0),
+                M("install two named cron hooks"),
+                HSFEE);
+            env.close();
+            env(fset(bob, asfTshCollect), fee(XRP(1)));
+            env.close();
+
+            // array selects both named hooks
+            {
+                Json::Value cs;
+                cs[jss::HookNames] = hookNamesArray({"41414141", "42424242"});
+                auto const h = runCron(env, bob, cs);
+                BEAST_EXPECT(h.size() == 2);
+                if (h.size() == 2)
+                {
+                    BEAST_EXPECT(h[0] == accept_hash);
+                    BEAST_EXPECT(h[1] == accept2_hash);
+                }
+            }
+            // array selects just one of the two
+            {
+                Json::Value cs;
+                cs[jss::HookNames] = hookNamesArray({"42424242"});
+                auto const h = runCron(env, bob, cs);
+                BEAST_EXPECT(h.size() == 1);
+                if (h.size() == 1)
+                    BEAST_EXPECT(h[0] == accept2_hash);
+            }
+            // nameless cron fires neither named hook
+            {
+                auto const h = runCron(env, bob, Json::Value{});
+                BEAST_EXPECT(h.size() == 0);
+            }
+        }
+
+        // A recurring named cron keeps firing the named hook on every
+        // recurrence
+        {
+            auto const carol = Account{"carol"};
+            Env env{*this, features};
+            env.fund(XRP(10000), carol);
+            env.close();
+
+            auto jvh = hso(accept_wasm);
+            jvh[jss::HookName] = "41414141";
+            jvh[jss::Flags] = hsfCOLLECT;
+            env(ripple::test::jtx::hook(carol, {{jvh}}, 0),
+                M("install recurring named cron hook"),
+                HSFEE);
+            env.close();
+            env(fset(carol, asfTshCollect), fee(XRP(1)));
+            env.close();
+
+            auto const baseTime =
+                env.current()->parentCloseTime().time_since_epoch().count();
+            Json::Value cs;
+            cs[jss::TransactionType] = jss::CronSet;
+            cs[jss::Account] = carol.human();
+            cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
+            cs[sfDelaySeconds.jsonName] = 100;
+            cs[sfRepeatCount.jsonName] = 2;  // fires 3 times in total
+            cs[jss::HookName] = "41414141";
+            env(cs, fee(XRP(1)), ter(tesSUCCESS));
+            env.close(10s);
+
+            int firings = 0;
+            int namedExecutions = 0;
+            for (int i = 0; i < 100 && firings < 3; ++i)
+            {
+                env.close(10s);
+                auto const& txs = env.closed()->txs;
+                for (auto it = txs.begin(); it != txs.end(); ++it)
+                {
+                    if (it->first->getTxnType() != ttCRON)
+                        continue;
+                    ++firings;
+                    if (it->second &&
+                        it->second->isFieldPresent(sfHookExecutions))
+                        for (auto const& e :
+                             it->second->getFieldArray(sfHookExecutions))
+                            if (e.getFieldH256(sfHookHash) == accept_hash)
+                                ++namedExecutions;
+                }
+            }
+            // the named hook fired on every recurrence, not just the first --
+            // i.e. the selector persisted across cron re-creation
+            BEAST_EXPECT(firings == 3);
+            BEAST_EXPECT(namedExecutions == 3);
+        }
+
+        //@@start named-hooks-test-recurring-cron-array
+        // A recurring cron carrying HookNames keeps firing both selected named
+        // hooks on every recurrence
+        {
+            auto const dave = Account{"dave"};
+            Env env{*this, features};
+            env.fund(XRP(10000), dave);
+            env.close();
+
+            auto jvh = hso(accept_wasm);
+            jvh[jss::HookName] = "41414141";
+            jvh[jss::Flags] = hsfCOLLECT;
+            auto jvh2 = hso(accept2_wasm);
+            jvh2[jss::HookName] = "42424242";
+            jvh2[jss::Flags] = hsfCOLLECT;
+            env(ripple::test::jtx::hook(dave, {{jvh, jvh2}}, 0),
+                M("install recurring named cron hooks"),
+                HSFEE);
+            env.close();
+            env(fset(dave, asfTshCollect), fee(XRP(1)));
+            env.close();
+
+            auto const baseTime =
+                env.current()->parentCloseTime().time_since_epoch().count();
+            Json::Value cs;
+            cs[jss::TransactionType] = jss::CronSet;
+            cs[jss::Account] = dave.human();
+            cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
+            cs[sfDelaySeconds.jsonName] = 100;
+            cs[sfRepeatCount.jsonName] = 2;  // fires 3 times in total
+            cs[jss::HookNames] = hookNamesArray({"41414141", "42424242"});
+            env(cs, fee(XRP(1)), ter(tesSUCCESS));
+            env.close(10s);
+
+            int firings = 0;
+            int firstNamedExecutions = 0;
+            int secondNamedExecutions = 0;
+            for (int i = 0; i < 100 && firings < 3; ++i)
+            {
+                env.close(10s);
+                auto const& txs = env.closed()->txs;
+                for (auto it = txs.begin(); it != txs.end(); ++it)
+                {
+                    if (it->first->getTxnType() != ttCRON)
+                        continue;
+                    ++firings;
+                    if (it->second &&
+                        it->second->isFieldPresent(sfHookExecutions))
+                        for (auto const& e :
+                             it->second->getFieldArray(sfHookExecutions))
+                        {
+                            if (e.getFieldH256(sfHookHash) == accept_hash)
+                                ++firstNamedExecutions;
+                            if (e.getFieldH256(sfHookHash) == accept2_hash)
+                                ++secondNamedExecutions;
+                        }
+                }
+            }
+            BEAST_EXPECT(firings == 3);
+            BEAST_EXPECT(firstNamedExecutions == 3);
+            BEAST_EXPECT(secondNamedExecutions == 3);
+        }
+        //@@end named-hooks-test-recurring-cron-array
+    }
+
     void
     testFillCopy(FeatureBitset features)
     {
@@ -15099,6 +15667,8 @@ public:
 
         testHookOnV2(features);
         testHookName(features);
+        testHookNamesArray(features);
+        testCronHookName(features);
 
         testFillCopy(features);
 

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -1510,7 +1510,13 @@ TxQ::accept(Application& app, OpenView& view)
         uint256 klStart = keylet::cron(0, accountID).key;
         uint256 const klEnd = keylet::cron(currentTime + 1, accountID).key;
 
-        std::set<AccountID> cronAccs;
+        bool const namedHooks = view.rules().enabled(featureNamedHooks);
+
+        //@@start named-hooks-cron-scan-auth
+        // owner account -> its cron ledger object (there is at most one cron
+        // per account). The SLE is retained so any named-hook selector(s) it
+        // carries can be copied onto the emitted Cron pseudo-txn.
+        std::map<AccountID, std::shared_ptr<SLE const>> cronAccs;
 
         auto counter = 0;
         // include max 128 cron txns in the ledger
@@ -1528,23 +1534,70 @@ TxQ::accept(Application& app, OpenView& view)
                 if (safe_cast<LedgerEntryType>(
                         sle->getFieldU16(sfLedgerEntryType)) == ltCRON)
                 {
-                    // valid cron object, add it to the list
-                    cronAccs.emplace(sle->getAccountID(sfOwner));
+                    AccountID const owner = sle->getAccountID(sfOwner);
+
+                    if (!namedHooks)
+                    {
+                        // Preserve the pre-NamedHooks Cron scheduler output:
+                        // every due ltCRON owner is pinged, even if a stale or
+                        // orphan object is encountered in the scan window.
+                        cronAccs.emplace(owner, sle);
+                    }
+                    else
+                    {
+                        // Only the account's current cron pointer is
+                        // authoritative once the selector amendment needs the
+                        // cron object for pseudo-txn field copying.
+                        // Stale/orphan entries still consume this scan loop's
+                        // 128-key budget; changing that accounting is a broader
+                        // Cron scheduler behavior change and is intentionally
+                        // left out here.
+                        auto const accountSle =
+                            view.read(keylet::account(owner));
+                        if (accountSle && accountSle->isFieldPresent(sfCron) &&
+                            accountSle->getFieldH256(sfCron) == sle->key())
+                        {
+                            cronAccs.emplace(owner, sle);
+                        }
+                    }
                 }
             }
-
             klStart = *next;
         }
+        //@@end named-hooks-cron-scan-auth
 
         auto const seq = view.info().seq;
 
         // insert Cron pseudos for each of the accs we need to ping
-        for (AccountID const& id : cronAccs)
+        for (auto const& cronAcc : cronAccs)
         {
-            STTx cronTx(ttCRON, [=](auto& obj) {
+            AccountID const& id = cronAcc.first;
+            std::shared_ptr<SLE const> const& cronSle = cronAcc.second;
+            STTx cronTx(ttCRON, [&](auto& obj) {
                 obj[sfAccount] = AccountID();
                 obj[sfLedgerSequence] = seq;
                 obj[sfOwner] = id;
+                //@@start named-hooks-cron-pseudo-selector
+                if (namedHooks)
+                {
+                    // Bind the pseudo-txn to the exact cron object found during
+                    // TxQ scheduling. Cron::doApply treats this as stale if the
+                    // owner replaced or removed the cron before the pseudo
+                    // applies.
+                    obj[sfCron] = cronSle->key();
+
+                    // carry the cron's named-hook selector(s), if any, so the
+                    // pseudo-txn triggers the selected named hook(s) on the
+                    // owner (in addition to the owner's unnamed hooks, as
+                    // always)
+                    if (cronSle->isFieldPresent(sfHookName))
+                        obj.setFieldVL(
+                            sfHookName, cronSle->getFieldVL(sfHookName));
+                    if (cronSle->isFieldPresent(sfHookNames))
+                        obj.setFieldArray(
+                            sfHookNames, cronSle->getFieldArray(sfHookNames));
+                }
+                //@@end named-hooks-cron-pseudo-selector
             });
 
             uint256 txID = cronTx.getTransactionID();

--- a/src/xrpld/app/tx/detail/Change.cpp
+++ b/src/xrpld/app/tx/detail/Change.cpp
@@ -45,6 +45,14 @@ Change::preflight(PreflightContext const& ctx)
     if (!isTesSuccess(ret))
         return ret;
 
+    if (ctx.tx.isFieldPresent(sfHookNames) ||
+        (ctx.rules.enabled(featureNamedHooks) &&
+         ctx.tx.isFieldPresent(sfHookName)))
+    {
+        JLOG(ctx.j.warn()) << "Change: Hook selectors are not allowed";
+        return temMALFORMED;
+    }
+
     auto account = ctx.tx.getAccountID(sfAccount);
     if (account != beast::zero)
     {

--- a/src/xrpld/app/tx/detail/Cron.cpp
+++ b/src/xrpld/app/tx/detail/Cron.cpp
@@ -27,6 +27,7 @@
 #include <xrpl/protocol/Quality.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/st.h>
+#include <optional>
 
 namespace ripple {
 
@@ -45,6 +46,14 @@ Cron::preflight(PreflightContext const& ctx)
     auto const ret = preflight0(ctx);
     if (!isTesSuccess(ret))
         return ret;
+
+    bool const namedHooks = ctx.rules.enabled(featureNamedHooks);
+
+    //@@start named-hooks-cron-preflight-selector
+    auto const selectors = validateHookSelectors(ctx, true);
+    if (!isTesSuccess(selectors))
+        return selectors;
+    //@@end named-hooks-cron-preflight-selector
 
     auto account = ctx.tx.getAccountID(sfAccount);
     if (account != beast::zero)
@@ -75,6 +84,16 @@ Cron::preflight(PreflightContext const& ctx)
         return temBAD_SEQUENCE;
     }
 
+    //@@start named-hooks-cron-preflight-binding
+    if (namedHooks &&
+        (!ctx.tx.isFieldPresent(sfCron) ||
+         ctx.tx.getFieldH256(sfCron) == beast::zero))
+    {
+        JLOG(ctx.j.warn()) << "Cron: Missing cron object";
+        return temMALFORMED;
+    }
+    //@@end named-hooks-cron-preflight-binding
+
     return tesSUCCESS;
 }
 
@@ -92,6 +111,7 @@ Cron::doApply()
 {
     auto& view = ctx_.view();
     auto const& tx = ctx_.tx;
+    bool const namedHooks = view.rules().enabled(featureNamedHooks);
 
     if (view.rules().enabled(fixCronStacking))
     {
@@ -115,11 +135,30 @@ Cron::doApply()
 
     if (!sle->isFieldPresent(sfCron))
     {
+        if (namedHooks && tx.isFieldPresent(sfCron))
+        {
+            JLOG(j_.warn()) << "Cron: stale cron pseudo for account " << id;
+            return tesSUCCESS;
+        }
+
         JLOG(j_.warn()) << "Cron: sfCron missing from account " << id;
         return tefINTERNAL;
     }
 
+    //@@start named-hooks-cron-stale-pseudo
     uint256 ptr = sle->getFieldH256(sfCron);
+    // The Cron pseudo-txn is scheduled against a specific ltCRON object. If
+    // the owner replaced or removed that object earlier in this ledger, this
+    // pseudo is stale and must not execute the owner's new cron with the old
+    // pseudo's selector fields.
+    if (namedHooks && tx.isFieldPresent(sfCron) &&
+        ptr != tx.getFieldH256(sfCron))
+    {
+        JLOG(j_.warn()) << "Cron: stale cron pseudo for account " << id;
+        return tesSUCCESS;
+    }
+    //@@end named-hooks-cron-stale-pseudo
+
     Keylet klOld{ltCRON, ptr};
     auto sleCron = view.peek(klOld);
     if (!sleCron)
@@ -132,6 +171,20 @@ Cron::doApply()
     uint32_t recur = sleCron->getFieldU32(sfRepeatCount);
 
     uint32_t lastStartTime = sleCron->getFieldU32(sfStartTime);
+
+    //@@start named-hooks-cron-capture-selector
+    // capture the named-hook selector(s) (if any) before the object is erased,
+    // so they persist across recurring executions (featureNamedHooks)
+    std::optional<Blob> hookName;
+    std::optional<STArray> hookNames;
+    if (namedHooks)
+    {
+        if (sleCron->isFieldPresent(sfHookName))
+            hookName = sleCron->getFieldVL(sfHookName);
+        if (sleCron->isFieldPresent(sfHookNames))
+            hookNames = sleCron->getFieldArray(sfHookNames);
+    }
+    //@@end named-hooks-cron-capture-selector
 
     // do all this sanity checking before we modify the ledger...
     uint32_t afterTime = lastStartTime + delay;
@@ -175,6 +228,14 @@ Cron::doApply()
     sleCron->setFieldU32(sfRepeatCount, recur - 1);
     sleCron->setFieldU32(sfStartTime, afterTime);
     sleCron->setAccountID(sfOwner, id);
+
+    //@@start named-hooks-cron-carry-forward
+    // carry the named-hook selector(s) forward to the next execution
+    if (hookName)
+        sleCron->setFieldVL(sfHookName, *hookName);
+    if (hookNames)
+        sleCron->setFieldArray(sfHookNames, *hookNames);
+    //@@end named-hooks-cron-carry-forward
 
     sle->setFieldH256(sfCron, klCron.key);
 

--- a/src/xrpld/app/tx/detail/CronSet.cpp
+++ b/src/xrpld/app/tx/detail/CronSet.cpp
@@ -64,6 +64,16 @@ CronSet::preflight(PreflightContext const& ctx)
     bool const hasRepeat = tx.isFieldPresent(sfRepeatCount);
     bool const hasStartTime = tx.isFieldPresent(sfStartTime);
 
+    //@@start named-hooks-cronset-selector-note
+    // Note: sfHookName / sfHookNames are common transaction selectors,
+    // validated by preflight1 (which requires featureNamedHooks). On a CronSet
+    // they additionally serve as the selector persisted on the cron object (and
+    // carried by the emitted Cron pseudo-txn), gated in doApply. They are
+    // deliberately NOT rejected here: a CronSet (or a tfCronUnset) may carry
+    // sfHookName purely to select named hooks on its own hook chain, exactly as
+    // for any other transaction.
+    //@@end named-hooks-cronset-selector-note
+
     if (tx.isFlag(tfCronUnset))
     {
         // delete operation
@@ -267,6 +277,23 @@ CronSet::doApply()
     sleCron->setFieldU32(sfDelaySeconds, delay);
     sleCron->setFieldU32(sfRepeatCount, recur);
     sleCron->setAccountID(sfOwner, id);
+
+    //@@start named-hooks-cronset-persist-selector
+    // persist the optional named-hook selector(s) on the cron so the emitted
+    // Cron pseudo-txn triggers the selected named hook(s) on the owner
+    // (featureNamedHooks).
+    if (view.rules().enabled(featureNamedHooks))
+    {
+        if (tx.isFieldPresent(sfHookName))
+        {
+            Blob const hookName = tx.getFieldVL(sfHookName);
+            if (!hookName.empty())
+                sleCron->setFieldVL(sfHookName, hookName);
+        }
+        if (tx.isFieldPresent(sfHookNames))
+            sleCron->setFieldArray(sfHookNames, tx.getFieldArray(sfHookNames));
+    }
+    //@@end named-hooks-cronset-persist-selector
 
     sle->setFieldH256(sfCron, klCron.key);
 

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -36,14 +36,64 @@
 #include <xrpl/hook/Enum.h>
 #include <xrpl/json/to_string.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/STAccount.h>
 #include <xrpl/protocol/UintTypes.h>
 #include <limits>
+#include <optional>
 #include <set>
 
 namespace ripple {
+
+// Determines whether `hookObj` (a hook installed on an account's hook chain) is
+// selected to run by the triggering transaction `tx`, according to the
+// transaction's hook-name selector(s) (featureNamedHooks).
+//
+//   * A hook with no name (absent or empty sfHookName) is always selected.
+//   * A named hook is selected when the transaction carries a matching
+//     selector: either a single sfHookName equal to the hook's name, or an
+//     sfHookNames array containing an entry equal to it. The two forms are
+//     mutually exclusive at preflight, so the array is consulted first and,
+//     when present, is authoritative.
+//
+// No explicit amendment check is needed here: a hook can only carry a name when
+// featureNamedHooks is enabled (SetHook enforces this and amendments do not
+// deactivate), so for any hook with a non-empty name the amendment is
+// necessarily active. Pre-amendment no hook is named, so this function returns
+// true for every hook and the selector fields are inert. Validation of selector
+// fields on emitted/pseudo transactions is handled on their preflight paths.
+//
+// This mirrors the gate applied during fee calculation so that the fee charged
+// always matches the set of hooks that actually execute.
+static bool
+txSelectsHook(STObject const& hookObj, STTx const& tx)
+{
+    if (!hookObj.isFieldPresent(sfHookName))
+        return true;
+
+    Blob const required = hookObj.getFieldVL(sfHookName);
+    if (required.empty())
+        return true;
+
+    if (tx.isFieldPresent(sfHookNames))
+    {
+        for (auto const& entry : tx.getFieldArray(sfHookNames))
+        {
+            if (entry.getFName() == sfNamedHook &&
+                entry.isFieldPresent(sfHookName) &&
+                entry.getFieldVL(sfHookName) == required)
+                return true;
+        }
+        return false;
+    }
+
+    if (tx.isFieldPresent(sfHookName))
+        return tx.getFieldVL(sfHookName) == required;
+
+    return false;
+}
 
 /** Performs early sanity checks on the txid */
 NotTEC
@@ -90,6 +140,70 @@ preflight0(PreflightContext const& ctx)
     return tesSUCCESS;
 }
 
+NotTEC
+validateHookSelectors(PreflightContext const& ctx, bool allowLegacyHookName)
+{
+    if (ctx.tx.isFieldPresent(sfHookName))
+    {
+        if (!ctx.rules.enabled(featureHooks))
+            return temMALFORMED;
+
+        if (!ctx.rules.enabled(featureNamedHooks))
+        {
+            // Some pre-amendment paths (notably emitted transactions and
+            // pseudo-transactions) historically accepted the legacy single
+            // sfHookName field because they did not run this validation.
+            // Preserve that behavior where callers opt in. The new sfHookNames
+            // array remains rejected below unless featureNamedHooks is enabled.
+            if (!allowLegacyHookName)
+                return temMALFORMED;
+        }
+
+        if (ctx.rules.enabled(featureNamedHooks) &&
+            !SetHook::validateHookName(ctx.tx.getFieldVL(sfHookName), ctx.j))
+            return temMALFORMED;
+    }
+
+    if (ctx.tx.isFieldPresent(sfHookNames))
+    {
+        if (!ctx.rules.enabled(featureHooks) ||
+            !ctx.rules.enabled(featureNamedHooks))
+            return temMALFORMED;
+
+        // sfHookName (single selector) and sfHookNames (array selector) are
+        // mutually exclusive
+        if (ctx.tx.isFieldPresent(sfHookName))
+            return temMALFORMED;
+
+        auto const& names = ctx.tx.getFieldArray(sfHookNames);
+        if (names.empty() || names.size() > hook::maxNamedHookSelectors())
+            return temMALFORMED;
+
+        std::set<Blob> seen;
+        for (auto const& entry : names)
+        {
+            // each entry must be a canonical sfNamedHook wrapper, not some
+            // other inner object that merely happens to carry sfHookName
+            if (entry.getFName() != sfNamedHook)
+                return temMALFORMED;
+
+            if (!entry.isFieldPresent(sfHookName))
+                return temMALFORMED;
+
+            Blob const name = entry.getFieldVL(sfHookName);
+
+            // an empty name is "unnamed" and is meaningless as a selector
+            if (name.empty() || !SetHook::validateHookName(name, ctx.j))
+                return temMALFORMED;
+
+            if (!seen.insert(name).second)
+                return temMALFORMED;  // duplicate selector
+        }
+    }
+
+    return tesSUCCESS;
+}
+
 /** Performs early sanity checks on the account and fee fields */
 NotTEC
 preflight1(PreflightContext const& ctx)
@@ -121,14 +235,22 @@ preflight1(PreflightContext const& ctx)
         return temBAD_FEE;
     }
 
+    bool const emittedBypass = ctx.rules.enabled(featureHooks) &&
+        hook::isEmittedTxn(ctx.tx) &&
+        ((ctx.app.getHashRouter().getFlags(ctx.tx.getTransactionID()) &
+          SF_EMITTED) ||
+         (ctx.flags & tapPREFLIGHT_EMIT));
+
+    auto const selectors = validateHookSelectors(ctx, emittedBypass);
+    if (!isTesSuccess(selectors))
+        return selectors;
+
     // if a hook emitted this transaction we bypass signature checks
     // there is a bar to circularing emitted transactions on the network
     // in their prevalidated form so this is safe
     if (ctx.rules.enabled(featureHooks) && hook::isEmittedTxn(ctx.tx))
     {
-        if ((ctx.app.getHashRouter().getFlags(ctx.tx.getTransactionID()) &
-             SF_EMITTED) ||
-            (ctx.flags & tapPREFLIGHT_EMIT))
+        if (emittedBypass)
         {
             if (ctx.tx.getSeqProxy().isTicket() &&
                 ctx.tx.isFieldPresent(sfAccountTxnID))
@@ -147,16 +269,6 @@ preflight1(PreflightContext const& ctx)
             // state in the local instance.
             return telNON_LOCAL_EMITTED_TXN;
         }
-    }
-
-    if (ctx.tx.isFieldPresent(sfHookName))
-    {
-        if (!ctx.rules.enabled(featureHooks) ||
-            !ctx.rules.enabled(featureNamedHooks))
-            return temMALFORMED;
-
-        if (!SetHook::validateHookName(ctx.tx.getFieldVL(sfHookName), ctx.j))
-            return temMALFORMED;
     }
 
     auto const spk = ctx.tx.getSigningPubKey();
@@ -283,19 +395,11 @@ Transactor::calculateHookChainFee(
             // LCOV_EXCL_STOP
         }
 
-        std::optional<Blob> requiredHookName;
-        if (hookObj.isFieldPresent(sfHookName) &&
-            hookObj.getFieldVL(sfHookName).size() > 0)
-            requiredHookName = hookObj.getFieldVL(sfHookName);
-
-        if (requiredHookName)
-        {
-            // need to specify same hook name in the transaction
-            if (!tx.isFieldPresent(sfHookName))
-                continue;
-            if (*requiredHookName != tx.getFieldVL(sfHookName))
-                continue;
-        }
+        //@@start named-hooks-fee-gate
+        // skip hooks not selected by the transaction's hook-name selector(s)
+        if (!txSelectsHook(hookObj, tx))
+            continue;
+        //@@end named-hooks-fee-gate
 
         uint32_t flags = 0;
         if (hookObj.isFieldPresent(sfFlags))
@@ -1354,19 +1458,11 @@ Transactor::executeHookChain(
             // LCOV_EXCL_STOP
         }
 
-        std::optional<Blob> requiredHookName;
-        if (hookObj.isFieldPresent(sfHookName) &&
-            hookObj.getFieldVL(sfHookName).size() > 0)
-            requiredHookName = hookObj.getFieldVL(sfHookName);
-
-        if (requiredHookName)
-        {
-            // need to specify same hook name in the transaction
-            if (!ctx_.tx.isFieldPresent(sfHookName))
-                continue;
-            if (*requiredHookName != ctx_.tx.getFieldVL(sfHookName))
-                continue;
-        }
+        //@@start named-hooks-execution-gate
+        // skip hooks not selected by the transaction's hook-name selector(s)
+        if (!txSelectsHook(hookObj, ctx_.tx))
+            continue;
+        //@@end named-hooks-execution-gate
 
         // check if the hook can fire
         uint256 hookOn = hook::getHookOn(
@@ -1482,6 +1578,45 @@ Transactor::executeHookChain(
     return tesSUCCESS;
 }
 
+static std::optional<uint8_t>
+callbackHookChainPosition(
+    STObject const& emitDetails,
+    AccountID const& callbackAccountID,
+    uint256 const& callbackHookHash)
+{
+    if (!emitDetails.isFieldPresent(sfEmitNonce) ||
+        !emitDetails.isFieldPresent(sfEmitParentTxnID))
+        return std::nullopt;
+
+    auto const expectedNonce = emitDetails.getFieldH256(sfEmitNonce);
+    auto const parentTxnID = emitDetails.getFieldH256(sfEmitParentTxnID);
+
+    for (uint8_t position = 0; position < hook::maxHookChainLength();
+         ++position)
+    {
+        // etxn_nonce hashes the uint16_t emit_nonce_counter; hash_append
+        // includes integral width, so a uint32_t with the same value will not
+        // match.
+        for (uint16_t nonce = 0; nonce <= hook_api::max_nonce; ++nonce)
+        {
+            for (uint32_t flags = 0; flags < 4; ++flags)
+            {
+                auto const candidate = sha512Half(
+                    HashPrefix::emitTxnNonce,
+                    parentTxnID,
+                    nonce,
+                    callbackAccountID,
+                    callbackHookHash,
+                    (static_cast<uint32_t>(position) << 2U) | flags);
+                if (candidate == expectedNonce)
+                    return position;
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
 void
 Transactor::doHookCallback(
     std::shared_ptr<STObject const> const& provisionalMeta)
@@ -1501,6 +1636,21 @@ Transactor::doHookCallback(
     AccountID const& callbackAccountID =
         emitDetails.getAccountID(sfEmitCallback);
     uint256 const& callbackHookHash = emitDetails.getFieldH256(sfEmitHookHash);
+    bool const namedHooks = view().rules().enabled(featureNamedHooks);
+    bool const hasCallbackNonce = namedHooks &&
+        emitDetails.isFieldPresent(sfEmitNonce) &&
+        emitDetails.isFieldPresent(sfEmitParentTxnID);
+    std::optional<uint8_t> callbackPosition;
+    if (hasCallbackNonce)
+        callbackPosition = callbackHookChainPosition(
+            emitDetails, callbackAccountID, callbackHookHash);
+
+    if (hasCallbackNonce && !callbackPosition)
+    {
+        JLOG(j_.warn()) << "HookError[" << callbackAccountID
+                        << "]: Callback nonce did not identify hook slot";
+        return;
+    }
 
     auto const& hooksCallback = view().peek(keylet::hook(callbackAccountID));
     auto const& hookDef = view().peek(keylet::hookDefinition(callbackHookHash));
@@ -1532,6 +1682,17 @@ Transactor::doHookCallback(
 
     bool found = false;
     auto const& hooks = hooksCallback->getFieldArray(sfHooks);
+
+    // Count how many slots currently carry the callback hash. The emit-position
+    // filter below only needs to disambiguate genuinely duplicate-hash slots;
+    // when exactly one slot matches we deliver to it even if the emitting hook
+    // was relocated to a different chain index since it emitted.
+    std::size_t callbackHashSlots = 0;
+    for (auto const& hookObj : hooks)
+        if (hookObj.isFieldPresent(sfHookHash) &&
+            hookObj.getFieldH256(sfHookHash) == callbackHookHash)
+            ++callbackHashSlots;
+
     uint8_t hook_no = 0;
     for (auto const& hookObj : hooks)
     {
@@ -1542,6 +1703,15 @@ Transactor::doHookCallback(
 
         if (hookObj.getFieldH256(sfHookHash) != callbackHookHash)
             continue;
+
+        //@@start named-hooks-callback-slot-filter
+        // Only disambiguate by emit position when more than one slot carries
+        // the hash; an unambiguous callback is otherwise delivered even after a
+        // benign hook relocation within this transaction.
+        if (namedHooks && callbackPosition && callbackHashSlots > 1 &&
+            *callbackPosition != hook_no - 1)
+            continue;
+        //@@end named-hooks-callback-slot-filter
 
         uint256 hookCanEmit = hook::getHookCanEmit(hookObj, hookDef);
 
@@ -1813,7 +1983,7 @@ Transactor::doTSH(
 void
 Transactor::doAgainAsWeak(
     AccountID const& hookAccountID,
-    std::set<uint256> const& hookHashes,
+    std::set<std::pair<uint8_t, uint256>> const& requestedHooks,
     hook::HookStateMap& stateMap,
     std::vector<hook::HookResult>& results,
     std::shared_ptr<STObject const> const& provisionalMeta)
@@ -1833,6 +2003,7 @@ Transactor::doAgainAsWeak(
     }
 
     auto const& hooks = hooksArray->getFieldArray(sfHooks);
+    bool const namedHooks = view().rules().enabled(featureNamedHooks);
     uint8_t hook_no = 0;
     for (auto const& hookObj : hooks)
     {
@@ -1843,9 +2014,58 @@ Transactor::doAgainAsWeak(
 
         uint256 const& hookHash = hookObj.getFieldH256(sfHookHash);
 
-        if (hookHashes.find(hookObj.getFieldH256(sfHookHash)) ==
-            hookHashes.end())
+        //@@start named-hooks-aaw-exact-replay
+        if (namedHooks)
+        {
+            bool matched = requestedHooks.find({hook_no - 1, hookHash}) !=
+                requestedHooks.end();
+            if (!matched)
+            {
+                // Exact {position, hash} failed: fall back to hash matching
+                // only when this hash is unambiguous in both the requested set
+                // and the current chain (a single requesting slot whose index
+                // merely shifted within this same transaction). Ambiguous
+                // duplicate-hash cases still require the exact position.
+                std::size_t reqForHash = 0;
+                for (auto const& requestedHook : requestedHooks)
+                    if (requestedHook.second == hookHash)
+                        ++reqForHash;
+                std::size_t curForHash = 0;
+                for (auto const& other : hooks)
+                    if (other.isFieldPresent(sfHookHash) &&
+                        other.getFieldH256(sfHookHash) == hookHash)
+                        ++curForHash;
+                if (reqForHash == 1 && curForHash == 1)
+                    matched = true;
+            }
+            if (!matched)
+                continue;
+        }
+        else
+        {
+            bool requestedHash = false;
+            for (auto const& requestedHook : requestedHooks)
+            {
+                if (requestedHook.second == hookHash)
+                {
+                    requestedHash = true;
+                    break;
+                }
+            }
+            if (!requestedHash)
+                continue;
+        }
+        //@@end named-hooks-aaw-exact-replay
+
+        //@@start named-hooks-aaw-selector-gate
+        // honor the transaction's hook-name selector(s) on replay too, so a
+        // selected hook's "execute again as weak" request cannot replay an
+        // unselected slot that merely shares the same hook hash under a
+        // different name (featureNamedHooks; inert pre-amendment as no hook can
+        // be named)
+        if (namedHooks && !txSelectsHook(hookObj, ctx_.tx))
             continue;
+        //@@end named-hooks-aaw-selector-gate
 
         auto const& hookDef = view().peek(keylet::hookDefinition(hookHash));
         if (!hookDef)
@@ -1967,10 +2187,11 @@ Transactor::operator()()
 
     bool const hooksEnabled = view().rules().enabled(featureHooks);
 
-    // AgainAsWeak map stores information about accounts whose strongly executed
-    // hooks request an additional weak execution after the otxn has finished
-    // application to the ledger
-    std::map<AccountID, std::set<uint256>> aawMap;
+    // AgainAsWeak records the exact hook slot and hash that requested replay so
+    // featureNamedHooks can disambiguate duplicate-hash slots. Before that
+    // amendment is enabled, doAgainAsWeak deliberately falls back to the
+    // historical hash-only replay rule.
+    std::map<AccountID, std::set<std::pair<uint8_t, uint256>>> aawMap;
 
     std::vector<std::pair<AccountID, bool>> tsh =
         hook::getTransactionalStakeHolders(ctx_.tx, ctx_.view());
@@ -2027,9 +2248,11 @@ Transactor::operator()()
             if (hookResult.executeAgainAsWeak)
             {
                 if (aawMap.find(hookResult.account) == aawMap.end())
-                    aawMap[hookResult.account] = {hookResult.hookHash};
+                    aawMap[hookResult.account] = {
+                        {hookResult.hookChainPosition, hookResult.hookHash}};
                 else
-                    aawMap[hookResult.account].emplace(hookResult.hookHash);
+                    aawMap[hookResult.account].emplace(
+                        hookResult.hookChainPosition, hookResult.hookHash);
             }
         }
     }
@@ -2390,8 +2613,9 @@ Transactor::operator()()
         doTSH(false, tsh, stateMap, weakResults, proMeta);
 
         // execute any hooks that nominated for 'again as weak'
-        for (auto const& [accID, hookHashes] : aawMap)
-            doAgainAsWeak(accID, hookHashes, stateMap, weakResults, proMeta);
+        for (auto const& [accID, requestedHooks] : aawMap)
+            doAgainAsWeak(
+                accID, requestedHooks, stateMap, weakResults, proMeta);
 
         // write hook results
         hook::finalizeHookState(stateMap, ctx_, ctx_.tx.getTransactionID());

--- a/src/xrpld/app/tx/detail/Transactor.h
+++ b/src/xrpld/app/tx/detail/Transactor.h
@@ -27,6 +27,8 @@
 #include <xrpld/ledger/detail/ApplyViewBase.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/protocol/XRPAmount.h>
+#include <set>
+#include <utility>
 #include <variant>
 
 namespace ripple {
@@ -200,7 +202,7 @@ protected:
     void
     doAgainAsWeak(
         AccountID const& hookAccountID,
-        std::set<uint256> const& hookHashes,
+        std::set<std::pair<uint8_t, uint256>> const& requestedHooks,
         hook::HookStateMap& stateMap,
         std::vector<hook::HookResult>& results,
         std::shared_ptr<STObject const> const& provisionalMeta);
@@ -276,6 +278,11 @@ private:
 /** Performs early sanity checks on the txid */
 NotTEC
 preflight0(PreflightContext const& ctx);
+
+NotTEC
+validateHookSelectors(
+    PreflightContext const& ctx,
+    bool allowLegacyHookName = false);
 
 /** Performs early sanity checks on the account and fee fields */
 NotTEC


### PR DESCRIPTION
<!--
rendered_from: pr-description.md.j2
rendered_at: 2026-06-26T06:39:12Z
branch: chrische-named-hooks-enhancements
commit: 3a4c1dd05
commit_message: feat: extend namedhooks with multi-name and cron-targeted selectors
-->

---

<sub>Last updated: 2026-06-26 | branch: chrische-named-hooks-enhancements | commit: 3a4c1dd05 (feat: extend namedhooks with multi-name and cron-targeted selectors)</sub>

---


# NamedHooks selectors: multi-name trigger support and cron-targeted hooks

## Source inspiration

> chrische - Yesterday at 2:22 PM
>
> I am surprised that new features on Xahau are always shipped immediately as
> amendments without any prior discussion to take potential user demands into
> account. Here are my Questions for NamedHooks:
>
> I like the concept of NamedHooks.
>
> Can the triggering transaction also contain an array with more than one
> HookName? This could helpful if the caller what to trigger more than one
> NamedHook with one transaction.
>
> Can the Cron pseudo-transactions also carry a HookName or an array of HookNames
> that is passed via the CronSet transaction? This could, for example, be helpful
> for the Reward Auto Claim Hook. XAH Teleport would then finally work again,
> since the transfer would not consume a hook fee.

This PR implements both requests under the existing `featureNamedHooks`
amendment:

1. `HookNames`: a transaction-level array selector that can trigger multiple
   named hooks in one transaction.
2. Cron-carried named-hook selectors: `CronSet` can persist `HookName` or
   `HookNames`, and the validator-injected, zero-fee `ttCRON`
   pseudo-transaction carries the same selector to the owner hook chain.

<!-- marker: reviewer-start-here -->

## Feature guide

### 1. Trigger multiple named hooks from one transaction

Transactions may now carry:

```json
{
  "TransactionType": "Invoke",
  "Account": "...",
  "HookNames": [
    { "NamedHook": { "HookName": "41414141" } },
    { "NamedHook": { "HookName": "42424242" } }
  ]
}
```

Rules:

- `HookName` and `HookNames` are mutually exclusive.
- `HookNames` must be a non-empty `STArray` of canonical `NamedHook` objects.
- Each `NamedHook` must contain a non-empty, valid `HookName`.
- Duplicate selectors are malformed.
- The array is capped by `hook::maxNamedHookSelectors()` (currently 32).
- Unnamed hooks still run as before.
- During normal strong/weak hook-chain execution, named hooks only run when
  their name is explicitly selected.

### 2. Target named hooks from Cron

`CronSet` may now carry either selector form:

```json
{
  "TransactionType": "CronSet",
  "Account": "...",
  "StartTime": 123456789,
  "HookNames": [
    { "NamedHook": { "HookName": "52455744" } },
    { "NamedHook": { "HookName": "58414854" } }
  ]
}
```

For set operations, the selector is stored on the `ltCRON` object, copied onto
the validator-injected `ttCRON` pseudo-transaction, and carried forward across
recurrences. This lets a cron run specific named hooks on the owner without
requiring a separate triggering transfer whose purpose is only to enter the hook
chain.

### 3. Compatibility notes

- This is folded into `featureNamedHooks`, not a new `NamedHooksV2` amendment,
  because `featureNamedHooks` has not activated.
- A release containing the old `featureNamedHooks` semantics has shipped, so old
  binaries may still advertise support for the amendment. Operationally, do not
  activate `featureNamedHooks` on a network until the intended validator set has
  upgraded to a binary containing this change.
- The Cron/callback/again-as-weak hardening in this PR is also gated behind
  `featureNamedHooks` where it changes deterministic ledger output. Before the
  amendment is enabled, the new binary preserves the released Cron pseudo-txn
  shape and legacy duplicate-hash hook replay behavior.
- `Cron` remains a weak/collect TSH flow. A cron-targeted hook still needs the
  existing collect semantics (`hsfCOLLECT`) to run from the Cron pseudo-txn.

## User-visible behavior

| Scenario | Result |
|---|---|
| Tx has no selector | Unnamed hooks run; named hooks do not run |
| Tx has `HookName: "AAAA"` | Unnamed hooks and named hook `AAAA` run |
| Tx has `HookNames: ["AAAA", "BBBB"]` | Unnamed hooks plus named hooks `AAAA` and `BBBB` run |
| Tx has non-matching selector | Unnamed hooks run; non-matching named hooks do not |
| CronSet set operation has `HookName` or `HookNames` | Selector persists to `ltCRON`, emitted `ttCRON`, and recurrences |
| CronSet unset operation has `HookName` or `HookNames` | Selector applies only to the unset transaction's own hook chain; nothing is persisted |
| Callback execution | Uses emit callback metadata; it does not require selector fields on the callback transaction |
| `featureNamedHooks` disabled | Selector fields are malformed |

## Guided code review

<details>
<summary>1. Protocol surface: fields, array wrapper, transaction formats</summary>

### New selector fields

`sfHookName` already existed. This change adds `sfHookNames` as the array
selector and `sfNamedHook` as the canonical inner-object wrapper.

📍 [`include/xrpl/protocol/detail/sfields.macro:292-296`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/include/xrpl/protocol/detail/sfields.macro#L292-L296)
```cpp
 292 TYPED_SFIELD(sfAssetClass,               VL,        29)
 293 TYPED_SFIELD(sfProvider,                 VL,        30)
 294 TYPED_SFIELD(sfMPTokenMetadata,          VL,        31)
 295 TYPED_SFIELD(sfCredentialType,           VL,        32)
 296 TYPED_SFIELD(sfHookName,                 VL,        97)
```

📍 [`include/xrpl/protocol/detail/sfields.macro:388-394`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/include/xrpl/protocol/detail/sfields.macro#L388-L394)
```cpp
 388 UNTYPED_SFIELD(sfImportVLKey,            OBJECT,    94)
 389 UNTYPED_SFIELD(sfActiveValidator,        OBJECT,    95)
 390 UNTYPED_SFIELD(sfGenesisMint,            OBJECT,    96)
 391 UNTYPED_SFIELD(sfRemark,                 OBJECT,    97)
 392 UNTYPED_SFIELD(sfHighReward,             OBJECT,    98)
 393 UNTYPED_SFIELD(sfLowReward,              OBJECT,    99)
 394 UNTYPED_SFIELD(sfNamedHook,              OBJECT,   100)
```

📍 [`include/xrpl/protocol/detail/sfields.macro:426-431`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/include/xrpl/protocol/detail/sfields.macro#L426-L431)
```cpp
 426 UNTYPED_SFIELD(sfHookEmissions,          ARRAY,     93)
 427 UNTYPED_SFIELD(sfImportVLKeys,           ARRAY,     94)
 428 UNTYPED_SFIELD(sfActiveValidators,       ARRAY,     95)
 429 UNTYPED_SFIELD(sfGenesisMints,           ARRAY,     96)
 430 UNTYPED_SFIELD(sfRemarks,                ARRAY,     97)
 431 UNTYPED_SFIELD(sfHookNames,              ARRAY,     98)
```

### Canonical `NamedHook` object

Each `HookNames` array entry must be a `NamedHook` object containing exactly the
named-hook selector field expected by validation.

📍 [`src/libxrpl/protocol/InnerObjectFormats.cpp:111-113`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/libxrpl/protocol/InnerObjectFormats.cpp#L111-L113)
```cpp
 111     add(sfNamedHook.jsonName,
 112         sfNamedHook.getCode(),
 113         {{sfHookName, soeREQUIRED}});
```

### Common transaction selector fields

The selector fields are common transaction fields so they can gate any
transaction's hook execution, matching the existing single `HookName` behavior.

📍 [`src/libxrpl/protocol/TxFormats.cpp:34-53`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/libxrpl/protocol/TxFormats.cpp#L34-L53)
```cpp
  34         {sfSourceTag, soeOPTIONAL},
  35         {sfAccount, soeREQUIRED},
  36         {sfSequence, soeREQUIRED},
  37         {sfPreviousTxnID, soeOPTIONAL},  // emulate027
  38         {sfLastLedgerSequence, soeOPTIONAL},
  39         {sfAccountTxnID, soeOPTIONAL},
  40         {sfFee, soeREQUIRED},
  41         {sfOperationLimit, soeOPTIONAL},
  42         {sfMemos, soeOPTIONAL},
  43         {sfSigningPubKey, soeREQUIRED},
  44         {sfTicketSequence, soeOPTIONAL},
  45         {sfTxnSignature, soeOPTIONAL},
  46         {sfSigners, soeOPTIONAL},  // submit_multisigned
  47         {sfEmitDetails, soeOPTIONAL},
  48         {sfFirstLedgerSequence, soeOPTIONAL},
  49         {sfNetworkID, soeOPTIONAL},
  50         {sfHookParameters, soeOPTIONAL},
  51         {sfHookName, soeOPTIONAL},
  52         {sfHookNames, soeOPTIONAL},
  53     };
```

### Cron object and pseudo-transaction shape

`ltCRON` stores the selector. `ttCRON` can carry `sfCron`, but that field stays
optional in the static transaction format because the binding is only emitted
and enforced after `featureNamedHooks` is enabled. This keeps pre-amendment Cron
pseudo-transaction bytes compatible with the released binary.

📍 [`include/xrpl/protocol/detail/ledger_entries.macro:61-70`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/include/xrpl/protocol/detail/ledger_entries.macro#L61-L70)
```cpp
  61 LEDGER_ENTRY_DUPLICATE(ltCRON, 0x0041, Cron, cron, ({
  62     {sfOwner,                soeREQUIRED},
  63     {sfStartTime,            soeREQUIRED},
  64     {sfDelaySeconds,         soeREQUIRED},
  65     {sfRepeatCount,          soeREQUIRED},
  66     {sfOwnerNode,            soeREQUIRED},
  67     {sfPreviousTxnID,        soeREQUIRED},
  68     {sfPreviousTxnLgrSeq,    soeREQUIRED},
  69     {sfHookName,             soeOPTIONAL},
  70     {sfHookNames,            soeOPTIONAL},
```

📍 [`include/xrpl/protocol/detail/transactions.macro:503-509`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/include/xrpl/protocol/detail/transactions.macro#L503-L509)
```cpp
 503 /* A pseudo-txn alarm signal for invoking a hook, emitted by validators after alarm set conditions are met.
 504    The optional sfHookName / sfHookNames selector(s) it carries come from the common transaction fields. */
 505 TRANSACTION(ttCRON, 92, Cron, ({
 506     {sfOwner, soeREQUIRED},
 507     {sfLedgerSequence, soeREQUIRED},
 508     {sfCron, soeOPTIONAL},
 509 }))
```

</details>

<details>
<summary>2. Selector validation and match semantics</summary>

The hook selection rule is shared by fee calculation and execution, so fees
match the hooks that actually run.

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:70-96`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L70-L96)
```cpp
  70 static bool
  71 txSelectsHook(STObject const& hookObj, STTx const& tx)
  72 {
  73     if (!hookObj.isFieldPresent(sfHookName))
  74         return true;
  75 
  76     Blob const required = hookObj.getFieldVL(sfHookName);
  77     if (required.empty())
  78         return true;
  79 
  80     if (tx.isFieldPresent(sfHookNames))
  81     {
  82         for (auto const& entry : tx.getFieldArray(sfHookNames))
  83         {
  84             if (entry.getFName() == sfNamedHook &&
  85                 entry.isFieldPresent(sfHookName) &&
  86                 entry.getFieldVL(sfHookName) == required)
  87                 return true;
  88         }
  89         return false;
  90     }
  91 
  92     if (tx.isFieldPresent(sfHookName))
  93         return tx.getFieldVL(sfHookName) == required;
  94 
  95     return false;
  96 }
```

Validation is centralized and runs before the emitted-transaction shortcut; Cron
pseudo-transactions call the same helper.

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:143-205`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L143-L205)
```cpp
 143 NotTEC
 144 validateHookSelectors(PreflightContext const& ctx, bool allowLegacyHookName)
 145 {
 146     if (ctx.tx.isFieldPresent(sfHookName))
 147     {
 148         if (!ctx.rules.enabled(featureHooks))
 149             return temMALFORMED;
 150 
 151         if (!ctx.rules.enabled(featureNamedHooks))
 152         {
 153             // Some pre-amendment paths (notably emitted transactions and
 154             // pseudo-transactions) historically accepted the legacy single
 155             // sfHookName field because they did not run this validation.
 156             // Preserve that behavior where callers opt in. The new sfHookNames
 157             // array remains rejected below unless featureNamedHooks is enabled.
 158             if (!allowLegacyHookName)
 159                 return temMALFORMED;
 160         }
 161 
 162         if (ctx.rules.enabled(featureNamedHooks) &&
 163             !SetHook::validateHookName(ctx.tx.getFieldVL(sfHookName), ctx.j))
 164             return temMALFORMED;
 165     }
 166 
 167     if (ctx.tx.isFieldPresent(sfHookNames))
 168     {
 169         if (!ctx.rules.enabled(featureHooks) ||
 170             !ctx.rules.enabled(featureNamedHooks))
 171             return temMALFORMED;
 172 
 173         // sfHookName (single selector) and sfHookNames (array selector) are
 174         // mutually exclusive
 175         if (ctx.tx.isFieldPresent(sfHookName))
 176             return temMALFORMED;
 177 
 178         auto const& names = ctx.tx.getFieldArray(sfHookNames);
 179         if (names.empty() || names.size() > hook::maxNamedHookSelectors())
 180             return temMALFORMED;
 181 
 182         std::set<Blob> seen;
 183         for (auto const& entry : names)
 184         {
 185             // each entry must be a canonical sfNamedHook wrapper, not some
 186             // other inner object that merely happens to carry sfHookName
 187             if (entry.getFName() != sfNamedHook)
 188                 return temMALFORMED;
 189 
 190             if (!entry.isFieldPresent(sfHookName))
 191                 return temMALFORMED;
 192 
 193             Blob const name = entry.getFieldVL(sfHookName);
 194 
 195             // an empty name is "unnamed" and is meaningless as a selector
 196             if (name.empty() || !SetHook::validateHookName(name, ctx.j))
 197                 return temMALFORMED;
 198 
 199             if (!seen.insert(name).second)
 200                 return temMALFORMED;  // duplicate selector
 201         }
 202     }
 203 
 204     return tesSUCCESS;
 205 }
```

The selector cap is deliberately small because cron can re-emit the selector on
each recurrence.

📍 [`include/xrpl/hook/Enum.h:125-129`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/include/xrpl/hook/Enum.h#L125-L129)
```cpp
 125 inline uint32_t
 126 maxNamedHookSelectors(void)
 127 {
 128     return 32;
 129 }
```

</details>

<details>
<summary>3. Fee identity: selected hooks are the charged hooks</summary>

`calculateHookChainFee` consults the same selector predicate as hook execution.
This preserves the key invariant: a transaction pays for the hook set that can
run, rather than for a broader or narrower set.

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:399-401`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L399-L401)
```cpp
 399         // skip hooks not selected by the transaction's hook-name selector(s)
 400         if (!txSelectsHook(hookObj, tx))
 401             continue;
```

Execution uses the same predicate before applying each hook in the chain.

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:1462-1464`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L1462-L1464)
```cpp
1462         // skip hooks not selected by the transaction's hook-name selector(s)
1463         if (!txSelectsHook(hookObj, ctx_.tx))
1464             continue;
```

</details>

<details>
<summary>4. Cron plumbing: CronSet -> ltCRON -> ttCRON -> recurrence</summary>

`CronSet` accepts normal selector fields as transaction selectors, then persists
non-empty selectors onto the cron object when `featureNamedHooks` is enabled.
The first comment is the gotcha: selectors on `CronSet` still select hooks for
the `CronSet` transaction itself, and may also become the cron's persisted
selector.

📍 [`src/xrpld/app/tx/detail/CronSet.cpp:68-74`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/CronSet.cpp#L68-L74)
```cpp
  68     // Note: sfHookName / sfHookNames are common transaction selectors,
  69     // validated by preflight1 (which requires featureNamedHooks). On a CronSet
  70     // they additionally serve as the selector persisted on the cron object (and
  71     // carried by the emitted Cron pseudo-txn), gated in doApply. They are
  72     // deliberately NOT rejected here: a CronSet (or a tfCronUnset) may carry
  73     // sfHookName purely to select named hooks on its own hook chain, exactly as
  74     // for any other transaction.
```

📍 [`src/xrpld/app/tx/detail/CronSet.cpp:282-295`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/CronSet.cpp#L282-L295)
```cpp
 282     // persist the optional named-hook selector(s) on the cron so the emitted
 283     // Cron pseudo-txn triggers the selected named hook(s) on the owner
 284     // (featureNamedHooks).
 285     if (view.rules().enabled(featureNamedHooks))
 286     {
 287         if (tx.isFieldPresent(sfHookName))
 288         {
 289             Blob const hookName = tx.getFieldVL(sfHookName);
 290             if (!hookName.empty())
 291                 sleCron->setFieldVL(sfHookName, hookName);
 292         }
 293         if (tx.isFieldPresent(sfHookNames))
 294             sleCron->setFieldArray(sfHookNames, tx.getFieldArray(sfHookNames));
 295     }
```

`TxQ` scans due cron objects. Before `featureNamedHooks`, it preserves the
legacy owner-ping behavior. After `featureNamedHooks`, it verifies the owner
still points at that cron before copying selectors onto the emitted
pseudo-transaction. The scan-window comment is intentional: changing stale/orphan
cron scan accounting is a separate Cron scheduler concern, not part of this
named-hook selector amendment.

📍 [`src/xrpld/app/misc/detail/TxQ.cpp:1516-1566`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/misc/detail/TxQ.cpp#L1516-L1566)
```cpp
1516         // owner account -> its cron ledger object (there is at most one cron
1517         // per account). The SLE is retained so any named-hook selector(s) it
1518         // carries can be copied onto the emitted Cron pseudo-txn.
1519         std::map<AccountID, std::shared_ptr<SLE const>> cronAccs;
1520 
1521         auto counter = 0;
1522         // include max 128 cron txns in the ledger
1523         while (++counter < 129 && klStart < klEnd)
1524         {
1525             std::optional<uint256 const> next = view.succ(klStart, klEnd);
1526             if (!next.has_value())
1527                 break;
1528 
1529             Keylet kl{ltANY, *next};
1530 
1531             if (view.exists(kl))
1532             {
1533                 auto sle = view.read(kl);
1534                 if (safe_cast<LedgerEntryType>(
1535                         sle->getFieldU16(sfLedgerEntryType)) == ltCRON)
1536                 {
1537                     AccountID const owner = sle->getAccountID(sfOwner);
1538 
1539                     if (!namedHooks)
1540                     {
1541                         // Preserve the pre-NamedHooks Cron scheduler output:
1542                         // every due ltCRON owner is pinged, even if a stale or
1543                         // orphan object is encountered in the scan window.
1544                         cronAccs.emplace(owner, sle);
1545                     }
1546                     else
1547                     {
1548                         // Only the account's current cron pointer is
1549                         // authoritative once the selector amendment needs the
1550                         // cron object for pseudo-txn field copying.
1551                         // Stale/orphan entries still consume this scan loop's
1552                         // 128-key budget; changing that accounting is a broader
1553                         // Cron scheduler behavior change and is intentionally
1554                         // left out here.
1555                         auto const accountSle =
1556                             view.read(keylet::account(owner));
1557                         if (accountSle && accountSle->isFieldPresent(sfCron) &&
1558                             accountSle->getFieldH256(sfCron) == sle->key())
1559                         {
1560                             cronAccs.emplace(owner, sle);
1561                         }
1562                     }
1563                 }
1564             }
1565             klStart = *next;
1566         }
```

📍 [`src/xrpld/app/misc/detail/TxQ.cpp:1581-1599`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/misc/detail/TxQ.cpp#L1581-L1599)
```cpp
1581                 if (namedHooks)
1582                 {
1583                     // Bind the pseudo-txn to the exact cron object found during
1584                     // TxQ scheduling. Cron::doApply treats this as stale if the
1585                     // owner replaced or removed the cron before the pseudo
1586                     // applies.
1587                     obj[sfCron] = cronSle->key();
1588 
1589                     // carry the cron's named-hook selector(s), if any, so the
1590                     // pseudo-txn triggers the selected named hook(s) on the
1591                     // owner (in addition to the owner's unnamed hooks, as
1592                     // always)
1593                     if (cronSle->isFieldPresent(sfHookName))
1594                         obj.setFieldVL(
1595                             sfHookName, cronSle->getFieldVL(sfHookName));
1596                     if (cronSle->isFieldPresent(sfHookNames))
1597                         obj.setFieldArray(
1598                             sfHookNames, cronSle->getFieldArray(sfHookNames));
1599                 }
```

`Cron::preflight` validates selector shape and, after `featureNamedHooks`, also
requires the pseudo to identify the exact cron object through `sfCron`.

📍 [`src/xrpld/app/tx/detail/Cron.cpp:53-55`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Cron.cpp#L53-L55)
```cpp
  53     auto const selectors = validateHookSelectors(ctx, true);
  54     if (!isTesSuccess(selectors))
  55         return selectors;
```

📍 [`src/xrpld/app/tx/detail/Cron.cpp:88-94`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Cron.cpp#L88-L94)
```cpp
  88     if (namedHooks &&
  89         (!ctx.tx.isFieldPresent(sfCron) ||
  90          ctx.tx.getFieldH256(sfCron) == beast::zero))
  91     {
  92         JLOG(ctx.j.warn()) << "Cron: Missing cron object";
  93         return temMALFORMED;
  94     }
```

`Cron::doApply` no-ops stale `sfCron`-bound pseudos after `featureNamedHooks`,
captures selectors before deleting the old object, and carries them forward to
the recreated cron on recurrence.

📍 [`src/xrpld/app/tx/detail/Cron.cpp:149-159`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Cron.cpp#L149-L159)
```cpp
 149     uint256 ptr = sle->getFieldH256(sfCron);
 150     // The Cron pseudo-txn is scheduled against a specific ltCRON object. If
 151     // the owner replaced or removed that object earlier in this ledger, this
 152     // pseudo is stale and must not execute the owner's new cron with the old
 153     // pseudo's selector fields.
 154     if (namedHooks && tx.isFieldPresent(sfCron) &&
 155         ptr != tx.getFieldH256(sfCron))
 156     {
 157         JLOG(j_.warn()) << "Cron: stale cron pseudo for account " << id;
 158         return tesSUCCESS;
 159     }
```

📍 [`src/xrpld/app/tx/detail/Cron.cpp:176-186`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Cron.cpp#L176-L186)
```cpp
 176     // capture the named-hook selector(s) (if any) before the object is erased,
 177     // so they persist across recurring executions (featureNamedHooks)
 178     std::optional<Blob> hookName;
 179     std::optional<STArray> hookNames;
 180     if (namedHooks)
 181     {
 182         if (sleCron->isFieldPresent(sfHookName))
 183             hookName = sleCron->getFieldVL(sfHookName);
 184         if (sleCron->isFieldPresent(sfHookNames))
 185             hookNames = sleCron->getFieldArray(sfHookNames);
 186     }
```

📍 [`src/xrpld/app/tx/detail/Cron.cpp:233-237`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Cron.cpp#L233-L237)
```cpp
 233     // carry the named-hook selector(s) forward to the next execution
 234     if (hookName)
 235         sleCron->setFieldVL(sfHookName, *hookName);
 236     if (hookNames)
 237         sleCron->setFieldArray(sfHookNames, *hookNames);
```

</details>

<details>
<summary>5. Adversarial hardening from review</summary>

### Consensus boundary for hardening

The review found real correctness hardening opportunities, but some of them
would fork mixed binaries if they changed deterministic ledger output before the
NamedHooks amendment. The code therefore gates the output-changing pieces behind
`featureNamedHooks`:

- `ttCRON` only carries `sfCron` after the amendment.
- TxQ's authoritative cron-pointer filter only applies after the amendment.
- `Cron::doApply` only treats an `sfCron` mismatch as a stale pseudo after the
  amendment.
- Callback slot filtering and again-as-weak exact replay only narrow duplicate
  same-hash behavior after the amendment.

### Callback slot recovery

Callbacks used to identify the callback hook by hook hash. With named hooks, the
same code hash can be installed in multiple named slots. The emitted nonce
encodes the hook-chain position, so after `featureNamedHooks` callback dispatch
recovers the emitting slot. The position is only used to disambiguate when more
than one slot carries the hash; an unambiguous (single-match) callback is still
delivered even if the hook was relocated to a different chain index within the
transaction. Before the amendment, duplicate-hash callback behavior remains
legacy-compatible.

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:1581-1618`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L1581-L1618)
```cpp
1581 static std::optional<uint8_t>
1582 callbackHookChainPosition(
1583     STObject const& emitDetails,
1584     AccountID const& callbackAccountID,
1585     uint256 const& callbackHookHash)
1586 {
1587     if (!emitDetails.isFieldPresent(sfEmitNonce) ||
1588         !emitDetails.isFieldPresent(sfEmitParentTxnID))
1589         return std::nullopt;
1590 
1591     auto const expectedNonce = emitDetails.getFieldH256(sfEmitNonce);
1592     auto const parentTxnID = emitDetails.getFieldH256(sfEmitParentTxnID);
1593 
1594     for (uint8_t position = 0; position < hook::maxHookChainLength();
1595          ++position)
1596     {
1597         // etxn_nonce hashes the uint16_t emit_nonce_counter; hash_append
1598         // includes integral width, so a uint32_t with the same value will not
1599         // match.
1600         for (uint16_t nonce = 0; nonce <= hook_api::max_nonce; ++nonce)
1601         {
1602             for (uint32_t flags = 0; flags < 4; ++flags)
1603             {
1604                 auto const candidate = sha512Half(
1605                     HashPrefix::emitTxnNonce,
1606                     parentTxnID,
1607                     nonce,
1608                     callbackAccountID,
1609                     callbackHookHash,
1610                     (static_cast<uint32_t>(position) << 2U) | flags);
1611                 if (candidate == expectedNonce)
1612                     return position;
1613             }
1614         }
1615     }
1616 
1617     return std::nullopt;
1618 }
```

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:1708-1713`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L1708-L1713)
```cpp
1708         // Only disambiguate by emit position when more than one slot carries
1709         // the hash; an unambiguous callback is otherwise delivered even after a
1710         // benign hook relocation within this transaction.
1711         if (namedHooks && callbackPosition && callbackHashSlots > 1 &&
1712             *callbackPosition != hook_no - 1)
1713             continue;
```

### Again-as-weak exact replay identity

Again-as-weak replay records both hook-chain position and hook hash. Hash alone
is not enough when the same code is installed under multiple names, so the exact
`{position, hash}` pair is matched first. Because position is not stable across a
same-transaction `SetHook` update, replay falls back to hash matching when the
hash is unambiguous (a single requesting slot and a single current slot), so a
benign self-relocation does not drop the replay; genuinely ambiguous duplicate-
hash cases still require the exact position. Before `featureNamedHooks`, replay
deliberately uses the legacy hash-only behavior.

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:2018-2057`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L2018-L2057)
```cpp
2018         if (namedHooks)
2019         {
2020             bool matched = requestedHooks.find({hook_no - 1, hookHash}) !=
2021                 requestedHooks.end();
2022             if (!matched)
2023             {
2024                 // Exact {position, hash} failed: fall back to hash matching
2025                 // only when this hash is unambiguous in both the requested set
2026                 // and the current chain (a single requesting slot whose index
2027                 // merely shifted within this same transaction). Ambiguous
2028                 // duplicate-hash cases still require the exact position.
2029                 std::size_t reqForHash = 0;
2030                 for (auto const& requestedHook : requestedHooks)
2031                     if (requestedHook.second == hookHash)
2032                         ++reqForHash;
2033                 std::size_t curForHash = 0;
2034                 for (auto const& other : hooks)
2035                     if (other.isFieldPresent(sfHookHash) &&
2036                         other.getFieldH256(sfHookHash) == hookHash)
2037                         ++curForHash;
2038                 if (reqForHash == 1 && curForHash == 1)
2039                     matched = true;
2040             }
2041             if (!matched)
2042                 continue;
2043         }
2044         else
2045         {
2046             bool requestedHash = false;
2047             for (auto const& requestedHook : requestedHooks)
2048             {
2049                 if (requestedHook.second == hookHash)
2050                 {
2051                     requestedHash = true;
2052                     break;
2053                 }
2054             }
2055             if (!requestedHash)
2056                 continue;
2057         }
```

📍 [`src/xrpld/app/tx/detail/Transactor.cpp:2061-2067`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/xrpld/app/tx/detail/Transactor.cpp#L2061-L2067)
```cpp
2061         // honor the transaction's hook-name selector(s) on replay too, so a
2062         // selected hook's "execute again as weak" request cannot replay an
2063         // unselected slot that merely shares the same hook hash under a
2064         // different name (featureNamedHooks; inert pre-amendment as no hook can
2065         // be named)
2066         if (namedHooks && !txSelectsHook(hookObj, ctx_.tx))
2067             continue;
```

</details>

<details>
<summary>6. Tests worth reading</summary>

`SetHook_test` covers multi-name selector execution, selector validation, fee
identity, weak/collect selection, cron-targeted named hooks, and recurring cron
array execution.

📍 [`src/test/app/SetHook_test.cpp:2230-2262`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/test/app/SetHook_test.cpp#L2230-L2262)
```cpp
2230             // Array with one name: only that hook fires
2231             {
2232                 auto jv = invoke::invoke(alice);
2233                 jv[jss::HookNames] = hookNamesArray({"41414141"});
2234                 env(jv, M("array selects AAAA only"), HSFEE);
2235                 env.close();
2236                 auto const ex = env.meta()->getFieldArray(sfHookExecutions);
2237                 BEAST_EXPECT(ex.size() == 1);
2238                 BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept_hash);
2239             }
2240 
2241             // Array with the other name
2242             {
2243                 auto jv = invoke::invoke(alice);
2244                 jv[jss::HookNames] = hookNamesArray({"42424242"});
2245                 env(jv, M("array selects BBBB only"), HSFEE);
2246                 env.close();
2247                 auto const ex = env.meta()->getFieldArray(sfHookExecutions);
2248                 BEAST_EXPECT(ex.size() == 1);
2249                 BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept2_hash);
2250             }
2251 
2252             // Array with both names: both hooks fire (in install order)
2253             {
2254                 auto jv = invoke::invoke(alice);
2255                 jv[jss::HookNames] = hookNamesArray({"41414141", "42424242"});
2256                 env(jv, M("array selects both AAAA and BBBB"), HSFEE);
2257                 env.close();
2258                 auto const ex = env.meta()->getFieldArray(sfHookExecutions);
2259                 BEAST_EXPECT(ex.size() == 2);
2260                 BEAST_EXPECT(ex[0].getFieldH256(sfHookHash) == accept_hash);
2261                 BEAST_EXPECT(ex[1].getFieldH256(sfHookHash) == accept2_hash);
2262             }
```

📍 [`src/test/app/SetHook_test.cpp:2277-2303`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/test/app/SetHook_test.cpp#L2277-L2303)
```cpp
2277             // The fee gate uses the same selector logic as execution, so the
2278             // per-hook cost is additive: fee(both) - fee(none) == the sum of
2279             // each hook's individual incremental cost.
2280             {
2281                 auto feeFor = [&](Json::Value const& jv) {
2282                     return calculateBaseFee(*env.current(), *env.jt(jv).stx);
2283                 };
2284                 auto jvNone = invoke::invoke(alice);
2285                 auto jvA = invoke::invoke(alice);
2286                 jvA[jss::HookNames] = hookNamesArray({"41414141"});
2287                 auto jvB = invoke::invoke(alice);
2288                 jvB[jss::HookNames] = hookNamesArray({"42424242"});
2289                 auto jvBoth = invoke::invoke(alice);
2290                 jvBoth[jss::HookNames] =
2291                     hookNamesArray({"41414141", "42424242"});
2292                 BEAST_EXPECT(feeFor(jvA) > feeFor(jvNone));
2293                 BEAST_EXPECT(feeFor(jvB) > feeFor(jvNone));
2294                 BEAST_EXPECT(feeFor(jvBoth) > feeFor(jvA));
2295                 BEAST_EXPECT(
2296                     feeFor(jvBoth) + feeFor(jvNone) ==
2297                     feeFor(jvA) + feeFor(jvB));
2298                 // a selector matching no installed hook costs the same as no
2299                 // selector at all
2300                 auto jvNon = invoke::invoke(alice);
2301                 jvNon[jss::HookNames] = hookNamesArray({"5A5A5A5A"});
2302                 BEAST_EXPECT(feeFor(jvNon) == feeFor(jvNone));
2303             }
```

📍 [`src/test/app/SetHook_test.cpp:2539-2599`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/test/app/SetHook_test.cpp#L2539-L2599)
```cpp
2539         // A recurring cron carrying HookNames keeps firing both selected named
2540         // hooks on every recurrence
2541         {
2542             auto const dave = Account{"dave"};
2543             Env env{*this, features};
2544             env.fund(XRP(10000), dave);
2545             env.close();
2546 
2547             auto jvh = hso(accept_wasm);
2548             jvh[jss::HookName] = "41414141";
2549             jvh[jss::Flags] = hsfCOLLECT;
2550             auto jvh2 = hso(accept2_wasm);
2551             jvh2[jss::HookName] = "42424242";
2552             jvh2[jss::Flags] = hsfCOLLECT;
2553             env(ripple::test::jtx::hook(dave, {{jvh, jvh2}}, 0),
2554                 M("install recurring named cron hooks"),
2555                 HSFEE);
2556             env.close();
2557             env(fset(dave, asfTshCollect), fee(XRP(1)));
2558             env.close();
2559 
2560             auto const baseTime =
2561                 env.current()->parentCloseTime().time_since_epoch().count();
2562             Json::Value cs;
2563             cs[jss::TransactionType] = jss::CronSet;
2564             cs[jss::Account] = dave.human();
2565             cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
2566             cs[sfDelaySeconds.jsonName] = 100;
2567             cs[sfRepeatCount.jsonName] = 2;  // fires 3 times in total
2568             cs[jss::HookNames] = hookNamesArray({"41414141", "42424242"});
2569             env(cs, fee(XRP(1)), ter(tesSUCCESS));
2570             env.close(10s);
2571 
2572             int firings = 0;
2573             int firstNamedExecutions = 0;
2574             int secondNamedExecutions = 0;
2575             for (int i = 0; i < 100 && firings < 3; ++i)
2576             {
2577                 env.close(10s);
2578                 auto const& txs = env.closed()->txs;
2579                 for (auto it = txs.begin(); it != txs.end(); ++it)
2580                 {
2581                     if (it->first->getTxnType() != ttCRON)
2582                         continue;
2583                     ++firings;
2584                     if (it->second &&
2585                         it->second->isFieldPresent(sfHookExecutions))
2586                         for (auto const& e :
2587                              it->second->getFieldArray(sfHookExecutions))
2588                         {
2589                             if (e.getFieldH256(sfHookHash) == accept_hash)
2590                                 ++firstNamedExecutions;
2591                             if (e.getFieldH256(sfHookHash) == accept2_hash)
2592                                 ++secondNamedExecutions;
2593                         }
2594                 }
2595             }
2596             BEAST_EXPECT(firings == 3);
2597             BEAST_EXPECT(firstNamedExecutions == 3);
2598             BEAST_EXPECT(secondNamedExecutions == 3);
2599         }
```

`Cron_test` covers cron object storage, amendment-off gating, emitted pseudo
selector carry, recurrence persistence, malformed arrays, and empty single-name
normalization.

📍 [`src/test/app/Cron_test.cpp:518-532`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/test/app/Cron_test.cpp#L518-L532)
```cpp
 518             // HookNames array stored on the cron object
 519             {
 520                 auto cs = cron::set(alice);
 521                 cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
 522                 cs[jss::HookNames] = namesArray({"41424344", "41424345"});
 523                 env(cs, fee(XRP(1)), ter(tesSUCCESS));
 524                 env.close();
 525 
 526                 auto const accSle = env.le(keylet::account(alice.id()));
 527                 auto const cronSle =
 528                     env.le(keylet::child(accSle->getFieldH256(sfCron)));
 529                 BEAST_EXPECT(cronSle && cronSle->isFieldPresent(sfHookNames));
 530                 BEAST_EXPECT(cronSle->getFieldArray(sfHookNames).size() == 2);
 531                 BEAST_EXPECT(!cronSle->isFieldPresent(sfHookName));
 532             }
```

📍 [`src/test/app/Cron_test.cpp:628-658`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/test/app/Cron_test.cpp#L628-L658)
```cpp
 628         // the emitted Cron pseudo-txn carries the selector
 629         {
 630             Env env{*this, features | featureCron};
 631             env.fund(XRP(1000), alice);
 632             env.close();
 633             auto const baseTime =
 634                 env.current()->parentCloseTime().time_since_epoch().count();
 635             auto cs = cron::set(alice);
 636             cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
 637             cs[jss::HookName] = "41424344";
 638             env(cs, fee(XRP(1)), ter(tesSUCCESS));
 639             env.close();
 640 
 641             bool fired = false;
 642             for (int i = 0; i < 40 && !fired; ++i)
 643             {
 644                 env.close(10s);
 645                 auto const& txs = env.closed()->txs;
 646                 for (auto it = txs.begin(); it != txs.end(); ++it)
 647                 {
 648                     if (it->first->getTxnType() != ttCRON)
 649                         continue;
 650                     fired = true;
 651                     BEAST_EXPECT(it->first->isFieldPresent(sfHookName));
 652                     BEAST_EXPECT(
 653                         strHex(it->first->getFieldVL(sfHookName)) ==
 654                         "41424344");
 655                 }
 656             }
 657             BEAST_EXPECT(fired);
 658         }
```

📍 [`src/test/app/Cron_test.cpp:569-591`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/test/app/Cron_test.cpp#L569-L591)
```cpp
 569             // malformed HookNames arrays are rejected for CronSet too
 570             {
 571                 auto cs = cron::set(alice);
 572                 cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
 573                 cs[jss::HookNames] = Json::Value{Json::arrayValue};
 574                 env(cs, fee(XRP(1)), ter(temMALFORMED));
 575             }
 576             {
 577                 auto cs = cron::set(alice);
 578                 cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
 579                 cs[jss::HookNames] = namesArray({"41424344", "41424344"});
 580                 env(cs, fee(XRP(1)), ter(temMALFORMED));
 581             }
 582             {
 583                 auto cs = cron::set(alice);
 584                 cs[sfStartTime.jsonName] = Json::UInt(baseTime + 1000);
 585                 Json::Value arr{Json::arrayValue};
 586                 Json::Value entry;
 587                 entry[sfHook.jsonName][jss::HookName] = "41424344";
 588                 arr.append(entry);
 589                 cs[jss::HookNames] = arr;
 590                 env(cs, fee(XRP(1)), ter(temMALFORMED));
 591             }
```

📍 [`src/test/app/Cron_test.cpp:701-739`](https://github.com/Xahau/xahaud/blob/3a4c1dd05326d9e7c3c694d754034b382df36d58/src/test/app/Cron_test.cpp#L701-L739)
```cpp
 701         // a recurring cron keeps its array selector across executions
 702         {
 703             Env env{*this, features | featureCron};
 704             env.fund(XRP(1000), alice);
 705             env.close();
 706             auto const baseTime =
 707                 env.timeKeeper().now().time_since_epoch().count();
 708             auto cs = cron::set(alice);
 709             cs[sfStartTime.jsonName] = Json::UInt(baseTime + 100);
 710             cs[sfDelaySeconds.jsonName] = 100;
 711             cs[sfRepeatCount.jsonName] = 3;
 712             cs[jss::HookNames] = namesArray({"41424344", "41424345"});
 713             env(cs, fee(XRP(1)), ter(tesSUCCESS));
 714             env.close(10s);
 715 
 716             bool fired = false;
 717             for (int i = 0; i < 40 && !fired; ++i)
 718             {
 719                 env.close(10s);
 720                 auto const& txs = env.closed()->txs;
 721                 for (auto it = txs.begin(); it != txs.end(); ++it)
 722                     if (it->first->getTxnType() == ttCRON)
 723                         fired = true;
 724             }
 725             BEAST_EXPECT(fired);
 726 
 727             auto const accSle = env.le(keylet::account(alice.id()));
 728             BEAST_EXPECT(accSle && accSle->isFieldPresent(sfCron));
 729             auto const cronSle =
 730                 env.le(keylet::child(accSle->getFieldH256(sfCron)));
 731             BEAST_EXPECT(cronSle && cronSle->isFieldPresent(sfHookNames));
 732             BEAST_EXPECT(cronSle && !cronSle->isFieldPresent(sfHookName));
 733             if (cronSle && cronSle->isFieldPresent(sfHookNames))
 734             {
 735                 auto const& hookNames = cronSle->getFieldArray(sfHookNames);
 736                 BEAST_EXPECT(hookNames.size() == 2);
 737                 BEAST_EXPECT(cronSle->getFieldU32(sfRepeatCount) == 2);
 738             }
 739         }
```

</details>

## FAQ

### Why not create `featureNamedHooksV2`?

This PR reuses `featureNamedHooks` because the amendment has not activated. That
keeps the user-facing story simple: NamedHooks includes both single-name and
multi-name selector support.

The caveat is governance/rollout: old binaries that advertise support for
`featureNamedHooks` but do not include this PR would not amendment-block if the
amendment activated. Do not activate `featureNamedHooks` until the intended
validator set has upgraded to a binary containing this change. If there is any
uncertainty about deployed validators or activation coordination, a fresh
amendment is the conservative safe-halt option.

### Do unnamed hooks still run?

Yes. Unnamed hooks are always selected. The selectors only restrict named hooks.

### Can a transaction specify both `HookName` and `HookNames`?

No. That is malformed. Use `HookName` for one named hook or `HookNames` for one
or more named hooks.

### Why is `HookNames` capped at 32?

Cron can persist and re-emit the selector array on each recurrence. A small cap
keeps selector payload growth bounded while still allowing far more names than a
normal hook chain can use.

### Does Cron run named hooks strongly?

No. This does not change Cron's TSH model. Cron-triggered hooks still use the
existing weak/collect path, so a targeted named hook must be collect-capable.

### Why does `ttCRON` carry `sfCron`?

After `featureNamedHooks`, the pseudo-transaction identifies the exact cron
object scheduled by TxQ. If the owner replaces or removes that cron before the
pseudo applies, `Cron::doApply` can detect the stale pseudo and no-op instead of
executing the replacement cron with stale selector fields. Before the amendment,
`ttCRON` omits `sfCron` to preserve the released pseudo-transaction bytes.

### What about stale/orphan cron objects consuming the 128 scan window?

That is a broader Cron scheduler issue. This PR preserves the pre-amendment scan
behavior. After `featureNamedHooks`, non-authoritative cron objects are not used
for selector copying, but they still consume the same scan-window budget so this
PR does not silently change Cron scheduler accounting.

### Can emitted transactions carry selector fields?

The new `HookNames` array is validated before the emitted transaction preflight
shortcut, so malformed arrays or arrays without `featureNamedHooks` are rejected
before the emitted transaction is accepted. The legacy single `HookName` field
keeps its pre-amendment emitted/pseudo compatibility path: before
`featureNamedHooks`, emitted and pseudo transactions that historically skipped
that validation still do so; after `featureNamedHooks`, it is validated normally.

### Do callback transactions need selector fields?

No. Callback dispatch is driven by `sfEmitDetails` metadata from the emitted
transaction, not by `HookName` or `HookNames` on the callback transaction. The
slot-recovery hardening in this PR keeps that existing behavior while avoiding
ambiguous duplicate-hash callback dispatch.

### What if the same hook hash is installed in multiple named slots?

Selector matching is slot-aware where it matters:

- normal fee/execution matching still checks the transaction selector;
- callback dispatch recovers the emitting slot from `sfEmitNonce`, using the
  position to disambiguate only when more than one slot carries the hash;
- again-as-weak replay matches the exact `{position, hash}`, falling back to hash
  matching when that hash is unambiguous in the chain.

In every case, when only one slot carries the hash the behavior is unambiguous;
the position is only decisive for genuine duplicate-hash chains.

Those two duplicate-hash hardenings only narrow behavior after
`featureNamedHooks`; before the amendment, callback and again-as-weak replay
remain legacy-compatible.

## Pre-Merge Verification Checklist

Latest local verification after the feature-gating hardening:

- [x] `cmake --build build --target rippled -j 8`
- [x] `./build/rippled --unittest=Cron` — 7 cases / 5,273 tests / 0 failures
- [x] `./build/rippled --unittest=SetHook0` — 94 cases / 13,231 tests / 0 failures
- [x] `./build/rippled --unittest=SetHook7` — 93 cases / 12,873 tests / 0 failures
- [x] `./build/rippled --unittest=SetHookTSH0` — 78 cases / 34,311 tests / 0 failures
- [x] `./build/rippled --unittest=Feature,ServerDefinitions` — 15 cases / 7,093 tests / 0 failures
- [x] `git diff --check`

Total distinct focused coverage: 287 cases / 72,781 tests / 0 failures.

## Residual review notes

- Dedicated tests for duplicate same-hash callback slots and exact-slot
  again-as-weak replay would be useful follow-up coverage.
- Direct emitted-selector validation tests would be useful: malformed
  `HookName`/`HookNames`, wrong-wrapper arrays, over-limit arrays, and selector
  fields when `featureNamedHooks` is disabled.
- Direct `featureHooks`-off selector rejection coverage would close the other
  explicit branch in `validateHookSelectors`.
- Direct stale-`sfCron` pseudo no-op coverage would be useful for the hardening
  that binds `ttCRON` to a specific cron object.
- Direct mixed-gating compatibility tests would be useful: pre-amendment
  `ttCRON` should omit `sfCron`, TxQ should preserve the legacy owner-ping set,
  duplicate-hash callback/AAW should preserve legacy behavior, and legacy single
  `HookName` should remain accepted on emitted/pseudo paths that historically
  skipped selector validation.
- Direct selector rejection coverage for Change-style pseudo transactions after
  `featureNamedHooks` would document the intentional boundary that only `ttCRON`
  may carry selectors. Pre-amendment, legacy single `HookName` remains accepted
  there for mixed-binary compatibility; the new `HookNames` array does not.
- The stale/orphan cron scan-window issue is intentionally documented but not
  fixed here because it is a broader Cron scheduler behavior change.

<!-- marker: reviewer-end -->
