### PR TITLE
fix(manifest): bound untrusted cache without stalling gossip

### DIFF
--- a/include/xrpl/basics/base64.h
+++ b/include/xrpl/basics/base64.h
@@ -62,6 +62,24 @@
 
 namespace ripple {
 
+namespace base64 {
+
+/** Returns the maximum number of characters needed to base64-encode bytes. */
+constexpr std::size_t
+encoded_size(std::size_t const numBytes)
+{
+    return 4 * ((numBytes + 2) / 3);
+}
+
+/** Returns an upper bound on bytes decoded from base64 characters. */
+constexpr std::size_t
+decoded_size(std::size_t const numChars)
+{
+    return ((numChars / 4) * 3) + 2;
+}
+
+}  // namespace base64
+
 std::string
 base64_encode(std::uint8_t const* data, std::size_t len);
 

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -212,6 +212,7 @@ JSS(build_version);    // out: NetworkOPs
 JSS(bytes_written);
 JSS(cancel_after);           // out: AccountChannels
 JSS(can_delete);             // out: CanDelete
+JSS(candidates);             // in: ValidatorList
 JSS(mpt_amount);             // out: mpt_holders
 JSS(mpt_issuance_id);        // in: Payment, mpt_holders
 JSS(mptoken_index);          // out: mpt_holders

--- a/src/libxrpl/basics/base64.cpp
+++ b/src/libxrpl/basics/base64.cpp
@@ -111,18 +111,6 @@ get_inverse()
     return &tab[0];
 }
 
-/// Returns max chars needed to encode a base64 string
-inline std::size_t constexpr encoded_size(std::size_t n)
-{
-    return 4 * ((n + 2) / 3);
-}
-
-/// Returns max bytes needed to decode a base64 string
-inline std::size_t constexpr decoded_size(std::size_t n)
-{
-    return ((n / 4) * 3) + 2;
-}
-
 /** Encode a series of octets as a padded, base64 string.
 
     The resulting string will not be null terminated.

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -1155,15 +1155,13 @@ public:
         auto const invalidSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
             cache
-                .applyManifestWithEviction(
-                    makeManifest(
-                        invalidMasterSecret,
-                        KeyType::ed25519,
-                        invalidSigning.second,
-                        KeyType::secp256k1,
-                        0,
-                        true),
-                    {})
+                .applyManifestWithEviction(makeManifest(
+                    invalidMasterSecret,
+                    KeyType::ed25519,
+                    invalidSigning.second,
+                    KeyType::secp256k1,
+                    0,
+                    true))
                 .disposition == ManifestDisposition::invalid);
         BEAST_EXPECT(retainedMasters() == beforeInvalid);
 
@@ -1183,10 +1181,8 @@ public:
                 clone(incoming), ManifestRetention::evictable) ==
             ManifestDisposition::untrustedCapacity);
 
-        hash_set<PublicKey> const currentValidationKeys = {
-            untrustedSigningKeys.front()};
-        auto const incomingAdmission = cache.applyManifestWithEviction(
-            clone(incoming), currentValidationKeys);
+        auto const incomingAdmission =
+            cache.applyManifestWithEviction(clone(incoming));
         BEAST_EXPECT(
             incomingAdmission.disposition == ManifestDisposition::accepted);
         BEAST_EXPECT(!incomingAdmission.acceptedUpdate);
@@ -1194,7 +1190,6 @@ public:
         auto const afterEviction = retainedMasters();
         BEAST_EXPECT(afterEviction.size() == 1001);
         BEAST_EXPECT(afterEviction.contains(trustedMaster));
-        BEAST_EXPECT(afterEviction.contains(untrustedMasters.front()));
         BEAST_EXPECT(afterEviction.contains(incomingMaster));
 
         std::optional<std::size_t> evicted;
@@ -1215,25 +1210,17 @@ public:
         }
 
         auto const replacementSigning = randomKeyPair(KeyType::secp256k1);
-        auto const updateAdmission = cache.applyManifestWithEviction(
-            makeManifest(
+        auto const updateAdmission =
+            cache.applyManifestWithEviction(makeManifest(
                 incomingMasterSecret,
                 KeyType::ed25519,
                 replacementSigning.second,
                 KeyType::secp256k1,
-                1),
-            {});
+                1));
         BEAST_EXPECT(
             updateAdmission.disposition == ManifestDisposition::accepted);
         BEAST_EXPECT(updateAdmission.acceptedUpdate);
         BEAST_EXPECT(retainedMasters() == afterEviction);
-
-        hash_set<PublicKey> allCurrentSigningKeys;
-        cache.for_each_manifest(
-            [&allCurrentSigningKeys](Manifest const& manifest) {
-                if (manifest.signingKey)
-                    allCurrentSigningKeys.insert(*manifest.signingKey);
-            });
 
         auto const secondIncomingMasterSecret = randomSecretKey();
         auto const secondIncomingMaster =
@@ -1241,14 +1228,12 @@ public:
         auto const secondIncomingSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
             cache
-                .applyManifestWithEviction(
-                    makeManifest(
-                        secondIncomingMasterSecret,
-                        KeyType::ed25519,
-                        secondIncomingSigning.second,
-                        KeyType::secp256k1,
-                        0),
-                    allCurrentSigningKeys)
+                .applyManifestWithEviction(makeManifest(
+                    secondIncomingMasterSecret,
+                    KeyType::ed25519,
+                    secondIncomingSigning.second,
+                    KeyType::secp256k1,
+                    0))
                 .disposition == ManifestDisposition::accepted);
         auto const afterAllActiveEviction = retainedMasters();
         BEAST_EXPECT(afterAllActiveEviction.size() == 1001);
@@ -1273,17 +1258,11 @@ public:
         for (std::size_t i = 0; i < 8; ++i)
         {
             BEAST_EXPECT(
-                cache
-                    .applyManifestWithEviction(
-                        std::move(evictionBurst[i]),
-                        {secondIncomingSigning.first})
+                cache.applyManifestWithEviction(std::move(evictionBurst[i]))
                     .disposition == ManifestDisposition::accepted);
         }
         BEAST_EXPECT(
-            cache
-                .applyManifestWithEviction(
-                    std::move(evictionBurst.back()),
-                    {secondIncomingSigning.first})
+            cache.applyManifestWithEviction(std::move(evictionBurst.back()))
                 .disposition == ManifestDisposition::untrustedCapacity);
         BEAST_EXPECT(retainedMasters().size() == 1001);
 
@@ -1292,28 +1271,24 @@ public:
         auto const refilledSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
             cache
-                .applyManifestWithEviction(
-                    makeManifest(
-                        refilledMasterSecret,
-                        KeyType::ed25519,
-                        refilledSigning.second,
-                        KeyType::secp256k1,
-                        0),
-                    {secondIncomingSigning.first})
+                .applyManifestWithEviction(makeManifest(
+                    refilledMasterSecret,
+                    KeyType::ed25519,
+                    refilledSigning.second,
+                    KeyType::secp256k1,
+                    0))
                 .disposition == ManifestDisposition::accepted);
 
         // Exhausting the eviction budget must not block an existing entry.
         auto const finalReplacementSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
             cache
-                .applyManifestWithEviction(
-                    makeManifest(
-                        secondIncomingMasterSecret,
-                        KeyType::ed25519,
-                        finalReplacementSigning.second,
-                        KeyType::secp256k1,
-                        1),
-                    {})
+                .applyManifestWithEviction(makeManifest(
+                    refilledMasterSecret,
+                    KeyType::ed25519,
+                    finalReplacementSigning.second,
+                    KeyType::secp256k1,
+                    1))
                 .disposition == ManifestDisposition::accepted);
     }
 

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -1043,15 +1043,17 @@ public:
         auto const invalidMasterSecret = randomSecretKey();
         auto const invalidSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
-            cache.applyManifestWithEviction(
-                makeManifest(
-                    invalidMasterSecret,
-                    KeyType::ed25519,
-                    invalidSigning.second,
-                    KeyType::secp256k1,
-                    0,
-                    true),
-                {}) == ManifestDisposition::invalid);
+            cache
+                .applyManifestWithEviction(
+                    makeManifest(
+                        invalidMasterSecret,
+                        KeyType::ed25519,
+                        invalidSigning.second,
+                        KeyType::secp256k1,
+                        0,
+                        true),
+                    {})
+                .disposition == ManifestDisposition::invalid);
         BEAST_EXPECT(retainedMasters() == beforeInvalid);
 
         auto const incomingMasterSecret = randomSecretKey();
@@ -1072,10 +1074,11 @@ public:
 
         hash_set<PublicKey> const currentValidationKeys = {
             untrustedSigningKeys.front()};
+        auto const incomingAdmission = cache.applyManifestWithEviction(
+            clone(incoming), currentValidationKeys);
         BEAST_EXPECT(
-            cache.applyManifestWithEviction(
-                clone(incoming), currentValidationKeys) ==
-            ManifestDisposition::accepted);
+            incomingAdmission.disposition == ManifestDisposition::accepted);
+        BEAST_EXPECT(!incomingAdmission.acceptedUpdate);
 
         auto const afterEviction = retainedMasters();
         BEAST_EXPECT(afterEviction.size() == 1001);
@@ -1101,15 +1104,17 @@ public:
         }
 
         auto const replacementSigning = randomKeyPair(KeyType::secp256k1);
+        auto const updateAdmission = cache.applyManifestWithEviction(
+            makeManifest(
+                incomingMasterSecret,
+                KeyType::ed25519,
+                replacementSigning.second,
+                KeyType::secp256k1,
+                1),
+            {});
         BEAST_EXPECT(
-            cache.applyManifestWithEviction(
-                makeManifest(
-                    incomingMasterSecret,
-                    KeyType::ed25519,
-                    replacementSigning.second,
-                    KeyType::secp256k1,
-                    1),
-                {}) == ManifestDisposition::accepted);
+            updateAdmission.disposition == ManifestDisposition::accepted);
+        BEAST_EXPECT(updateAdmission.acceptedUpdate);
         BEAST_EXPECT(retainedMasters() == afterEviction);
 
         hash_set<PublicKey> allCurrentSigningKeys;
@@ -1124,14 +1129,16 @@ public:
             derivePublicKey(KeyType::ed25519, secondIncomingMasterSecret);
         auto const secondIncomingSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
-            cache.applyManifestWithEviction(
-                makeManifest(
-                    secondIncomingMasterSecret,
-                    KeyType::ed25519,
-                    secondIncomingSigning.second,
-                    KeyType::secp256k1,
-                    0),
-                allCurrentSigningKeys) == ManifestDisposition::accepted);
+            cache
+                .applyManifestWithEviction(
+                    makeManifest(
+                        secondIncomingMasterSecret,
+                        KeyType::ed25519,
+                        secondIncomingSigning.second,
+                        KeyType::secp256k1,
+                        0),
+                    allCurrentSigningKeys)
+                .disposition == ManifestDisposition::accepted);
         auto const afterAllActiveEviction = retainedMasters();
         BEAST_EXPECT(afterAllActiveEviction.size() == 1001);
         BEAST_EXPECT(afterAllActiveEviction.contains(trustedMaster));
@@ -1155,43 +1162,48 @@ public:
         for (std::size_t i = 0; i < 8; ++i)
         {
             BEAST_EXPECT(
-                cache.applyManifestWithEviction(
-                    std::move(evictionBurst[i]),
-                    {secondIncomingSigning.first}) ==
-                ManifestDisposition::accepted);
+                cache
+                    .applyManifestWithEviction(
+                        std::move(evictionBurst[i]),
+                        {secondIncomingSigning.first})
+                    .disposition == ManifestDisposition::accepted);
         }
         BEAST_EXPECT(
-            cache.applyManifestWithEviction(
-                std::move(evictionBurst.back()),
-                {secondIncomingSigning.first}) ==
-            ManifestDisposition::untrustedCapacity);
+            cache
+                .applyManifestWithEviction(
+                    std::move(evictionBurst.back()),
+                    {secondIncomingSigning.first})
+                .disposition == ManifestDisposition::untrustedCapacity);
         BEAST_EXPECT(retainedMasters().size() == 1001);
 
         now += std::chrono::seconds{1};
         auto const refilledMasterSecret = randomSecretKey();
         auto const refilledSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
-            cache.applyManifestWithEviction(
-                makeManifest(
-                    refilledMasterSecret,
-                    KeyType::ed25519,
-                    refilledSigning.second,
-                    KeyType::secp256k1,
-                    0),
-                {secondIncomingSigning.first}) ==
-            ManifestDisposition::accepted);
+            cache
+                .applyManifestWithEviction(
+                    makeManifest(
+                        refilledMasterSecret,
+                        KeyType::ed25519,
+                        refilledSigning.second,
+                        KeyType::secp256k1,
+                        0),
+                    {secondIncomingSigning.first})
+                .disposition == ManifestDisposition::accepted);
 
         // Exhausting the eviction budget must not block an existing entry.
         auto const finalReplacementSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
-            cache.applyManifestWithEviction(
-                makeManifest(
-                    secondIncomingMasterSecret,
-                    KeyType::ed25519,
-                    finalReplacementSigning.second,
-                    KeyType::secp256k1,
-                    1),
-                {}) == ManifestDisposition::accepted);
+            cache
+                .applyManifestWithEviction(
+                    makeManifest(
+                        secondIncomingMasterSecret,
+                        KeyType::ed25519,
+                        finalReplacementSigning.second,
+                        KeyType::secp256k1,
+                        1),
+                    {})
+                .disposition == ManifestDisposition::accepted);
     }
 
     void

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -1195,6 +1195,38 @@ public:
     }
 
     void
+    testTrustPromotionInvalidatesSnapshot()
+    {
+        testcase("trust promotion invalidates snapshot");
+
+        ManifestCache cache;
+        auto const masterSecret = randomSecretKey();
+        auto const master = derivePublicKey(KeyType::ed25519, masterSecret);
+        auto const signing = randomKeyPair(KeyType::secp256k1);
+
+        BEAST_EXPECT(
+            cache.applyManifest(
+                makeManifest(
+                    masterSecret,
+                    KeyType::ed25519,
+                    signing.second,
+                    KeyType::secp256k1,
+                    0),
+                ManifestRateLimitCapPolicy::Capped) ==
+            ManifestDisposition::accepted);
+
+        auto const admitted = cache.sequence();
+        cache.promoteToTrusted(randomMasterKey());
+        BEAST_EXPECT(cache.sequence() == admitted);
+
+        cache.promoteToTrusted(master);
+        BEAST_EXPECT(cache.sequence() == admitted + 1);
+
+        cache.promoteToTrusted(master);
+        BEAST_EXPECT(cache.sequence() == admitted + 1);
+    }
+
+    void
     run() override
     {
         ManifestCache cache;
@@ -1321,6 +1353,7 @@ public:
         testManifestDomainNames();
         testManifestVersioning();
         testUntrustedEviction();
+        testTrustPromotionInvalidatesSnapshot();
     }
 };
 

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -464,8 +464,10 @@ public:
         auto const kp0 = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
             ManifestDisposition::accepted ==
-            cache.applyManifest(makeManifest(
-                sk, KeyType::ed25519, kp0.second, KeyType::secp256k1, 0)));
+            cache.applyManifest(
+                makeManifest(
+                    sk, KeyType::ed25519, kp0.second, KeyType::secp256k1, 0),
+                ManifestRateLimitCapPolicy::Capped));
         BEAST_EXPECT(cache.getSigningKey(pk) == kp0.first);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == pk);
 
@@ -476,8 +478,10 @@ public:
         auto const kp1 = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
             ManifestDisposition::accepted ==
-            cache.applyManifest(makeManifest(
-                sk, KeyType::ed25519, kp1.second, KeyType::secp256k1, 1)));
+            cache.applyManifest(
+                makeManifest(
+                    sk, KeyType::ed25519, kp1.second, KeyType::secp256k1, 1),
+                ManifestRateLimitCapPolicy::Capped));
         BEAST_EXPECT(cache.getSigningKey(pk) == kp1.first);
         BEAST_EXPECT(cache.getMasterKey(kp1.first) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
@@ -486,8 +490,10 @@ public:
         // applied with the same signing key but a higher sequence
         BEAST_EXPECT(
             ManifestDisposition::badEphemeralKey ==
-            cache.applyManifest(makeManifest(
-                sk, KeyType::ed25519, kp1.second, KeyType::secp256k1, 2)));
+            cache.applyManifest(
+                makeManifest(
+                    sk, KeyType::ed25519, kp1.second, KeyType::secp256k1, 2),
+                ManifestRateLimitCapPolicy::Capped));
         BEAST_EXPECT(cache.getSigningKey(pk) == kp1.first);
         BEAST_EXPECT(cache.getMasterKey(kp1.first) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
@@ -497,7 +503,9 @@ public:
         // key from a revoked master public key
         BEAST_EXPECT(
             ManifestDisposition::accepted ==
-            cache.applyManifest(makeRevocation(sk, KeyType::ed25519)));
+            cache.applyManifest(
+                makeRevocation(sk, KeyType::ed25519),
+                ManifestRateLimitCapPolicy::Capped));
         BEAST_EXPECT(cache.revoked(pk));
         BEAST_EXPECT(cache.getSigningKey(pk) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
@@ -1015,21 +1023,30 @@ public:
             // applyManifest should accept new manifests with
             // higher sequence numbers
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a0)) ==
+                cache.applyManifest(
+                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a0)) == ManifestDisposition::stale);
+                cache.applyManifest(
+                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::stale);
 
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a1)) ==
+                cache.applyManifest(
+                    clone(s_a1), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a1)) == ManifestDisposition::stale);
+                cache.applyManifest(
+                    clone(s_a1), ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::stale);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a0)) == ManifestDisposition::stale);
+                cache.applyManifest(
+                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::stale);
 
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a2)) ==
+                cache.applyManifest(
+                    clone(s_a2), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::badEphemeralKey);
 
             // applyManifest should accept manifests with max sequence numbers
@@ -1037,29 +1054,40 @@ public:
             BEAST_EXPECT(!cache.revoked(pk_a));
             BEAST_EXPECT(s_aMax.revoked());
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_aMax)) ==
+                cache.applyManifest(
+                    clone(s_aMax), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_aMax)) ==
+                cache.applyManifest(
+                    clone(s_aMax), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::stale);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a1)) == ManifestDisposition::stale);
+                cache.applyManifest(
+                    clone(s_a1), ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::stale);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_a0)) == ManifestDisposition::stale);
+                cache.applyManifest(
+                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::stale);
             BEAST_EXPECT(cache.revoked(pk_a));
 
             // applyManifest should reject manifests with invalid signatures
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_b0)) ==
+                cache.applyManifest(
+                    clone(s_b0), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_b0)) == ManifestDisposition::stale);
+                cache.applyManifest(
+                    clone(s_b0), ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::stale);
             BEAST_EXPECT(!deserializeManifest(fake));
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_b1)) ==
+                cache.applyManifest(
+                    clone(s_b1), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::invalid);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_b2)) ==
+                cache.applyManifest(
+                    clone(s_b2), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
 
             auto const s_c0 = makeManifest(
@@ -1069,7 +1097,8 @@ public:
                 KeyType::ed25519,
                 47);
             BEAST_EXPECT(
-                cache.applyManifest(clone(s_c0)) ==
+                cache.applyManifest(
+                    clone(s_c0), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::badMasterKey);
         }
 

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -1224,6 +1224,32 @@ public:
 
         cache.promoteToTrusted(master);
         BEAST_EXPECT(cache.sequence() == admitted + 1);
+
+        ManifestCache retryCache;
+        auto const retryMasterSecret = randomSecretKey();
+        auto const retrySigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            retryCache.applyManifest(
+                makeManifest(
+                    retryMasterSecret,
+                    KeyType::ed25519,
+                    retrySigning.second,
+                    KeyType::secp256k1,
+                    0),
+                ManifestRateLimitCapPolicy::Capped) ==
+            ManifestDisposition::accepted);
+        auto const retryAdmitted = retryCache.sequence();
+        BEAST_EXPECT(
+            retryCache.applyManifest(
+                makeManifest(
+                    retryMasterSecret,
+                    KeyType::ed25519,
+                    retrySigning.second,
+                    KeyType::secp256k1,
+                    0),
+                ManifestRateLimitCapPolicy::Uncapped) ==
+            ManifestDisposition::stale);
+        BEAST_EXPECT(retryCache.sequence() == retryAdmitted + 1);
     }
 
     void

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -1153,16 +1153,23 @@ public:
         auto const beforeInvalid = retainedMasters();
         auto const invalidMasterSecret = randomSecretKey();
         auto const invalidSigning = randomKeyPair(KeyType::secp256k1);
+        bool sampledCurrentValidations = false;
         BEAST_EXPECT(
             cache
-                .applyManifestWithEviction(makeManifest(
-                    invalidMasterSecret,
-                    KeyType::ed25519,
-                    invalidSigning.second,
-                    KeyType::secp256k1,
-                    0,
-                    true))
+                .applyManifestWithEviction(
+                    makeManifest(
+                        invalidMasterSecret,
+                        KeyType::ed25519,
+                        invalidSigning.second,
+                        KeyType::secp256k1,
+                        0,
+                        true),
+                    [&sampledCurrentValidations] {
+                        sampledCurrentValidations = true;
+                        return hash_set<PublicKey>{};
+                    })
                 .disposition == ManifestDisposition::invalid);
+        BEAST_EXPECT(!sampledCurrentValidations);
         BEAST_EXPECT(retainedMasters() == beforeInvalid);
 
         auto const incomingMasterSecret = randomSecretKey();
@@ -1181,8 +1188,11 @@ public:
                 clone(incoming), ManifestRetention::evictable) ==
             ManifestDisposition::untrustedCapacity);
 
-        auto const incomingAdmission =
-            cache.applyManifestWithEviction(clone(incoming));
+        hash_set<PublicKey> const currentValidationKeys = {
+            untrustedSigningKeys.front()};
+        auto const incomingAdmission = cache.applyManifestWithEviction(
+            clone(incoming),
+            [&currentValidationKeys] { return currentValidationKeys; });
         BEAST_EXPECT(
             incomingAdmission.disposition == ManifestDisposition::accepted);
         BEAST_EXPECT(!incomingAdmission.acceptedUpdate);
@@ -1190,6 +1200,7 @@ public:
         auto const afterEviction = retainedMasters();
         BEAST_EXPECT(afterEviction.size() == 1001);
         BEAST_EXPECT(afterEviction.contains(trustedMaster));
+        BEAST_EXPECT(afterEviction.contains(untrustedMasters.front()));
         BEAST_EXPECT(afterEviction.contains(incomingMaster));
 
         std::optional<std::size_t> evicted;
@@ -1222,29 +1233,68 @@ public:
         BEAST_EXPECT(updateAdmission.acceptedUpdate);
         BEAST_EXPECT(retainedMasters() == afterEviction);
 
+        hash_set<PublicKey> allCurrentSigningKeys;
+        cache.for_each_manifest(
+            [&allCurrentSigningKeys](Manifest const& manifest) {
+                if (manifest.signingKey)
+                    allCurrentSigningKeys.insert(*manifest.signingKey);
+            });
+        allCurrentSigningKeys.erase(replacementSigning.first);
+
         auto const secondIncomingMasterSecret = randomSecretKey();
         auto const secondIncomingMaster =
             derivePublicKey(KeyType::ed25519, secondIncomingMasterSecret);
         auto const secondIncomingSigning = randomKeyPair(KeyType::secp256k1);
         BEAST_EXPECT(
             cache
-                .applyManifestWithEviction(makeManifest(
-                    secondIncomingMasterSecret,
-                    KeyType::ed25519,
-                    secondIncomingSigning.second,
-                    KeyType::secp256k1,
-                    0))
+                .applyManifestWithEviction(
+                    makeManifest(
+                        secondIncomingMasterSecret,
+                        KeyType::ed25519,
+                        secondIncomingSigning.second,
+                        KeyType::secp256k1,
+                        0),
+                    [&allCurrentSigningKeys] { return allCurrentSigningKeys; })
                 .disposition == ManifestDisposition::accepted);
-        auto const afterAllActiveEviction = retainedMasters();
-        BEAST_EXPECT(afterAllActiveEviction.size() == 1001);
-        BEAST_EXPECT(afterAllActiveEviction.contains(trustedMaster));
-        BEAST_EXPECT(afterAllActiveEviction.contains(secondIncomingMaster));
+        auto const afterSoleDormantEviction = retainedMasters();
+        BEAST_EXPECT(afterSoleDormantEviction.size() == 1001);
+        BEAST_EXPECT(afterSoleDormantEviction.contains(trustedMaster));
+        BEAST_EXPECT(afterSoleDormantEviction.contains(secondIncomingMaster));
+        BEAST_EXPECT(!afterSoleDormantEviction.contains(incomingMaster));
 
-        // Two eviction permits were consumed above. Time is held fixed while
+        // With no dormant victim, eviction falls back to the full evictable
+        // population.
+        allCurrentSigningKeys.clear();
+        cache.for_each_manifest(
+            [&allCurrentSigningKeys](Manifest const& manifest) {
+                if (manifest.signingKey)
+                    allCurrentSigningKeys.insert(*manifest.signingKey);
+            });
+        auto const thirdIncomingMasterSecret = randomSecretKey();
+        auto const thirdIncomingMaster =
+            derivePublicKey(KeyType::ed25519, thirdIncomingMasterSecret);
+        auto const thirdIncomingSigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            cache
+                .applyManifestWithEviction(
+                    makeManifest(
+                        thirdIncomingMasterSecret,
+                        KeyType::ed25519,
+                        thirdIncomingSigning.second,
+                        KeyType::secp256k1,
+                        0),
+                    [&allCurrentSigningKeys] { return allCurrentSigningKeys; })
+                .disposition == ManifestDisposition::accepted);
+        auto const afterFallbackEviction = retainedMasters();
+        BEAST_EXPECT(afterFallbackEviction.size() == 1001);
+        BEAST_EXPECT(afterFallbackEviction.contains(trustedMaster));
+        BEAST_EXPECT(afterFallbackEviction.contains(thirdIncomingMaster));
+
+        // Three eviction permits were consumed above. Time is held fixed while
         // the remainder of the burst is consumed.
         std::vector<Manifest> evictionBurst;
-        evictionBurst.reserve(9);
-        for (std::size_t i = 0; i < 9; ++i)
+        evictionBurst.reserve(8);
+        for (std::size_t i = 0; i < 8; ++i)
         {
             auto const masterSecret = randomSecretKey();
             auto const signing = randomKeyPair(KeyType::secp256k1);
@@ -1255,7 +1305,7 @@ public:
                 KeyType::secp256k1,
                 0));
         }
-        for (std::size_t i = 0; i < 8; ++i)
+        for (std::size_t i = 0; i < 7; ++i)
         {
             BEAST_EXPECT(
                 cache.applyManifestWithEviction(std::move(evictionBurst[i]))

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -243,6 +243,20 @@ public:
         return m2;
     }
 
+    static std::optional<ManifestRetention>
+    retentionOf(ManifestCache const& cache, PublicKey const& master)
+    {
+        std::optional<ManifestRetention> result;
+        cache.for_each_manifest(
+            [](std::size_t) {},
+            [&result, &master](
+                Manifest const& manifest, ManifestRetention retention) {
+                if (manifest.masterKey == master)
+                    result = retention;
+            });
+        return result;
+    }
+
     void
     testLoadStore(ManifestCache& m)
     {
@@ -287,25 +301,71 @@ public:
                 env.journal);
 
             {
-                // save should not store untrusted master keys to db
-                // except for revocations
-                m.save(
-                    *dbCon,
-                    "ValidatorManifests",
-                    [&unl](PublicKey const& pubKey) {
-                        return unl->listed(pubKey);
+                // Protection is current-source policy, not a second permanent
+                // manifest authority. Source removal demotes revocations into
+                // the ordinary bounded population. The existing wallet format
+                // still saves retained revocations.
+                ManifestCache persistence;
+                auto const protectedSecret = randomSecretKey();
+                auto const protectedSigning = randomKeyPair(KeyType::secp256k1);
+                auto const protectedOld = makeManifest(
+                    protectedSecret,
+                    KeyType::ed25519,
+                    protectedSigning.second,
+                    KeyType::secp256k1,
+                    0);
+                auto const protectedRevocation =
+                    makeRevocation(protectedSecret, KeyType::ed25519);
+                auto const arbitrarySecret = randomSecretKey();
+                auto const arbitraryRevocation =
+                    makeRevocation(arbitrarySecret, KeyType::ed25519);
+                auto const protectedMaster = protectedRevocation.masterKey;
+                auto const arbitraryMaster = arbitraryRevocation.masterKey;
+                BEAST_EXPECT(
+                    persistence.applyManifest(
+                        clone(protectedRevocation),
+                        ManifestRetention::protected_) ==
+                    ManifestDisposition::accepted);
+                BEAST_EXPECT(
+                    persistence.applyManifest(
+                        clone(arbitraryRevocation),
+                        ManifestRetention::evictable) ==
+                    ManifestDisposition::accepted);
+
+                persistence.reconcileRetention({});
+                BEAST_EXPECT(
+                    retentionOf(persistence, protectedMaster) ==
+                    ManifestRetention::evictable);
+                BEAST_EXPECT(
+                    retentionOf(persistence, arbitraryMaster) ==
+                    ManifestRetention::evictable);
+
+                persistence.save(
+                    *dbCon, "ValidatorManifests", [](PublicKey const&) {
+                        return false;
                     });
 
                 ManifestCache loaded;
 
                 loaded.load(*dbCon, "ValidatorManifests");
-
-                // check that all loaded manifests are revocations
-                std::vector<Manifest const*> const loadedManifests(
-                    sort(getPopulatedManifests(loaded)));
-
-                for (auto const& man : loadedManifests)
-                    BEAST_EXPECT(man->revoked());
+                BEAST_EXPECT(loaded.revoked(protectedMaster));
+                BEAST_EXPECT(loaded.revoked(arbitraryMaster));
+                BEAST_EXPECT(
+                    retentionOf(loaded, protectedMaster) ==
+                    ManifestRetention::protected_);
+                // Startup reconciliation is what returns database-only rows
+                // to the bounded population once live sources are known.
+                loaded.reconcileRetention({});
+                BEAST_EXPECT(
+                    retentionOf(loaded, protectedMaster) ==
+                    ManifestRetention::evictable);
+                BEAST_EXPECT(
+                    retentionOf(loaded, arbitraryMaster) ==
+                    ManifestRetention::evictable);
+                BEAST_EXPECT(
+                    loaded.applyManifest(
+                        clone(protectedOld), ManifestRetention::evictable) ==
+                    ManifestDisposition::stale);
             }
             {
                 // save should store all trusted master keys to db
@@ -415,10 +475,61 @@ public:
                     cfgRevocation));
 
                 BEAST_EXPECT(loaded.revoked(pk));
+                loaded.reconcileRetention({});
+                BEAST_EXPECT(
+                    retentionOf(loaded, pk) == ManifestRetention::protected_);
             }
         }
         boost::filesystem::remove(
             getDatabasePath() / boost::filesystem::path(dbName));
+    }
+
+    void
+    testStartupRetentionReconciliation()
+    {
+        testcase("startup retention reconciliation");
+
+        jtx::Env env(*this);
+        ManifestCache manifests;
+        ManifestCache publisherManifests;
+        auto const formerSecret = randomSecretKey();
+        auto const formerSigning = randomKeyPair(KeyType::secp256k1);
+        auto const former = makeManifest(
+            formerSecret,
+            KeyType::ed25519,
+            formerSigning.second,
+            KeyType::secp256k1,
+            0);
+        auto const revocation =
+            makeRevocation(randomSecretKey(), KeyType::ed25519);
+        auto const formerMaster = former.masterKey;
+        auto const revokedMaster = revocation.masterKey;
+
+        // Database rows are provisionally loaded as protected before current
+        // local and publisher sources are known.
+        BEAST_EXPECT(
+            manifests.applyManifest(
+                clone(former), ManifestRetention::protected_) ==
+            ManifestDisposition::accepted);
+        BEAST_EXPECT(
+            manifests.applyManifest(
+                clone(revocation), ManifestRetention::protected_) ==
+            ManifestDisposition::accepted);
+
+        ValidatorList validators(
+            manifests,
+            publisherManifests,
+            env.timeKeeper(),
+            env.app().config().legacy("database_path"),
+            env.journal);
+        BEAST_EXPECT(validators.load({}, {}, {}));
+
+        BEAST_EXPECT(
+            retentionOf(manifests, formerMaster) ==
+            ManifestRetention::evictable);
+        BEAST_EXPECT(
+            retentionOf(manifests, revokedMaster) ==
+            ManifestRetention::evictable);
     }
 
     void
@@ -467,7 +578,7 @@ public:
             cache.applyManifest(
                 makeManifest(
                     sk, KeyType::ed25519, kp0.second, KeyType::secp256k1, 0),
-                ManifestRateLimitCapPolicy::Capped));
+                ManifestRetention::evictable));
         BEAST_EXPECT(cache.getSigningKey(pk) == kp0.first);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == pk);
 
@@ -481,7 +592,7 @@ public:
             cache.applyManifest(
                 makeManifest(
                     sk, KeyType::ed25519, kp1.second, KeyType::secp256k1, 1),
-                ManifestRateLimitCapPolicy::Capped));
+                ManifestRetention::evictable));
         BEAST_EXPECT(cache.getSigningKey(pk) == kp1.first);
         BEAST_EXPECT(cache.getMasterKey(kp1.first) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
@@ -493,7 +604,7 @@ public:
             cache.applyManifest(
                 makeManifest(
                     sk, KeyType::ed25519, kp1.second, KeyType::secp256k1, 2),
-                ManifestRateLimitCapPolicy::Capped));
+                ManifestRetention::evictable));
         BEAST_EXPECT(cache.getSigningKey(pk) == kp1.first);
         BEAST_EXPECT(cache.getMasterKey(kp1.first) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
@@ -505,7 +616,7 @@ public:
             ManifestDisposition::accepted ==
             cache.applyManifest(
                 makeRevocation(sk, KeyType::ed25519),
-                ManifestRateLimitCapPolicy::Capped));
+                ManifestRetention::evictable));
         BEAST_EXPECT(cache.revoked(pk));
         BEAST_EXPECT(cache.getSigningKey(pk) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
@@ -1005,7 +1116,7 @@ public:
                     trustedSigning.second,
                     KeyType::secp256k1,
                     0),
-                ManifestRateLimitCapPolicy::Uncapped) ==
+                ManifestRetention::protected_) ==
             ManifestDisposition::accepted);
 
         std::vector<PublicKey> untrustedMasters;
@@ -1025,7 +1136,7 @@ public:
                         signing.second,
                         KeyType::secp256k1,
                         0),
-                    ManifestRateLimitCapPolicy::Capped) ==
+                    ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             untrustedMasters.push_back(master);
             untrustedSigningKeys.push_back(signing.first);
@@ -1069,7 +1180,7 @@ public:
 
         BEAST_EXPECT(
             cache.applyManifest(
-                clone(incoming), ManifestRateLimitCapPolicy::Capped) ==
+                clone(incoming), ManifestRetention::evictable) ==
             ManifestDisposition::untrustedCapacity);
 
         hash_set<PublicKey> const currentValidationKeys = {
@@ -1207,9 +1318,9 @@ public:
     }
 
     void
-    testTrustPromotionInvalidatesSnapshot()
+    testRetentionInvalidatesSnapshot()
     {
-        testcase("trust promotion invalidates snapshot");
+        testcase("retention changes invalidate snapshot");
 
         ManifestCache cache;
         auto const masterSecret = randomSecretKey();
@@ -1224,18 +1335,27 @@ public:
                     signing.second,
                     KeyType::secp256k1,
                     0),
-                ManifestRateLimitCapPolicy::Capped) ==
-            ManifestDisposition::accepted);
+                ManifestRetention::evictable) == ManifestDisposition::accepted);
 
         auto const admitted = cache.sequence();
-        cache.promoteToTrusted(randomMasterKey());
+        cache.setRetention(randomMasterKey(), ManifestRetention::protected_);
         BEAST_EXPECT(cache.sequence() == admitted);
 
-        cache.promoteToTrusted(master);
+        cache.setRetention(master, ManifestRetention::protected_);
         BEAST_EXPECT(cache.sequence() == admitted + 1);
 
-        cache.promoteToTrusted(master);
+        cache.reconcileRetention({master});
         BEAST_EXPECT(cache.sequence() == admitted + 1);
+
+        cache.reconcileRetention({});
+        BEAST_EXPECT(cache.sequence() == admitted + 2);
+        BEAST_EXPECT(cache.getSequence(master) == 0);
+
+        cache.reconcileRetention({master});
+        BEAST_EXPECT(cache.sequence() == admitted + 3);
+
+        cache.setRetention(master, ManifestRetention::protected_);
+        BEAST_EXPECT(cache.sequence() == admitted + 3);
 
         ManifestCache retryCache;
         auto const retryMasterSecret = randomSecretKey();
@@ -1248,8 +1368,7 @@ public:
                     retrySigning.second,
                     KeyType::secp256k1,
                     0),
-                ManifestRateLimitCapPolicy::Capped) ==
-            ManifestDisposition::accepted);
+                ManifestRetention::evictable) == ManifestDisposition::accepted);
         auto const retryAdmitted = retryCache.sequence();
         BEAST_EXPECT(
             retryCache.applyManifest(
@@ -1259,8 +1378,7 @@ public:
                     retrySigning.second,
                     KeyType::secp256k1,
                     0),
-                ManifestRateLimitCapPolicy::Uncapped) ==
-            ManifestDisposition::stale);
+                ManifestRetention::protected_) == ManifestDisposition::stale);
         BEAST_EXPECT(retryCache.sequence() == retryAdmitted + 1);
     }
 
@@ -1305,29 +1423,29 @@ public:
             // higher sequence numbers
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a0), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a0), ManifestRetention::evictable) ==
                 ManifestDisposition::stale);
 
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a1), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a1), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a1), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a1), ManifestRetention::evictable) ==
                 ManifestDisposition::stale);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a0), ManifestRetention::evictable) ==
                 ManifestDisposition::stale);
 
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a2), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a2), ManifestRetention::evictable) ==
                 ManifestDisposition::badEphemeralKey);
 
             // applyManifest should accept manifests with max sequence numbers
@@ -1336,39 +1454,39 @@ public:
             BEAST_EXPECT(s_aMax.revoked());
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_aMax), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_aMax), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_aMax), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_aMax), ManifestRetention::evictable) ==
                 ManifestDisposition::stale);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a1), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a1), ManifestRetention::evictable) ==
                 ManifestDisposition::stale);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_a0), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_a0), ManifestRetention::evictable) ==
                 ManifestDisposition::stale);
             BEAST_EXPECT(cache.revoked(pk_a));
 
             // applyManifest should reject manifests with invalid signatures
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_b0), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_b0), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_b0), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_b0), ManifestRetention::evictable) ==
                 ManifestDisposition::stale);
             BEAST_EXPECT(!deserializeManifest(fake));
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_b1), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_b1), ManifestRetention::evictable) ==
                 ManifestDisposition::invalid);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_b2), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_b2), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
 
             auto const s_c0 = makeManifest(
@@ -1379,11 +1497,12 @@ public:
                 47);
             BEAST_EXPECT(
                 cache.applyManifest(
-                    clone(s_c0), ManifestRateLimitCapPolicy::Capped) ==
+                    clone(s_c0), ManifestRetention::evictable) ==
                 ManifestDisposition::badMasterKey);
         }
 
         testLoadStore(cache);
+        testStartupRetentionReconciliation();
         testGetSignature();
         testGetKeys();
         testValidatorToken();
@@ -1391,7 +1510,7 @@ public:
         testManifestDomainNames();
         testManifestVersioning();
         testUntrustedEviction();
-        testTrustPromotionInvalidatesSnapshot();
+        testRetentionInvalidatesSnapshot();
     }
 };
 

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -988,7 +988,10 @@ public:
     {
         testcase("untrusted eviction");
 
-        ManifestCache cache;
+        auto now = std::chrono::steady_clock::time_point{};
+        ManifestCache cache(
+            beast::Journal(beast::Journal::getNullSink()),
+            [&now] { return now; });
 
         auto const trustedMasterSecret = randomSecretKey();
         auto const trustedMaster =
@@ -1133,6 +1136,62 @@ public:
         BEAST_EXPECT(afterAllActiveEviction.size() == 1001);
         BEAST_EXPECT(afterAllActiveEviction.contains(trustedMaster));
         BEAST_EXPECT(afterAllActiveEviction.contains(secondIncomingMaster));
+
+        // Two eviction permits were consumed above. Time is held fixed while
+        // the remainder of the burst is consumed.
+        std::vector<Manifest> evictionBurst;
+        evictionBurst.reserve(9);
+        for (std::size_t i = 0; i < 9; ++i)
+        {
+            auto const masterSecret = randomSecretKey();
+            auto const signing = randomKeyPair(KeyType::secp256k1);
+            evictionBurst.push_back(makeManifest(
+                masterSecret,
+                KeyType::ed25519,
+                signing.second,
+                KeyType::secp256k1,
+                0));
+        }
+        for (std::size_t i = 0; i < 8; ++i)
+        {
+            BEAST_EXPECT(
+                cache.applyManifestWithEviction(
+                    std::move(evictionBurst[i]),
+                    {secondIncomingSigning.first}) ==
+                ManifestDisposition::accepted);
+        }
+        BEAST_EXPECT(
+            cache.applyManifestWithEviction(
+                std::move(evictionBurst.back()),
+                {secondIncomingSigning.first}) ==
+            ManifestDisposition::untrustedCapacity);
+        BEAST_EXPECT(retainedMasters().size() == 1001);
+
+        now += std::chrono::seconds{1};
+        auto const refilledMasterSecret = randomSecretKey();
+        auto const refilledSigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            cache.applyManifestWithEviction(
+                makeManifest(
+                    refilledMasterSecret,
+                    KeyType::ed25519,
+                    refilledSigning.second,
+                    KeyType::secp256k1,
+                    0),
+                {secondIncomingSigning.first}) ==
+            ManifestDisposition::accepted);
+
+        // Exhausting the eviction budget must not block an existing entry.
+        auto const finalReplacementSigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            cache.applyManifestWithEviction(
+                makeManifest(
+                    secondIncomingMasterSecret,
+                    KeyType::ed25519,
+                    finalReplacementSigning.second,
+                    KeyType::secp256k1,
+                    1),
+                {}) == ManifestDisposition::accepted);
     }
 
     void

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -984,6 +984,158 @@ public:
     }
 
     void
+    testUntrustedEviction()
+    {
+        testcase("untrusted eviction");
+
+        ManifestCache cache;
+
+        auto const trustedMasterSecret = randomSecretKey();
+        auto const trustedMaster =
+            derivePublicKey(KeyType::ed25519, trustedMasterSecret);
+        auto const trustedSigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            cache.applyManifest(
+                makeManifest(
+                    trustedMasterSecret,
+                    KeyType::ed25519,
+                    trustedSigning.second,
+                    KeyType::secp256k1,
+                    0),
+                ManifestRateLimitCapPolicy::Uncapped) ==
+            ManifestDisposition::accepted);
+
+        std::vector<PublicKey> untrustedMasters;
+        std::vector<PublicKey> untrustedSigningKeys;
+        untrustedMasters.reserve(1000);
+        untrustedSigningKeys.reserve(1000);
+        for (std::size_t i = 0; i < 1000; ++i)
+        {
+            auto const masterSecret = randomSecretKey();
+            auto const master = derivePublicKey(KeyType::ed25519, masterSecret);
+            auto const signing = randomKeyPair(KeyType::secp256k1);
+            BEAST_EXPECT(
+                cache.applyManifest(
+                    makeManifest(
+                        masterSecret,
+                        KeyType::ed25519,
+                        signing.second,
+                        KeyType::secp256k1,
+                        0),
+                    ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::accepted);
+            untrustedMasters.push_back(master);
+            untrustedSigningKeys.push_back(signing.first);
+        }
+
+        auto retainedMasters = [&cache]() {
+            hash_set<PublicKey> result;
+            cache.for_each_manifest([&result](Manifest const& manifest) {
+                result.insert(manifest.masterKey);
+            });
+            return result;
+        };
+
+        auto const beforeInvalid = retainedMasters();
+        auto const invalidMasterSecret = randomSecretKey();
+        auto const invalidSigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            cache.applyManifestWithEviction(
+                makeManifest(
+                    invalidMasterSecret,
+                    KeyType::ed25519,
+                    invalidSigning.second,
+                    KeyType::secp256k1,
+                    0,
+                    true),
+                {}) == ManifestDisposition::invalid);
+        BEAST_EXPECT(retainedMasters() == beforeInvalid);
+
+        auto const incomingMasterSecret = randomSecretKey();
+        auto const incomingMaster =
+            derivePublicKey(KeyType::ed25519, incomingMasterSecret);
+        auto const incomingSigning = randomKeyPair(KeyType::secp256k1);
+        auto const incoming = makeManifest(
+            incomingMasterSecret,
+            KeyType::ed25519,
+            incomingSigning.second,
+            KeyType::secp256k1,
+            0);
+
+        BEAST_EXPECT(
+            cache.applyManifest(
+                clone(incoming), ManifestRateLimitCapPolicy::Capped) ==
+            ManifestDisposition::untrustedCapacity);
+
+        hash_set<PublicKey> const currentValidationKeys = {
+            untrustedSigningKeys.front()};
+        BEAST_EXPECT(
+            cache.applyManifestWithEviction(
+                clone(incoming), currentValidationKeys) ==
+            ManifestDisposition::accepted);
+
+        auto const afterEviction = retainedMasters();
+        BEAST_EXPECT(afterEviction.size() == 1001);
+        BEAST_EXPECT(afterEviction.contains(trustedMaster));
+        BEAST_EXPECT(afterEviction.contains(untrustedMasters.front()));
+        BEAST_EXPECT(afterEviction.contains(incomingMaster));
+
+        std::optional<std::size_t> evicted;
+        for (std::size_t i = 0; i < untrustedMasters.size(); ++i)
+        {
+            if (!afterEviction.contains(untrustedMasters[i]))
+            {
+                BEAST_EXPECT(!evicted);
+                evicted = i;
+            }
+        }
+        BEAST_EXPECT(evicted);
+        if (evicted)
+        {
+            BEAST_EXPECT(
+                cache.getMasterKey(untrustedSigningKeys[*evicted]) ==
+                untrustedSigningKeys[*evicted]);
+        }
+
+        auto const replacementSigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            cache.applyManifestWithEviction(
+                makeManifest(
+                    incomingMasterSecret,
+                    KeyType::ed25519,
+                    replacementSigning.second,
+                    KeyType::secp256k1,
+                    1),
+                {}) == ManifestDisposition::accepted);
+        BEAST_EXPECT(retainedMasters() == afterEviction);
+
+        hash_set<PublicKey> allCurrentSigningKeys;
+        cache.for_each_manifest(
+            [&allCurrentSigningKeys](Manifest const& manifest) {
+                if (manifest.signingKey)
+                    allCurrentSigningKeys.insert(*manifest.signingKey);
+            });
+
+        auto const secondIncomingMasterSecret = randomSecretKey();
+        auto const secondIncomingMaster =
+            derivePublicKey(KeyType::ed25519, secondIncomingMasterSecret);
+        auto const secondIncomingSigning = randomKeyPair(KeyType::secp256k1);
+        BEAST_EXPECT(
+            cache.applyManifestWithEviction(
+                makeManifest(
+                    secondIncomingMasterSecret,
+                    KeyType::ed25519,
+                    secondIncomingSigning.second,
+                    KeyType::secp256k1,
+                    0),
+                allCurrentSigningKeys) == ManifestDisposition::accepted);
+        auto const afterAllActiveEviction = retainedMasters();
+        BEAST_EXPECT(afterAllActiveEviction.size() == 1001);
+        BEAST_EXPECT(afterAllActiveEviction.contains(trustedMaster));
+        BEAST_EXPECT(afterAllActiveEviction.contains(secondIncomingMaster));
+    }
+
+    void
     run() override
     {
         ManifestCache cache;
@@ -1109,6 +1261,7 @@ public:
         testManifestDeserialization();
         testManifestDomainNames();
         testManifestVersioning();
+        testUntrustedEviction();
     }
 };
 

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -308,7 +308,7 @@ private:
 
             manifests.applyManifest(
                 *deserializeManifest(cfgManifest),
-                ManifestRateLimitCapPolicy::Capped);
+                ManifestRetention::evictable);
             BEAST_EXPECT(trustedKeys->load(
                 localSigningPublicOuter, emptyCfgKeys, emptyCfgPublishers));
 
@@ -407,7 +407,7 @@ private:
 
             manifests.applyManifest(
                 *deserializeManifest(cfgManifest),
-                ManifestRateLimitCapPolicy::Capped);
+                ManifestRetention::evictable);
 
             BEAST_EXPECT(trustedKeys->load(
                 localSigningPublicOuter, cfgKeys, emptyCfgPublishers));
@@ -504,7 +504,7 @@ private:
                     pubRevokedSigning.first,
                     pubRevokedSigning.second,
                     std::numeric_limits<std::uint32_t>::max())),
-                ManifestRateLimitCapPolicy::Capped);
+                ManifestRetention::evictable);
 
             // these two are not revoked (and not in the manifest cache at all.)
             auto legitKey1 = randomMasterKey();
@@ -545,7 +545,7 @@ private:
                     pubRevokedSigning.first,
                     pubRevokedSigning.second,
                     std::numeric_limits<std::uint32_t>::max())),
-                ManifestRateLimitCapPolicy::Capped);
+                ManifestRetention::evictable);
 
             // this one is not revoked (and not in the manifest cache at all.)
             auto legitKey = randomMasterKey();
@@ -1038,19 +1038,11 @@ private:
             publisherSigning.first,
             publisherSigning.second,
             1));
-
-        // A manifest whose signing key is already used as a directly listed
-        // legacy identity must not be able to remap that identity.
-        auto const directListedSecret = randomSecretKey();
-        auto const directListedKey =
-            derivePublicKey(KeyType::ed25519, directListedSecret);
         BEAST_EXPECT(trustedKeys->load(
-            {},
-            {toBase58(TokenType::NodePublic, directListedKey)},
-            std::vector<std::string>{strHex(publisherPublic)}));
+            {}, {}, std::vector<std::string>{strHex(publisherPublic)}));
 
-        // Publisher candidates are independent of the ordinary untrusted
-        // cache and remain observable when that cache is full.
+        // Fill the bounded population. A publisher candidate is still admitted
+        // because its tier changes retention policy, not manifest authority.
         for (std::size_t i = 0; i < ValidatorList::maxPublisherCandidates; ++i)
         {
             auto const filler = randomValidator();
@@ -1059,170 +1051,20 @@ private:
             if (manifest)
                 BEAST_EXPECT(
                     validatorManifests.applyManifest(
-                        std::move(*manifest),
-                        ManifestRateLimitCapPolicy::Capped) ==
+                        std::move(*manifest), ManifestRetention::evictable) ==
                     ManifestDisposition::accepted);
         }
 
-        auto const listedValidator = randomValidator();
+        auto const listed = randomValidator();
         auto const candidate = randomValidator();
-        auto const liveCandidateSecret = randomSecretKey();
-        auto const liveCandidateMaster =
-            derivePublicKey(KeyType::ed25519, liveCandidateSecret);
-        auto const liveCandidateSigning = randomKeyPair(KeyType::secp256k1);
-        Validator const liveCandidate{
-            liveCandidateMaster,
-            liveCandidateSigning.first,
-            base64_encode(makeManifestString(
-                liveCandidateMaster,
-                liveCandidateSecret,
-                liveCandidateSigning.first,
-                liveCandidateSigning.second,
-                1))};
-
-        auto const equalSequenceMasterSecret = randomSecretKey();
-        auto const equalSequenceMaster =
-            derivePublicKey(KeyType::ed25519, equalSequenceMasterSecret);
-        auto const ordinaryEqualSigning = randomKeyPair(KeyType::secp256k1);
-        auto const candidateEqualSigning = randomKeyPair(KeyType::secp256k1);
-        auto ordinaryEqual = deserializeManifest(makeManifestString(
-            equalSequenceMaster,
-            equalSequenceMasterSecret,
-            ordinaryEqualSigning.first,
-            ordinaryEqualSigning.second,
-            1));
-        BEAST_EXPECT(ordinaryEqual);
-        if (ordinaryEqual)
-            BEAST_EXPECT(
-                validatorManifests.applyManifest(
-                    std::move(*ordinaryEqual),
-                    ManifestRateLimitCapPolicy::Uncapped) ==
-                ManifestDisposition::accepted);
-        Validator const equalSequenceCandidate{
-            equalSequenceMaster,
-            candidateEqualSigning.first,
-            base64_encode(makeManifestString(
-                equalSequenceMaster,
-                equalSequenceMasterSecret,
-                candidateEqualSigning.first,
-                candidateEqualSigning.second,
-                1))};
-
-        auto const ordinaryCrossMasterSecret = randomSecretKey();
-        auto const ordinaryCrossMaster =
-            derivePublicKey(KeyType::ed25519, ordinaryCrossMasterSecret);
-        auto const ordinaryCrossSigning = randomKeyPair(KeyType::secp256k1);
-        auto ordinaryCross = deserializeManifest(makeManifestString(
-            ordinaryCrossMaster,
-            ordinaryCrossMasterSecret,
-            ordinaryCrossSigning.first,
-            ordinaryCrossSigning.second,
-            1));
-        BEAST_EXPECT(ordinaryCross);
-        if (ordinaryCross)
-            BEAST_EXPECT(
-                validatorManifests.applyManifest(
-                    std::move(*ordinaryCross),
-                    ManifestRateLimitCapPolicy::Uncapped) ==
-                ManifestDisposition::accepted);
-
-        auto const candidateToOrdinaryMasterSecret = randomSecretKey();
-        auto const candidateToOrdinaryMaster =
-            derivePublicKey(KeyType::ed25519, candidateToOrdinaryMasterSecret);
-        Validator const candidateUsingOrdinaryMaster{
-            candidateToOrdinaryMaster,
-            ordinaryCrossMaster,
-            base64_encode(makeManifestString(
-                candidateToOrdinaryMaster,
-                candidateToOrdinaryMasterSecret,
-                ordinaryCrossMaster,
-                ordinaryCrossMasterSecret,
-                1))};
-        auto const candidateFromOrdinarySigning =
-            randomKeyPair(KeyType::secp256k1);
-        Validator const candidateUsingOrdinarySigningAsMaster{
-            ordinaryCrossSigning.first,
-            candidateFromOrdinarySigning.first,
-            base64_encode(makeManifestString(
-                ordinaryCrossSigning.first,
-                ordinaryCrossSigning.second,
-                candidateFromOrdinarySigning.first,
-                candidateFromOrdinarySigning.second,
-                1))};
-
-        auto const ordinaryRevocationOwnerSecret = randomSecretKey();
-        auto const ordinaryRevocationOwner =
-            derivePublicKey(KeyType::ed25519, ordinaryRevocationOwnerSecret);
-        auto const ordinaryRevokedAlias = randomKeyPair(KeyType::secp256k1);
-        auto ordinaryForRevocation = deserializeManifest(makeManifestString(
-            ordinaryRevocationOwner,
-            ordinaryRevocationOwnerSecret,
-            ordinaryRevokedAlias.first,
-            ordinaryRevokedAlias.second,
-            1));
-        BEAST_EXPECT(ordinaryForRevocation);
-        if (ordinaryForRevocation)
-            BEAST_EXPECT(
-                validatorManifests.applyManifest(
-                    std::move(*ordinaryForRevocation),
-                    ManifestRateLimitCapPolicy::Uncapped) ==
-                ManifestDisposition::accepted);
-        Validator const revokedOrdinaryAlias{
-            ordinaryRevokedAlias.first,
-            ordinaryRevokedAlias.first,
-            base64_encode(makeRevocationString(
-                ordinaryRevokedAlias.first, ordinaryRevokedAlias.second))};
-
-        auto const intersectingCandidate = randomValidator();
-        Validator const intersectingBareIdentity{
-            intersectingCandidate.signingPublic,
-            intersectingCandidate.signingPublic,
-            {}};
-
-        auto const bareSecret = randomSecretKey();
-        auto const bareMaster = derivePublicKey(KeyType::ed25519, bareSecret);
-        Validator const bareCandidate{bareMaster, bareMaster, {}};
-
-        auto const revokedCandidateSecret = randomSecretKey();
-        auto const revokedCandidateMaster =
-            derivePublicKey(KeyType::ed25519, revokedCandidateSecret);
-        Validator const revokedCandidate{
-            revokedCandidateMaster,
-            revokedCandidateMaster,
-            base64_encode(makeRevocationString(
-                revokedCandidateMaster, revokedCandidateSecret))};
-        auto const collidingMasterSecret = randomSecretKey();
-        auto const collidingMaster =
-            derivePublicKey(KeyType::ed25519, collidingMasterSecret);
-        Validator const collidingCandidate{
-            collidingMaster,
-            directListedKey,
-            base64_encode(makeManifestString(
-                collidingMaster,
-                collidingMasterSecret,
-                directListedKey,
-                directListedSecret,
-                1))};
-
         auto const validUntil = env.timeKeeper().now() + 1h;
         auto const blob = makeList(
-            {listedValidator},
+            {listed},
             1,
             validUntil.time_since_epoch().count(),
             {},
-            {candidate,
-             liveCandidate,
-             equalSequenceCandidate,
-             candidateUsingOrdinaryMaster,
-             candidateUsingOrdinarySigningAsMaster,
-             revokedOrdinaryAlias,
-             intersectingCandidate,
-             intersectingBareIdentity,
-             bareCandidate,
-             revokedCandidate,
-             collidingCandidate});
+            {candidate});
         auto const signature = signList(blob, publisherSigning);
-
         BEAST_EXPECT(
             trustedKeys
                 ->applyLists(
@@ -1232,434 +1074,107 @@ private:
                     "testCandidates.test")
                 .bestDisposition() == ListDisposition::accepted);
 
-        BEAST_EXPECT(trustedKeys->listed(listedValidator.masterPublic));
+        BEAST_EXPECT(trustedKeys->listed(listed.masterPublic));
         BEAST_EXPECT(!trustedKeys->listed(candidate.masterPublic));
-        BEAST_EXPECT(!trustedKeys->listed(candidate.signingPublic));
         BEAST_EXPECT(!trustedKeys->trusted(candidate.masterPublic));
-        BEAST_EXPECT(!trustedKeys->trusted(candidate.signingPublic));
-        auto candidatePolicy =
-            trustedKeys->manifestPolicy(candidate.masterPublic);
-        BEAST_EXPECT(!candidatePolicy.consensusListed);
-        BEAST_EXPECT(candidatePolicy.publisherCandidate);
-        BEAST_EXPECT(candidatePolicy.relayEligible());
-        auto listedPolicy =
-            trustedKeys->manifestPolicy(listedValidator.masterPublic);
-        BEAST_EXPECT(listedPolicy.consensusListed);
-        BEAST_EXPECT(!listedPolicy.publisherCandidate);
-        BEAST_EXPECT(listedPolicy.relayEligible());
+        auto const policy = trustedKeys->manifestPolicy(candidate.masterPublic);
+        BEAST_EXPECT(!policy.consensusListed);
+        BEAST_EXPECT(policy.publisherCandidate);
+        BEAST_EXPECT(policy.relayEligible());
 
-        // Candidate state does not enter the ordinary manifest cache.
+        // All provenance classes share ManifestCache's one high-water and
+        // signer-to-master index. Candidate status only protects retention.
         BEAST_EXPECT(
             validatorManifests.getMasterKey(candidate.signingPublic) ==
-            candidate.signingPublic);
+            candidate.masterPublic);
         BEAST_EXPECT(
             validatorManifests.getSigningKey(candidate.masterPublic) ==
-            candidate.masterPublic);
-        BEAST_EXPECT(!validatorManifests.getSequence(candidate.masterPublic));
+            candidate.signingPublic);
+        BEAST_EXPECT(
+            validatorManifests.getSequence(candidate.masterPublic) == 1);
 
-        auto identity =
-            trustedKeys->lookupMonitoringIdentity(candidate.masterPublic);
-        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::resolved);
-        BEAST_EXPECT(identity.master == candidate.masterPublic);
-        BEAST_EXPECT(identity.signing == candidate.signingPublic);
-        BEAST_EXPECT(!identity.presentInOrdinaryState);
-        BEAST_EXPECT(
-            identity.candidateIdentityPublishers.contains(publisherPublic));
-        BEAST_EXPECT(
-            identity.candidateManifestPublishers.contains(publisherPublic));
-
-        auto signer =
-            trustedKeys->resolveMonitoringSigner(candidate.signingPublic);
-        BEAST_EXPECT(signer.status == ValidatorIdentityStatus::resolved);
-        BEAST_EXPECT(signer.master == candidate.masterPublic);
-
-        // Same-master, same-sequence variants conflict symmetrically: neither
-        // signing key is attributed merely because it came from one layer.
-        BEAST_EXPECT(
-            trustedKeys->lookupMonitoringIdentity(equalSequenceMaster).status ==
-            ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(
-            trustedKeys->resolveMonitoringSigner(ordinaryEqualSigning.first)
-                .status == ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(
-            trustedKeys->resolveMonitoringSigner(candidateEqualSigning.first)
-                .status == ValidatorIdentityStatus::conflict);
-
-        // Candidate roles cannot reuse current ordinary master/signing
-        // namespaces under another identity.
-        BEAST_EXPECT(
-            trustedKeys->resolveMonitoringSigner(ordinaryCrossMaster).status ==
-            ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(
-            trustedKeys
-                ->resolveMonitoringSigner(candidateFromOrdinarySigning.first)
-                .status == ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(
-            trustedKeys->lookupMonitoringIdentity(ordinaryRevokedAlias.first)
-                .status == ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(
-            trustedKeys->resolveMonitoringSigner(ordinaryRevokedAlias.first)
-                .status == ValidatorIdentityStatus::conflict);
-
-        // Candidate master/signing intersections are reported symmetrically.
-        auto const intersectionOwner = trustedKeys->lookupMonitoringIdentity(
-            intersectingCandidate.masterPublic);
-        auto const intersectionIdentity = trustedKeys->lookupMonitoringIdentity(
-            intersectingCandidate.signingPublic);
-        BEAST_EXPECT(
-            intersectionOwner.status == ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(
-            intersectionIdentity.status == ValidatorIdentityStatus::conflict);
-        for (auto const& result : {intersectionOwner, intersectionIdentity})
-        {
-            BEAST_EXPECT(
-                std::find(
-                    result.conflictingMasters.begin(),
-                    result.conflictingMasters.end(),
-                    intersectingCandidate.masterPublic) !=
-                result.conflictingMasters.end());
-            BEAST_EXPECT(
-                std::find(
-                    result.conflictingMasters.begin(),
-                    result.conflictingMasters.end(),
-                    intersectingCandidate.signingPublic) !=
-                result.conflictingMasters.end());
-        }
-
-        auto bare = trustedKeys->lookupMonitoringIdentity(bareMaster);
-        BEAST_EXPECT(bare.status == ValidatorIdentityStatus::resolved);
-        BEAST_EXPECT(bare.signing == bareMaster);
-
-        auto revoked =
-            trustedKeys->lookupMonitoringIdentity(revokedCandidateMaster);
-        BEAST_EXPECT(revoked.status == ValidatorIdentityStatus::revoked);
-        BEAST_EXPECT(
-            trustedKeys->resolveMonitoringSigner(revokedCandidateMaster)
-                .status == ValidatorIdentityStatus::unknown);
-
-        // A valid candidate can intentionally reuse a key only when it can
-        // produce both required signatures. The monitoring view reports the
-        // resulting cross-master ambiguity; consensus remains on the direct
-        // listed identity.
-        auto collision = trustedKeys->resolveMonitoringSigner(directListedKey);
-        BEAST_EXPECT(collision.status == ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(trustedKeys->listed(directListedKey));
-
-        bool candidateRelayed = false;
-        validatorManifests.for_each_manifest([&](Manifest const& manifest) {
-            candidateRelayed = candidateRelayed ||
-                manifest.masterKey == candidate.masterPublic;
-        });
-        BEAST_EXPECT(!candidateRelayed);
-
-        auto const liveRotation = randomKeyPair(KeyType::secp256k1);
-        auto liveManifest = deserializeManifest(makeManifestString(
-            liveCandidateMaster,
-            liveCandidateSecret,
-            liveRotation.first,
-            liveRotation.second,
-            2));
-        BEAST_EXPECT(liveManifest);
-        if (liveManifest)
-        {
-            BEAST_EXPECT(
-                trustedKeys->applyCandidateManifest(std::move(*liveManifest)) ==
-                ManifestDisposition::accepted);
-        }
-        BEAST_EXPECT(
-            trustedKeys->lookupMonitoringIdentity(liveCandidateMaster)
-                .signing == liveRotation.first);
-        BEAST_EXPECT(trustedKeys->candidateManifestOverrides().size() == 1);
-
-        // A malformed candidate invalidates only the candidate extension.
-        // The signed legacy validator list, including its associated manifest,
-        // remains accepted and applied.
-        auto invalidCandidate = randomValidator();
-        auto invalidManifest = base64_decode(invalidCandidate.manifest);
-        invalidManifest.back() ^= 1;
-        invalidCandidate.manifest = base64_encode(invalidManifest);
-        auto const secondBlob = makeList(
-            {listedValidator},
-            2,
-            validUntil.time_since_epoch().count(),
-            {},
-            {candidate, invalidCandidate});
-        auto const secondSignature = signList(secondBlob, publisherSigning);
-        BEAST_EXPECT(
-            trustedKeys
-                ->applyLists(
-                    publisherManifest,
-                    1,
-                    {{secondBlob, secondSignature, {}}},
-                    "testCandidates.test")
-                .bestDisposition() == ListDisposition::accepted);
-        BEAST_EXPECT(trustedKeys->listed(listedValidator.signingPublic));
-        BEAST_EXPECT(
-            validatorManifests.getMasterKey(listedValidator.signingPublic) ==
-            listedValidator.masterPublic);
-        BEAST_EXPECT(
-            trustedKeys->lookupMonitoringIdentity(candidate.masterPublic)
-                .status == ValidatorIdentityStatus::unknown);
-        BEAST_EXPECT(
-            trustedKeys->lookupMonitoringIdentity(liveCandidateMaster).status ==
-            ValidatorIdentityStatus::unknown);
-        BEAST_EXPECT(trustedKeys->candidateManifestOverrides().empty());
-        candidatePolicy = trustedKeys->manifestPolicy(candidate.masterPublic);
-        BEAST_EXPECT(!candidatePolicy.consensusListed);
-        BEAST_EXPECT(!candidatePolicy.publisherCandidate);
-        BEAST_EXPECT(!candidatePolicy.relayEligible());
-
-        // Promotion is explicit. Repeating a candidate manifest in the
-        // validators tier moves it into ordinary manifest state; merely having
-        // appeared in an older candidate generation does not.
-        auto const thirdBlob = makeList(
-            {listedValidator, candidate, revokedCandidate},
-            3,
-            validUntil.time_since_epoch().count());
-        auto const thirdSignature = signList(thirdBlob, publisherSigning);
-        BEAST_EXPECT(
-            trustedKeys
-                ->applyLists(
-                    publisherManifest,
-                    1,
-                    {{thirdBlob, thirdSignature, {}}},
-                    "testCandidates.test")
-                .bestDisposition() == ListDisposition::accepted);
-        BEAST_EXPECT(
-            validatorManifests.getMasterKey(candidate.signingPublic) ==
-            candidate.masterPublic);
-        BEAST_EXPECT(trustedKeys->listed(candidate.signingPublic));
-        candidatePolicy = trustedKeys->manifestPolicy(candidate.masterPublic);
-        BEAST_EXPECT(candidatePolicy.consensusListed);
-        BEAST_EXPECT(!candidatePolicy.publisherCandidate);
-        BEAST_EXPECT(candidatePolicy.relayEligible());
-        identity =
-            trustedKeys->lookupMonitoringIdentity(candidate.masterPublic);
-        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::resolved);
-        BEAST_EXPECT(identity.presentInOrdinaryState);
-        BEAST_EXPECT(identity.candidateIdentityPublishers.empty());
-        BEAST_EXPECT(validatorManifests.revoked(revokedCandidateMaster));
-
-        trustedKeys->updateTrusted(
-            {},
-            env.timeKeeper().now(),
-            env.app().getOPs(),
-            env.app().overlay(),
-            env.app().getHashRouter());
-        BEAST_EXPECT(trustedKeys->trusted(directListedKey));
-        BEAST_EXPECT(trustedKeys->trusted(candidate.signingPublic));
-
-        // An already-expired generation preserves legacy ordinary-list and
-        // manifest handling, but does not seed the current candidate view.
-        env.timeKeeper().set(env.timeKeeper().now() + 2s);
-        auto const expiredCandidate = randomValidator();
-        auto const expiredValidator = randomValidator();
-        auto const expiredBlob = makeList(
-            {expiredValidator},
-            4,
-            (env.timeKeeper().now() - 1s).time_since_epoch().count(),
-            {},
-            {expiredCandidate});
-        auto const expiredSignature = signList(expiredBlob, publisherSigning);
-        auto const expiredResult = trustedKeys->applyLists(
-            publisherManifest,
-            1,
-            {{expiredBlob, expiredSignature, {}}},
-            "testCandidates.test");
-        BEAST_EXPECTS(
-            expiredResult.bestDisposition() == ListDisposition::expired,
-            to_string(expiredResult.bestDisposition()));
-        BEAST_EXPECT(
-            trustedKeys->lookupMonitoringIdentity(expiredCandidate.masterPublic)
-                .status == ValidatorIdentityStatus::unknown);
-        BEAST_EXPECT(
-            !validatorManifests.getSequence(expiredCandidate.masterPublic));
-        BEAST_EXPECT(
-            validatorManifests.getSequence(expiredValidator.masterPublic));
-        BEAST_EXPECT(trustedKeys->listed(expiredValidator.masterPublic));
-
-        // A malformed extension does not reject a newer legacy validator
-        // generation; it contributes no candidates.
-        auto const malformedShapeBlob = makeList(
-            {listedValidator},
-            5,
-            validUntil.time_since_epoch().count(),
-            {},
-            {candidate});
-        auto invalidJson = base64_decode(malformedShapeBlob);
-        auto const pos = invalidJson.find("\"candidates\":[");
-        BEAST_EXPECT(pos != std::string::npos);
-        if (pos != std::string::npos)
-        {
-            auto const arrayStart = pos + std::string{"\"candidates\":"}.size();
-            auto const arrayEnd = invalidJson.find(']', arrayStart);
-            BEAST_EXPECT(arrayEnd != std::string::npos);
-            if (arrayEnd != std::string::npos)
-            {
-                invalidJson.replace(
-                    arrayStart, arrayEnd - arrayStart + 1, "{}");
-                auto const invalidBlob = base64_encode(invalidJson);
-                auto const invalidSignature =
-                    signList(invalidBlob, publisherSigning);
-                BEAST_EXPECT(
-                    trustedKeys
-                        ->applyLists(
-                            publisherManifest,
-                            1,
-                            {{invalidBlob, invalidSignature, {}}},
-                            "testCandidates.test")
-                        .bestDisposition() == ListDisposition::accepted);
-                BEAST_EXPECT(
-                    trustedKeys->listed(listedValidator.signingPublic));
-                BEAST_EXPECT(
-                    trustedKeys
-                        ->lookupMonitoringIdentity(candidate.masterPublic)
-                        .status == ValidatorIdentityStatus::resolved);
-                BEAST_EXPECT(
-                    trustedKeys
-                        ->lookupMonitoringIdentity(candidate.masterPublic)
-                        .presentInOrdinaryState);
-            }
-        }
-    }
-
-    void
-    testCandidateVariantDeterminism()
-    {
-        testcase("Publisher candidate variant determinism");
-        using namespace std::chrono_literals;
-
-        jtx::Env env(*this);
-        auto const listedValidator = randomValidator();
         auto const candidateMasterSecret = randomSecretKey();
         auto const candidateMaster =
             derivePublicKey(KeyType::ed25519, candidateMasterSecret);
-
-        struct PublisherInput
-        {
-            PublicKey master;
-            std::pair<PublicKey, SecretKey> signing;
-            std::string manifest;
-        };
-        std::vector<PublisherInput> publishers;
-        for (int i = 0; i < 3; ++i)
-        {
-            auto const secret = randomSecretKey();
-            auto const master = derivePublicKey(KeyType::ed25519, secret);
-            auto const signing = randomKeyPair(KeyType::secp256k1);
-            publishers.push_back(PublisherInput{
-                master,
-                signing,
-                base64_encode(makeManifestString(
-                    master, secret, signing.first, signing.second, 1))});
-        }
-
-        struct VariantInput
-        {
-            Validator validator;
-            std::string serialized;
-        };
-        std::vector<VariantInput> variants;
-        for (int i = 0; i < 3; ++i)
-        {
-            auto const signing = randomKeyPair(KeyType::secp256k1);
-            auto const serialized = makeManifestString(
+        auto const candidateSigning1 = randomKeyPair(KeyType::secp256k1);
+        auto const candidateSigning2 = randomKeyPair(KeyType::secp256k1);
+        Validator const rotatingCandidate{
+            candidateMaster,
+            candidateSigning1.first,
+            base64_encode(makeManifestString(
                 candidateMaster,
                 candidateMasterSecret,
-                signing.first,
-                signing.second,
-                7);
-            variants.push_back(VariantInput{
-                Validator{
-                    candidateMaster, signing.first, base64_encode(serialized)},
-                serialized});
-        }
-        std::sort(
-            variants.begin(),
-            variants.end(),
-            [](VariantInput const& lhs, VariantInput const& rhs) {
-                return lhs.serialized < rhs.serialized;
-            });
-
-        // Assign the largest variant to one of the first two unordered-map
-        // publishers. The pre-fix first-two policy therefore differs from the
-        // required lexicographically smallest-two policy deterministically.
-        hash_map<PublicKey, std::size_t> iterationProbe;
-        for (std::size_t i = 0; i < publishers.size(); ++i)
-            iterationProbe.emplace(publishers[i].master, i);
-        std::vector<std::size_t> iterationOrder;
-        for (auto const& [_, index] : iterationProbe)
-        {
-            (void)_;
-            iterationOrder.push_back(index);
-        }
-        BEAST_EXPECT(iterationOrder.size() == 3);
-        if (iterationOrder.size() != 3)
-            return;
-
-        std::vector<std::size_t> publisherVariant(3);
-        publisherVariant[iterationOrder[0]] = 0;
-        publisherVariant[iterationOrder[1]] = 2;
-        publisherVariant[iterationOrder[2]] = 1;
-
-        auto runOrder = [&](std::vector<std::size_t> const& applyOrder) {
-            ManifestCache validatorManifests;
-            ManifestCache publisherManifests;
-            ValidatorList trustedKeys(
-                validatorManifests,
-                publisherManifests,
-                env.timeKeeper(),
-                env.app().config().legacy("database_path"),
-                env.journal);
-
-            std::vector<std::string> publisherKeys;
-            for (auto const& publisher : publishers)
-                publisherKeys.push_back(strHex(publisher.master));
-            BEAST_EXPECT(trustedKeys.load({}, {}, publisherKeys));
-
-            auto const validUntil = env.timeKeeper().now() + 1h;
-            for (auto const index : applyOrder)
-            {
-                auto const blob = makeList(
-                    {listedValidator},
+                candidateSigning1.first,
+                candidateSigning1.second,
+                1))};
+        auto const blob2 = makeList(
+            {listed},
+            2,
+            validUntil.time_since_epoch().count(),
+            {},
+            {candidate, rotatingCandidate});
+        auto const signature2 = signList(blob2, publisherSigning);
+        BEAST_EXPECT(
+            trustedKeys
+                ->applyLists(
+                    publisherManifest,
                     1,
-                    validUntil.time_since_epoch().count(),
-                    {},
-                    {variants[publisherVariant[index]].validator});
-                auto const signature =
-                    signList(blob, publishers[index].signing);
-                BEAST_EXPECT(
-                    trustedKeys
-                        .applyLists(
-                            publishers[index].manifest,
-                            1,
-                            {{blob, signature, {}}},
-                            "testCandidateVariantDeterminism.test")
-                        .bestDisposition() == ListDisposition::accepted);
-            }
+                    {{blob2, signature2, {}}},
+                    "testCandidates.test")
+                .bestDisposition() == ListDisposition::accepted);
 
-            std::vector<ValidatorIdentityStatus> result;
-            for (auto const& variant : variants)
-                result.push_back(trustedKeys
-                                     .resolveMonitoringSigner(
-                                         variant.validator.signingPublic)
-                                     .status);
+        auto rotation = deserializeManifest(makeManifestString(
+            candidateMaster,
+            candidateMasterSecret,
+            candidateSigning2.first,
+            candidateSigning2.second,
+            2));
+        BEAST_EXPECT(rotation);
+        if (rotation)
             BEAST_EXPECT(
-                trustedKeys.lookupMonitoringIdentity(candidateMaster).status ==
-                ValidatorIdentityStatus::conflict);
-            return result;
-        };
+                validatorManifests.applyManifest(
+                    std::move(*rotation), ManifestRetention::protected_) ==
+                ManifestDisposition::accepted);
+        BEAST_EXPECT(
+            validatorManifests.getSigningKey(candidateMaster) ==
+            candidateSigning2.first);
 
-        auto const forward = runOrder({0, 1, 2});
-        auto const reverse = runOrder({2, 1, 0});
-        BEAST_EXPECT(forward == reverse);
-        BEAST_EXPECT(forward.size() == 3);
-        if (forward.size() == 3)
-        {
-            BEAST_EXPECT(forward[0] == ValidatorIdentityStatus::conflict);
-            BEAST_EXPECT(forward[1] == ValidatorIdentityStatus::conflict);
-            BEAST_EXPECT(forward[2] == ValidatorIdentityStatus::unknown);
-        }
+        // Removing the candidate removes only its protection. Because the
+        // bounded population is already full, its transient manifest is
+        // discarded rather than creating a second retention pool.
+        auto const blob3 =
+            makeList({listed}, 3, validUntil.time_since_epoch().count());
+        auto const signature3 = signList(blob3, publisherSigning);
+        BEAST_EXPECT(
+            trustedKeys
+                ->applyLists(
+                    publisherManifest,
+                    1,
+                    {{blob3, signature3, {}}},
+                    "testCandidates.test")
+                .bestDisposition() == ListDisposition::accepted);
+        BEAST_EXPECT(
+            !trustedKeys->manifestPolicy(candidateMaster).publisherCandidate);
+        BEAST_EXPECT(!validatorManifests.getSequence(candidateMaster));
+
+        // Protection follows the current union of configured/listed and
+        // candidate masters. Removing a tier-1 entry demotes it through the
+        // same reconciliation path; it does not remain protected forever.
+        auto const replacementListed = randomValidator();
+        auto const blob4 = makeList(
+            {replacementListed}, 4, validUntil.time_since_epoch().count());
+        auto const signature4 = signList(blob4, publisherSigning);
+        BEAST_EXPECT(
+            trustedKeys
+                ->applyLists(
+                    publisherManifest,
+                    1,
+                    {{blob4, signature4, {}}},
+                    "testCandidates.test")
+                .bestDisposition() == ListDisposition::accepted);
+        BEAST_EXPECT(!trustedKeys->listed(listed.masterPublic));
+        BEAST_EXPECT(!validatorManifests.getSequence(listed.masterPublic));
+        BEAST_EXPECT(trustedKeys->listed(replacementListed.masterPublic));
     }
 
     void
@@ -1918,7 +1433,7 @@ private:
 
             BEAST_EXPECT(
                 manifestsOuter.applyManifest(
-                    std::move(*m1), ManifestRateLimitCapPolicy::Capped) ==
+                    std::move(*m1), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(trustedKeysOuter->listed(masterPublic));
             BEAST_EXPECT(trustedKeysOuter->trusted(masterPublic));
@@ -1937,7 +1452,7 @@ private:
                 2));
             BEAST_EXPECT(
                 manifestsOuter.applyManifest(
-                    std::move(*m2), ManifestRateLimitCapPolicy::Capped) ==
+                    std::move(*m2), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(trustedKeysOuter->listed(masterPublic));
             BEAST_EXPECT(trustedKeysOuter->trusted(masterPublic));
@@ -1956,7 +1471,7 @@ private:
             BEAST_EXPECT(mMax->revoked());
             BEAST_EXPECT(
                 manifestsOuter.applyManifest(
-                    std::move(*mMax), ManifestRateLimitCapPolicy::Capped) ==
+                    std::move(*mMax), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
                 manifestsOuter.getSigningKey(masterPublic) == masterPublic);
@@ -3456,7 +2971,7 @@ private:
             {
                 valManifests.applyManifest(
                     *deserializeManifest(base64_decode(self->manifest)),
-                    ManifestRateLimitCapPolicy::Capped);
+                    ManifestRetention::evictable);
                 BEAST_EXPECT(result->load(
                     self->signingPublic,
                     emptyCfgKeys,
@@ -4819,7 +4334,6 @@ public:
         testConfigLoad();
         testApplyLists();
         testCandidates();
-        testCandidateVariantDeterminism();
         testGetAvailable();
         testUpdateTrusted();
         testExpires();

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1034,18 +1034,50 @@ private:
             publisherSigning.second,
             1));
 
+        // A manifest whose signing key is already used as a directly listed
+        // legacy identity must not be able to remap that identity.
+        auto const directListedSecret = randomSecretKey();
+        auto const directListedKey =
+            derivePublicKey(KeyType::ed25519, directListedSecret);
         BEAST_EXPECT(trustedKeys->load(
-            {}, {}, std::vector<std::string>{strHex(publisherPublic)}));
+            {},
+            {toBase58(TokenType::NodePublic, directListedKey)},
+            std::vector<std::string>{strHex(publisherPublic)}));
 
         auto const listedValidator = randomValidator();
         auto const candidate = randomValidator();
+        auto const collidingMasterSecret = randomSecretKey();
+        auto const collidingMaster =
+            derivePublicKey(KeyType::ed25519, collidingMasterSecret);
+        Validator const collidingCandidate{
+            collidingMaster,
+            directListedKey,
+            base64_encode(makeManifestString(
+                collidingMaster,
+                collidingMasterSecret,
+                directListedKey,
+                directListedSecret,
+                1))};
+
+        auto mismatchedCandidate = randomValidator();
+        auto const mismatchedManifestOwner = randomValidator();
+        mismatchedCandidate.manifest = mismatchedManifestOwner.manifest;
+
+        auto invalidCandidate = randomValidator();
+        auto invalidManifest = base64_decode(invalidCandidate.manifest);
+        invalidManifest.back() ^= 1;
+        invalidCandidate.manifest = base64_encode(invalidManifest);
+
         auto const validUntil = env.timeKeeper().now() + 1h;
         auto const blob = makeList(
             {listedValidator},
             1,
             validUntil.time_since_epoch().count(),
             {},
-            {candidate});
+            {candidate,
+             collidingCandidate,
+             mismatchedCandidate,
+             invalidCandidate});
         auto const signature = signList(blob, publisherSigning);
 
         BEAST_EXPECT(
@@ -1068,6 +1100,45 @@ private:
         BEAST_EXPECT(
             validatorManifests.getSigningKey(candidate.masterPublic) ==
             candidate.signingPublic);
+        BEAST_EXPECT(
+            validatorManifests.getMasterKey(directListedKey) ==
+            directListedKey);
+        BEAST_EXPECT(trustedKeys->listed(directListedKey));
+        BEAST_EXPECT(!validatorManifests.getSequence(collidingMaster));
+        BEAST_EXPECT(
+            !validatorManifests.getSequence(mismatchedCandidate.masterPublic));
+        BEAST_EXPECT(
+            !validatorManifests.getSequence(invalidCandidate.masterPublic));
+
+        trustedKeys->updateTrusted(
+            {},
+            env.timeKeeper().now(),
+            env.app().getOPs(),
+            env.app().overlay(),
+            env.app().getHashRouter());
+        BEAST_EXPECT(trustedKeys->trusted(directListedKey));
+        BEAST_EXPECT(!trustedKeys->trusted(candidate.masterPublic));
+
+        // An already-expired generation must not seed candidate bindings.
+        env.timeKeeper().set(env.timeKeeper().now() + 2s);
+        auto const expiredCandidate = randomValidator();
+        auto const expiredBlob = makeList(
+            {listedValidator},
+            2,
+            (env.timeKeeper().now() - 1s).time_since_epoch().count(),
+            {},
+            {expiredCandidate});
+        auto const expiredSignature = signList(expiredBlob, publisherSigning);
+        auto const expiredResult = trustedKeys->applyLists(
+            publisherManifest,
+            1,
+            {{expiredBlob, expiredSignature, {}}},
+            "testCandidates.test");
+        BEAST_EXPECTS(
+            expiredResult.bestDisposition() == ListDisposition::expired,
+            to_string(expiredResult.bestDisposition()));
+        BEAST_EXPECT(
+            !validatorManifests.getSequence(expiredCandidate.masterPublic));
 
         // An optional candidates member is accepted only as an array.
         auto invalidJson = base64_decode(blob);

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -696,12 +696,17 @@ private:
 
         checkResult(
             trustedKeys->applyLists(
-                manifest1,
-                version,
-                {{expiredblob, expiredSig, {}}, {blob2, sig2, {}}},
-                siteUri),
+                manifest1, version, {{expiredblob, expiredSig, {}}}, siteUri),
             publisherPublic,
             ListDisposition::expired,
+            ListDisposition::expired);
+        expectUntrusted(lists.at(1));
+
+        checkResult(
+            trustedKeys->applyLists(
+                manifest1, version, {{blob2, sig2, {}}}, siteUri),
+            publisherPublic,
+            ListDisposition::accepted,
             ListDisposition::accepted);
 
         expectTrusted(lists.at(2));
@@ -1277,6 +1282,62 @@ private:
         // not remove publisher B's contribution.
         BEAST_EXPECT(validators->listed(shared.masterPublic));
         BEAST_EXPECT(validators->listed(replacement.masterPublic));
+
+        // Reapplying a pending list after its expiry exercises applyList's
+        // remaining-to-current recovery path rather than updateTrusted.
+        app.getOPs().clearUNLBlocked();
+        auto const expiredOnly = randomValidator();
+        auto const pendingAgain = makeList(
+            {expiredOnly},
+            3,
+            (env.timeKeeper().now() + 20s).time_since_epoch().count(),
+            (env.timeKeeper().now() + 10s).time_since_epoch().count());
+        auto const pendingAgainSig = signList(pendingAgain, publisherA.signing);
+        checkResult(
+            validators->applyLists(
+                publisherA.manifest,
+                2,
+                {{pendingAgain, pendingAgainSig, {}}},
+                siteUri),
+            publisherA.master,
+            ListDisposition::pending,
+            ListDisposition::pending);
+
+        env.timeKeeper().set(env.timeKeeper().now() + 21s);
+        checkResult(
+            validators->applyListsAndBroadcast(
+                publisherA.manifest,
+                2,
+                {{pendingAgain, pendingAgainSig, {}}},
+                siteUri,
+                uint256{},
+                app.overlay(),
+                app.getHashRouter(),
+                app.getOPs()),
+            publisherA.master,
+            ListDisposition::expired,
+            ListDisposition::expired);
+        BEAST_EXPECT(app.getOPs().isUNLBlocked());
+        BEAST_EXPECT(!validators->listed(replacement.masterPublic));
+        BEAST_EXPECT(!validators->listed(expiredOnly.masterPublic));
+        BEAST_EXPECT(validators->listed(shared.masterPublic));
+
+        // Publisher A never contributed expiredOnly. When publisher B moves
+        // away from shared, neither key may survive through phantom counts.
+        auto const replacementB = randomValidator();
+        auto const refreshB = makeList(
+            {replacementB},
+            2,
+            (env.timeKeeper().now() + 1h).time_since_epoch().count());
+        auto const refreshBSig = signList(refreshB, publisherB.signing);
+        checkResult(
+            validators->applyLists(
+                publisherB.manifest, 2, {{refreshB, refreshBSig, {}}}, siteUri),
+            publisherB.master,
+            ListDisposition::accepted,
+            ListDisposition::accepted);
+        BEAST_EXPECT(!validators->listed(shared.masterPublic));
+        BEAST_EXPECT(validators->listed(replacementB.masterPublic));
     }
 
     void

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -285,7 +285,9 @@ private:
                 localSigningPublicOuter, emptyCfgKeys, emptyCfgPublishers));
             BEAST_EXPECT(trustedKeys->listed(localSigningPublicOuter));
 
-            manifests.applyManifest(*deserializeManifest(cfgManifest));
+            manifests.applyManifest(
+                *deserializeManifest(cfgManifest),
+                ManifestRateLimitCapPolicy::Capped);
             BEAST_EXPECT(trustedKeys->load(
                 localSigningPublicOuter, emptyCfgKeys, emptyCfgPublishers));
 
@@ -382,7 +384,9 @@ private:
                 app.config().legacy("database_path"),
                 env.journal);
 
-            manifests.applyManifest(*deserializeManifest(cfgManifest));
+            manifests.applyManifest(
+                *deserializeManifest(cfgManifest),
+                ManifestRateLimitCapPolicy::Capped);
 
             BEAST_EXPECT(trustedKeys->load(
                 localSigningPublicOuter, cfgKeys, emptyCfgPublishers));
@@ -472,12 +476,14 @@ private:
             auto const pubRevokedSigning = randomKeyPair(KeyType::secp256k1);
             // make this manifest revoked (seq num = max)
             //  -- thus should not be loaded
-            pubManifests.applyManifest(*deserializeManifest(makeManifestString(
-                pubRevokedPublic,
-                pubRevokedSecret,
-                pubRevokedSigning.first,
-                pubRevokedSigning.second,
-                std::numeric_limits<std::uint32_t>::max())));
+            pubManifests.applyManifest(
+                *deserializeManifest(makeManifestString(
+                    pubRevokedPublic,
+                    pubRevokedSecret,
+                    pubRevokedSigning.first,
+                    pubRevokedSigning.second,
+                    std::numeric_limits<std::uint32_t>::max())),
+                ManifestRateLimitCapPolicy::Capped);
 
             // these two are not revoked (and not in the manifest cache at all.)
             auto legitKey1 = randomMasterKey();
@@ -511,12 +517,14 @@ private:
             auto const pubRevokedSigning = randomKeyPair(KeyType::secp256k1);
             // make this manifest revoked (seq num = max)
             //  -- thus should not be loaded
-            pubManifests.applyManifest(*deserializeManifest(makeManifestString(
-                pubRevokedPublic,
-                pubRevokedSecret,
-                pubRevokedSigning.first,
-                pubRevokedSigning.second,
-                std::numeric_limits<std::uint32_t>::max())));
+            pubManifests.applyManifest(
+                *deserializeManifest(makeManifestString(
+                    pubRevokedPublic,
+                    pubRevokedSecret,
+                    pubRevokedSigning.first,
+                    pubRevokedSigning.second,
+                    std::numeric_limits<std::uint32_t>::max())),
+                ManifestRateLimitCapPolicy::Capped);
 
             // this one is not revoked (and not in the manifest cache at all.)
             auto legitKey = randomMasterKey();
@@ -1237,7 +1245,8 @@ private:
                 1));
 
             BEAST_EXPECT(
-                manifestsOuter.applyManifest(std::move(*m1)) ==
+                manifestsOuter.applyManifest(
+                    std::move(*m1), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(trustedKeysOuter->listed(masterPublic));
             BEAST_EXPECT(trustedKeysOuter->trusted(masterPublic));
@@ -1255,7 +1264,8 @@ private:
                 signingKeys2.second,
                 2));
             BEAST_EXPECT(
-                manifestsOuter.applyManifest(std::move(*m2)) ==
+                manifestsOuter.applyManifest(
+                    std::move(*m2), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(trustedKeysOuter->listed(masterPublic));
             BEAST_EXPECT(trustedKeysOuter->trusted(masterPublic));
@@ -1273,7 +1283,8 @@ private:
 
             BEAST_EXPECT(mMax->revoked());
             BEAST_EXPECT(
-                manifestsOuter.applyManifest(std::move(*mMax)) ==
+                manifestsOuter.applyManifest(
+                    std::move(*mMax), ManifestRateLimitCapPolicy::Capped) ==
                 ManifestDisposition::accepted);
             BEAST_EXPECT(
                 manifestsOuter.getSigningKey(masterPublic) == masterPublic);
@@ -2772,7 +2783,8 @@ private:
             if (self)
             {
                 valManifests.applyManifest(
-                    *deserializeManifest(base64_decode(self->manifest)));
+                    *deserializeManifest(base64_decode(self->manifest)),
+                    ManifestRateLimitCapPolicy::Capped);
                 BEAST_EXPECT(result->load(
                     self->signingPublic,
                     emptyCfgKeys,

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1066,6 +1066,19 @@ private:
 
         auto const listedValidator = randomValidator();
         auto const candidate = randomValidator();
+        auto const liveCandidateSecret = randomSecretKey();
+        auto const liveCandidateMaster =
+            derivePublicKey(KeyType::ed25519, liveCandidateSecret);
+        auto const liveCandidateSigning = randomKeyPair(KeyType::secp256k1);
+        Validator const liveCandidate{
+            liveCandidateMaster,
+            liveCandidateSigning.first,
+            base64_encode(makeManifestString(
+                liveCandidateMaster,
+                liveCandidateSecret,
+                liveCandidateSigning.first,
+                liveCandidateSigning.second,
+                1))};
 
         auto const equalSequenceMasterSecret = randomSecretKey();
         auto const equalSequenceMaster =
@@ -1198,6 +1211,7 @@ private:
             validUntil.time_since_epoch().count(),
             {},
             {candidate,
+             liveCandidate,
              equalSequenceCandidate,
              candidateUsingOrdinaryMaster,
              candidateUsingOrdinarySigningAsMaster,
@@ -1223,6 +1237,16 @@ private:
         BEAST_EXPECT(!trustedKeys->listed(candidate.signingPublic));
         BEAST_EXPECT(!trustedKeys->trusted(candidate.masterPublic));
         BEAST_EXPECT(!trustedKeys->trusted(candidate.signingPublic));
+        auto candidatePolicy =
+            trustedKeys->manifestPolicy(candidate.masterPublic);
+        BEAST_EXPECT(!candidatePolicy.consensusListed);
+        BEAST_EXPECT(candidatePolicy.publisherCandidate);
+        BEAST_EXPECT(candidatePolicy.relayEligible());
+        auto listedPolicy =
+            trustedKeys->manifestPolicy(listedValidator.masterPublic);
+        BEAST_EXPECT(listedPolicy.consensusListed);
+        BEAST_EXPECT(!listedPolicy.publisherCandidate);
+        BEAST_EXPECT(listedPolicy.relayEligible());
 
         // Candidate state does not enter the ordinary manifest cache.
         BEAST_EXPECT(
@@ -1328,6 +1352,25 @@ private:
         });
         BEAST_EXPECT(!candidateRelayed);
 
+        auto const liveRotation = randomKeyPair(KeyType::secp256k1);
+        auto liveManifest = deserializeManifest(makeManifestString(
+            liveCandidateMaster,
+            liveCandidateSecret,
+            liveRotation.first,
+            liveRotation.second,
+            2));
+        BEAST_EXPECT(liveManifest);
+        if (liveManifest)
+        {
+            BEAST_EXPECT(
+                trustedKeys->applyCandidateManifest(std::move(*liveManifest)) ==
+                ManifestDisposition::accepted);
+        }
+        BEAST_EXPECT(
+            trustedKeys->lookupMonitoringIdentity(liveCandidateMaster)
+                .signing == liveRotation.first);
+        BEAST_EXPECT(trustedKeys->candidateManifestOverrides().size() == 1);
+
         // A malformed candidate invalidates only the candidate extension.
         // The signed legacy validator list, including its associated manifest,
         // remains accepted and applied.
@@ -1357,6 +1400,14 @@ private:
         BEAST_EXPECT(
             trustedKeys->lookupMonitoringIdentity(candidate.masterPublic)
                 .status == ValidatorIdentityStatus::unknown);
+        BEAST_EXPECT(
+            trustedKeys->lookupMonitoringIdentity(liveCandidateMaster).status ==
+            ValidatorIdentityStatus::unknown);
+        BEAST_EXPECT(trustedKeys->candidateManifestOverrides().empty());
+        candidatePolicy = trustedKeys->manifestPolicy(candidate.masterPublic);
+        BEAST_EXPECT(!candidatePolicy.consensusListed);
+        BEAST_EXPECT(!candidatePolicy.publisherCandidate);
+        BEAST_EXPECT(!candidatePolicy.relayEligible());
 
         // Promotion is explicit. Repeating a candidate manifest in the
         // validators tier moves it into ordinary manifest state; merely having
@@ -1378,6 +1429,10 @@ private:
             validatorManifests.getMasterKey(candidate.signingPublic) ==
             candidate.masterPublic);
         BEAST_EXPECT(trustedKeys->listed(candidate.signingPublic));
+        candidatePolicy = trustedKeys->manifestPolicy(candidate.masterPublic);
+        BEAST_EXPECT(candidatePolicy.consensusListed);
+        BEAST_EXPECT(!candidatePolicy.publisherCandidate);
+        BEAST_EXPECT(candidatePolicy.relayEligible());
         identity =
             trustedKeys->lookupMonitoringIdentity(candidate.masterPublic);
         BEAST_EXPECT(identity.status == ValidatorIdentityStatus::resolved);

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -131,7 +131,8 @@ private:
         std::vector<Validator> const& validators,
         std::size_t sequence,
         std::size_t validUntil,
-        std::optional<std::size_t> validFrom = {})
+        std::optional<std::size_t> validFrom = {},
+        std::vector<Validator> const& candidates = {})
     {
         std::string data = "{\"sequence\":" + std::to_string(sequence) +
             ",\"expiration\":" + std::to_string(validUntil);
@@ -146,7 +147,22 @@ private:
         }
 
         data.pop_back();
-        data += "]}";
+        data += "]";
+
+        if (!candidates.empty())
+        {
+            data += ",\"candidates\":[";
+            for (auto const& val : candidates)
+            {
+                data += "{\"validation_public_key\":\"" +
+                    strHex(val.masterPublic) + "\",\"manifest\":\"" +
+                    val.manifest + "\"},";
+            }
+            data.pop_back();
+            data += "]";
+        }
+
+        data += "}";
         return base64_encode(data);
     }
 
@@ -988,6 +1004,97 @@ private:
         }
 
         checkAvailable(trustedKeys, hexPublic, manifest2, 0, {});
+    }
+
+    void
+    testCandidates()
+    {
+        testcase("Publisher candidate manifests");
+        using namespace std::chrono_literals;
+
+        ManifestCache validatorManifests;
+        ManifestCache publisherManifests;
+        jtx::Env env(*this);
+        auto& app = env.app();
+        auto trustedKeys = std::make_unique<ValidatorList>(
+            validatorManifests,
+            publisherManifests,
+            env.timeKeeper(),
+            app.config().legacy("database_path"),
+            env.journal);
+
+        auto const publisherSecret = randomSecretKey();
+        auto const publisherPublic =
+            derivePublicKey(KeyType::ed25519, publisherSecret);
+        auto const publisherSigning = randomKeyPair(KeyType::secp256k1);
+        auto const publisherManifest = base64_encode(makeManifestString(
+            publisherPublic,
+            publisherSecret,
+            publisherSigning.first,
+            publisherSigning.second,
+            1));
+
+        BEAST_EXPECT(trustedKeys->load(
+            {}, {}, std::vector<std::string>{strHex(publisherPublic)}));
+
+        auto const listedValidator = randomValidator();
+        auto const candidate = randomValidator();
+        auto const validUntil = env.timeKeeper().now() + 1h;
+        auto const blob = makeList(
+            {listedValidator},
+            1,
+            validUntil.time_since_epoch().count(),
+            {},
+            {candidate});
+        auto const signature = signList(blob, publisherSigning);
+
+        BEAST_EXPECT(
+            trustedKeys
+                ->applyLists(
+                    publisherManifest,
+                    1,
+                    {{blob, signature, {}}},
+                    "testCandidates.test")
+                .bestDisposition() == ListDisposition::accepted);
+
+        BEAST_EXPECT(trustedKeys->listed(listedValidator.masterPublic));
+        BEAST_EXPECT(!trustedKeys->listed(candidate.masterPublic));
+        BEAST_EXPECT(!trustedKeys->listed(candidate.signingPublic));
+        BEAST_EXPECT(!trustedKeys->trusted(candidate.masterPublic));
+        BEAST_EXPECT(!trustedKeys->trusted(candidate.signingPublic));
+        BEAST_EXPECT(
+            validatorManifests.getMasterKey(candidate.signingPublic) ==
+            candidate.masterPublic);
+        BEAST_EXPECT(
+            validatorManifests.getSigningKey(candidate.masterPublic) ==
+            candidate.signingPublic);
+
+        // An optional candidates member is accepted only as an array.
+        auto invalidJson = base64_decode(blob);
+        auto const pos = invalidJson.find("\"candidates\":[");
+        BEAST_EXPECT(pos != std::string::npos);
+        if (pos != std::string::npos)
+        {
+            auto const arrayStart = pos + std::string{"\"candidates\":"}.size();
+            auto const arrayEnd = invalidJson.find(']', arrayStart);
+            BEAST_EXPECT(arrayEnd != std::string::npos);
+            if (arrayEnd != std::string::npos)
+            {
+                invalidJson.replace(
+                    arrayStart, arrayEnd - arrayStart + 1, "{}");
+                auto const invalidBlob = base64_encode(invalidJson);
+                auto const invalidSignature =
+                    signList(invalidBlob, publisherSigning);
+                BEAST_EXPECT(
+                    trustedKeys
+                        ->applyLists(
+                            publisherManifest,
+                            1,
+                            {{invalidBlob, invalidSignature, {}}},
+                            "testCandidates.test")
+                        .bestDisposition() == ListDisposition::invalid);
+            }
+        }
     }
 
     void
@@ -4146,6 +4253,7 @@ public:
         testGenesisQuorum();
         testConfigLoad();
         testApplyLists();
+        testCandidates();
         testGetAvailable();
         testUpdateTrusted();
         testExpires();

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1394,9 +1394,8 @@ private:
         BEAST_EXPECT(trustedKeys->trusted(directListedKey));
         BEAST_EXPECT(trustedKeys->trusted(candidate.signingPublic));
 
-        // An already-expired generation does not seed current candidates or
-        // selection, but its independently valid validator manifests may still
-        // advance the ordinary manifest high-water.
+        // An already-expired generation preserves legacy ordinary-list and
+        // manifest handling, but does not seed the current candidate view.
         env.timeKeeper().set(env.timeKeeper().now() + 2s);
         auto const expiredCandidate = randomValidator();
         auto const expiredValidator = randomValidator();
@@ -1422,7 +1421,7 @@ private:
             !validatorManifests.getSequence(expiredCandidate.masterPublic));
         BEAST_EXPECT(
             validatorManifests.getSequence(expiredValidator.masterPublic));
-        BEAST_EXPECT(!trustedKeys->listed(expiredValidator.masterPublic));
+        BEAST_EXPECT(trustedKeys->listed(expiredValidator.masterPublic));
 
         // A malformed extension does not reject a newer legacy validator
         // generation; it contributes no candidates.

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -143,7 +143,10 @@ private:
         for (auto const& val : validators)
         {
             data += "{\"validation_public_key\":\"" + strHex(val.masterPublic) +
-                "\",\"manifest\":\"" + val.manifest + "\"},";
+                "\"";
+            if (!val.manifest.empty())
+                data += ",\"manifest\":\"" + val.manifest + "\"";
+            data += "},";
         }
 
         data.pop_back();
@@ -155,8 +158,10 @@ private:
             for (auto const& val : candidates)
             {
                 data += "{\"validation_public_key\":\"" +
-                    strHex(val.masterPublic) + "\",\"manifest\":\"" +
-                    val.manifest + "\"},";
+                    strHex(val.masterPublic) + "\"";
+                if (!val.manifest.empty())
+                    data += ",\"manifest\":\"" + val.manifest + "\"";
+                data += "},";
             }
             data.pop_back();
             data += "]";
@@ -1044,9 +1049,9 @@ private:
             {toBase58(TokenType::NodePublic, directListedKey)},
             std::vector<std::string>{strHex(publisherPublic)}));
 
-        // Publisher candidates have a separate bounded lifetime and remain
-        // available even when ordinary untrusted gossip has filled its cache.
-        for (std::size_t i = 0; i < ManifestCache::maxPublisherCandidates; ++i)
+        // Publisher candidates are independent of the ordinary untrusted
+        // cache and remain observable when that cache is full.
+        for (std::size_t i = 0; i < ValidatorList::maxPublisherCandidates; ++i)
         {
             auto const filler = randomValidator();
             auto manifest = deserializeManifest(base64_decode(filler.manifest));
@@ -1061,48 +1066,10 @@ private:
 
         auto const listedValidator = randomValidator();
         auto const candidate = randomValidator();
-        auto const lateListedKey = randomKeyPair(KeyType::secp256k1);
-        auto const lateCandidateMasterSecret = randomSecretKey();
-        auto const lateCandidateMaster =
-            derivePublicKey(KeyType::ed25519, lateCandidateMasterSecret);
-        Validator const lateCollisionCandidate{
-            lateCandidateMaster,
-            lateListedKey.first,
-            base64_encode(makeManifestString(
-                lateCandidateMaster,
-                lateCandidateMasterSecret,
-                lateListedKey.first,
-                lateListedKey.second,
-                1))};
 
-        auto const maskedCandidateMasterSecret = randomSecretKey();
-        auto const maskedCandidateMaster =
-            derivePublicKey(KeyType::ed25519, maskedCandidateMasterSecret);
-        auto const maskedCandidateSigning = randomKeyPair(KeyType::secp256k1);
-        Validator const maskedCandidate{
-            maskedCandidateMaster,
-            maskedCandidateSigning.first,
-            base64_encode(makeManifestString(
-                maskedCandidateMaster,
-                maskedCandidateMasterSecret,
-                maskedCandidateSigning.first,
-                maskedCandidateSigning.second,
-                1))};
-
-        auto const revokedMainMasterSecret = randomSecretKey();
-        auto const revokedMainMaster =
-            derivePublicKey(KeyType::ed25519, revokedMainMasterSecret);
-        auto const revokedMainSigning = randomKeyPair(KeyType::secp256k1);
-        Validator const revokedMainCandidate{
-            revokedMainMaster,
-            revokedMainSigning.first,
-            base64_encode(makeManifestString(
-                revokedMainMaster,
-                revokedMainMasterSecret,
-                revokedMainSigning.first,
-                revokedMainSigning.second,
-                1))};
-        auto const graduatingCandidate = randomValidator();
+        auto const bareSecret = randomSecretKey();
+        auto const bareMaster = derivePublicKey(KeyType::ed25519, bareSecret);
+        Validator const bareCandidate{bareMaster, bareMaster, {}};
 
         auto const revokedCandidateSecret = randomSecretKey();
         auto const revokedCandidateMaster =
@@ -1125,30 +1092,13 @@ private:
                 directListedSecret,
                 1))};
 
-        auto mismatchedCandidate = randomValidator();
-        auto const mismatchedManifestOwner = randomValidator();
-        mismatchedCandidate.manifest = mismatchedManifestOwner.manifest;
-
-        auto invalidCandidate = randomValidator();
-        auto invalidManifest = base64_decode(invalidCandidate.manifest);
-        invalidManifest.back() ^= 1;
-        invalidCandidate.manifest = base64_encode(invalidManifest);
-
         auto const validUntil = env.timeKeeper().now() + 1h;
         auto const blob = makeList(
             {listedValidator},
             1,
             validUntil.time_since_epoch().count(),
             {},
-            {candidate,
-             lateCollisionCandidate,
-             maskedCandidate,
-             revokedMainCandidate,
-             graduatingCandidate,
-             revokedCandidate,
-             collidingCandidate,
-             mismatchedCandidate,
-             invalidCandidate});
+            {candidate, bareCandidate, revokedCandidate, collidingCandidate});
         auto const signature = signList(blob, publisherSigning);
 
         BEAST_EXPECT(
@@ -1165,58 +1115,50 @@ private:
         BEAST_EXPECT(!trustedKeys->listed(candidate.signingPublic));
         BEAST_EXPECT(!trustedKeys->trusted(candidate.masterPublic));
         BEAST_EXPECT(!trustedKeys->trusted(candidate.signingPublic));
+
+        // Candidate state does not enter the ordinary manifest cache.
         BEAST_EXPECT(
             validatorManifests.getMasterKey(candidate.signingPublic) ==
-            candidate.masterPublic);
-        BEAST_EXPECT(
-            validatorManifests.getSigningKey(candidate.masterPublic) ==
             candidate.signingPublic);
         BEAST_EXPECT(
-            validatorManifests.getMasterKey(lateListedKey.first) ==
-            lateCandidateMaster);
+            validatorManifests.getSigningKey(candidate.masterPublic) ==
+            candidate.masterPublic);
+        BEAST_EXPECT(!validatorManifests.getSequence(candidate.masterPublic));
 
-        // Ordinary manifest state masks candidate state dynamically in both
-        // lookup directions. This is current-view priority, not retained
-        // shadow history.
-        auto const mainCollisionMasterSecret = randomSecretKey();
-        auto const mainCollisionMaster =
-            derivePublicKey(KeyType::ed25519, mainCollisionMasterSecret);
-        auto mainCollision = deserializeManifest(makeManifestString(
-            mainCollisionMaster,
-            mainCollisionMasterSecret,
-            maskedCandidateSigning.first,
-            maskedCandidateSigning.second,
-            1));
-        BEAST_EXPECT(mainCollision);
-        if (mainCollision)
-            BEAST_EXPECT(
-                validatorManifests.applyManifest(
-                    std::move(*mainCollision),
-                    ManifestRateLimitCapPolicy::Uncapped) ==
-                ManifestDisposition::accepted);
+        auto identity =
+            trustedKeys->lookupMonitoringIdentity(candidate.masterPublic);
+        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::resolved);
+        BEAST_EXPECT(identity.master == candidate.masterPublic);
+        BEAST_EXPECT(identity.signing == candidate.signingPublic);
+        BEAST_EXPECT(!identity.presentInOrdinaryState);
         BEAST_EXPECT(
-            validatorManifests.getMasterKey(maskedCandidateSigning.first) ==
-            mainCollisionMaster);
+            identity.candidateIdentityPublishers.contains(publisherPublic));
         BEAST_EXPECT(
-            validatorManifests.getSigningKey(maskedCandidateMaster) ==
-            maskedCandidateMaster);
-        BEAST_EXPECT(!validatorManifests.getSequence(maskedCandidateMaster));
+            identity.candidateManifestPublishers.contains(publisherPublic));
 
-        auto mainRevocation = deserializeManifest(
-            makeRevocationString(revokedMainMaster, revokedMainMasterSecret));
-        BEAST_EXPECT(mainRevocation);
-        if (mainRevocation)
-            BEAST_EXPECT(
-                validatorManifests.applyManifest(
-                    std::move(*mainRevocation),
-                    ManifestRateLimitCapPolicy::Uncapped) ==
-                ManifestDisposition::accepted);
-        BEAST_EXPECT(validatorManifests.revoked(revokedMainMaster));
+        auto signer =
+            trustedKeys->resolveMonitoringSigner(candidate.signingPublic);
+        BEAST_EXPECT(signer.status == ValidatorIdentityStatus::resolved);
+        BEAST_EXPECT(signer.master == candidate.masterPublic);
+
+        auto bare = trustedKeys->lookupMonitoringIdentity(bareMaster);
+        BEAST_EXPECT(bare.status == ValidatorIdentityStatus::resolved);
+        BEAST_EXPECT(bare.signing == bareMaster);
+
+        auto revoked =
+            trustedKeys->lookupMonitoringIdentity(revokedCandidateMaster);
+        BEAST_EXPECT(revoked.status == ValidatorIdentityStatus::revoked);
         BEAST_EXPECT(
-            validatorManifests.getSigningKey(revokedMainMaster) ==
-            revokedMainMaster);
-        BEAST_EXPECT(!validatorManifests.getSequence(revokedMainMaster));
-        BEAST_EXPECT(!validatorManifests.getManifest(revokedMainMaster));
+            trustedKeys->resolveMonitoringSigner(revokedCandidateMaster)
+                .status == ValidatorIdentityStatus::unknown);
+
+        // A valid candidate can intentionally reuse a key only when it can
+        // produce both required signatures. The monitoring view reports the
+        // resulting cross-master ambiguity; consensus remains on the direct
+        // listed identity.
+        auto collision = trustedKeys->resolveMonitoringSigner(directListedKey);
+        BEAST_EXPECT(collision.status == ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(trustedKeys->listed(directListedKey));
 
         bool candidateRelayed = false;
         validatorManifests.for_each_manifest([&](Manifest const& manifest) {
@@ -1224,40 +1166,20 @@ private:
                 manifest.masterKey == candidate.masterPublic;
         });
         BEAST_EXPECT(!candidateRelayed);
-        BEAST_EXPECT(
-            validatorManifests.getMasterKey(
-                graduatingCandidate.signingPublic) ==
-            graduatingCandidate.masterPublic);
-        BEAST_EXPECT(validatorManifests.revoked(revokedCandidateMaster));
-        BEAST_EXPECT(
-            validatorManifests.getMasterKey(directListedKey) ==
-            directListedKey);
-        BEAST_EXPECT(trustedKeys->listed(directListedKey));
-        BEAST_EXPECT(!validatorManifests.getSequence(collidingMaster));
-        BEAST_EXPECT(
-            !validatorManifests.getSequence(mismatchedCandidate.masterPublic));
-        BEAST_EXPECT(
-            !validatorManifests.getSequence(invalidCandidate.masterPublic));
 
-        // Promotion is explicit: a candidate affects authoritative state only
-        // when its manifest appears in the validators tier. A newly listed
-        // signing alias remains a direct identity.
-        Validator const lateListedValidator{
-            lateListedKey.first, lateListedKey.first, {}};
-        Validator const graduatingListedValidator = graduatingCandidate;
-        Validator const revokedListedValidator = revokedCandidate;
+        // A malformed candidate invalidates only the candidate extension.
+        // The signed legacy validator list, including its associated manifest,
+        // remains accepted and applied.
+        auto invalidCandidate = randomValidator();
+        auto invalidManifest = base64_decode(invalidCandidate.manifest);
+        invalidManifest.back() ^= 1;
+        invalidCandidate.manifest = base64_encode(invalidManifest);
         auto const secondBlob = makeList(
-            {listedValidator,
-             lateListedValidator,
-             graduatingListedValidator,
-             revokedListedValidator},
+            {listedValidator},
             2,
             validUntil.time_since_epoch().count(),
             {},
-            {candidate,
-             lateCollisionCandidate,
-             graduatingCandidate,
-             revokedCandidate});
+            {candidate, invalidCandidate});
         auto const secondSignature = signList(secondBlob, publisherSigning);
         BEAST_EXPECT(
             trustedKeys
@@ -1267,17 +1189,40 @@ private:
                     {{secondBlob, secondSignature, {}}},
                     "testCandidates.test")
                 .bestDisposition() == ListDisposition::accepted);
-        BEAST_EXPECT(trustedKeys->listed(lateListedKey.first));
+        BEAST_EXPECT(trustedKeys->listed(listedValidator.signingPublic));
         BEAST_EXPECT(
-            validatorManifests.getMasterKey(lateListedKey.first) ==
-            lateListedKey.first);
+            validatorManifests.getMasterKey(listedValidator.signingPublic) ==
+            listedValidator.masterPublic);
         BEAST_EXPECT(
-            validatorManifests.getAuthoritativeSigningKey(
-                graduatingCandidate.masterPublic) ==
-            graduatingCandidate.signingPublic);
-        BEAST_EXPECT(trustedKeys->listed(graduatingCandidate.signingPublic));
+            trustedKeys->lookupMonitoringIdentity(candidate.masterPublic)
+                .status == ValidatorIdentityStatus::unknown);
+
+        // Promotion is explicit. Repeating a candidate manifest in the
+        // validators tier moves it into ordinary manifest state; merely having
+        // appeared in an older candidate generation does not.
+        auto const thirdBlob = makeList(
+            {listedValidator, candidate, revokedCandidate},
+            3,
+            validUntil.time_since_epoch().count());
+        auto const thirdSignature = signList(thirdBlob, publisherSigning);
         BEAST_EXPECT(
-            validatorManifests.authoritativeRevoked(revokedCandidateMaster));
+            trustedKeys
+                ->applyLists(
+                    publisherManifest,
+                    1,
+                    {{thirdBlob, thirdSignature, {}}},
+                    "testCandidates.test")
+                .bestDisposition() == ListDisposition::accepted);
+        BEAST_EXPECT(
+            validatorManifests.getMasterKey(candidate.signingPublic) ==
+            candidate.masterPublic);
+        BEAST_EXPECT(trustedKeys->listed(candidate.signingPublic));
+        identity =
+            trustedKeys->lookupMonitoringIdentity(candidate.masterPublic);
+        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::resolved);
+        BEAST_EXPECT(identity.presentInOrdinaryState);
+        BEAST_EXPECT(identity.candidateIdentityPublishers.empty());
+        BEAST_EXPECT(validatorManifests.revoked(revokedCandidateMaster));
 
         trustedKeys->updateTrusted(
             {},
@@ -1286,14 +1231,17 @@ private:
             env.app().overlay(),
             env.app().getHashRouter());
         BEAST_EXPECT(trustedKeys->trusted(directListedKey));
-        BEAST_EXPECT(!trustedKeys->trusted(candidate.masterPublic));
+        BEAST_EXPECT(trustedKeys->trusted(candidate.signingPublic));
 
-        // An already-expired generation must not seed candidate bindings.
+        // An already-expired generation does not seed current candidates or
+        // selection, but its independently valid validator manifests may still
+        // advance the ordinary manifest high-water.
         env.timeKeeper().set(env.timeKeeper().now() + 2s);
         auto const expiredCandidate = randomValidator();
+        auto const expiredValidator = randomValidator();
         auto const expiredBlob = makeList(
-            {listedValidator},
-            3,
+            {expiredValidator},
+            4,
             (env.timeKeeper().now() - 1s).time_since_epoch().count(),
             {},
             {expiredCandidate});
@@ -1307,10 +1255,13 @@ private:
             expiredResult.bestDisposition() == ListDisposition::expired,
             to_string(expiredResult.bestDisposition()));
         BEAST_EXPECT(
+            trustedKeys->lookupMonitoringIdentity(expiredCandidate.masterPublic)
+                .status == ValidatorIdentityStatus::unknown);
+        BEAST_EXPECT(
             !validatorManifests.getSequence(expiredCandidate.masterPublic));
         BEAST_EXPECT(
-            validatorManifests.getMasterKey(candidate.signingPublic) ==
-            candidate.signingPublic);
+            validatorManifests.getSequence(expiredValidator.masterPublic));
+        BEAST_EXPECT(!trustedKeys->listed(expiredValidator.masterPublic));
 
         // An optional candidates member is accepted only as an array.
         auto invalidJson = base64_decode(blob);

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1044,8 +1044,46 @@ private:
             {toBase58(TokenType::NodePublic, directListedKey)},
             std::vector<std::string>{strHex(publisherPublic)}));
 
+        // Publisher candidates have a separate bounded lifetime and remain
+        // available even when ordinary untrusted gossip has filled its cache.
+        for (std::size_t i = 0; i < ManifestCache::maxPublisherCandidates; ++i)
+        {
+            auto const filler = randomValidator();
+            auto manifest = deserializeManifest(base64_decode(filler.manifest));
+            BEAST_EXPECT(manifest);
+            if (manifest)
+                BEAST_EXPECT(
+                    validatorManifests.applyManifest(
+                        std::move(*manifest),
+                        ManifestRateLimitCapPolicy::Capped) ==
+                    ManifestDisposition::accepted);
+        }
+
         auto const listedValidator = randomValidator();
         auto const candidate = randomValidator();
+        auto const lateListedKey = randomKeyPair(KeyType::secp256k1);
+        auto const lateCandidateMasterSecret = randomSecretKey();
+        auto const lateCandidateMaster =
+            derivePublicKey(KeyType::ed25519, lateCandidateMasterSecret);
+        Validator const lateCollisionCandidate{
+            lateCandidateMaster,
+            lateListedKey.first,
+            base64_encode(makeManifestString(
+                lateCandidateMaster,
+                lateCandidateMasterSecret,
+                lateListedKey.first,
+                lateListedKey.second,
+                1))};
+        auto const graduatingCandidate = randomValidator();
+
+        auto const revokedCandidateSecret = randomSecretKey();
+        auto const revokedCandidateMaster =
+            derivePublicKey(KeyType::ed25519, revokedCandidateSecret);
+        Validator const revokedCandidate{
+            revokedCandidateMaster,
+            revokedCandidateMaster,
+            base64_encode(makeRevocationString(
+                revokedCandidateMaster, revokedCandidateSecret))};
         auto const collidingMasterSecret = randomSecretKey();
         auto const collidingMaster =
             derivePublicKey(KeyType::ed25519, collidingMasterSecret);
@@ -1075,6 +1113,9 @@ private:
             validUntil.time_since_epoch().count(),
             {},
             {candidate,
+             lateCollisionCandidate,
+             graduatingCandidate,
+             revokedCandidate,
              collidingCandidate,
              mismatchedCandidate,
              invalidCandidate});
@@ -1101,6 +1142,14 @@ private:
             validatorManifests.getSigningKey(candidate.masterPublic) ==
             candidate.signingPublic);
         BEAST_EXPECT(
+            validatorManifests.getMasterKey(lateListedKey.first) ==
+            lateCandidateMaster);
+        BEAST_EXPECT(
+            validatorManifests.getMasterKey(
+                graduatingCandidate.signingPublic) ==
+            graduatingCandidate.masterPublic);
+        BEAST_EXPECT(validatorManifests.revoked(revokedCandidateMaster));
+        BEAST_EXPECT(
             validatorManifests.getMasterKey(directListedKey) ==
             directListedKey);
         BEAST_EXPECT(trustedKeys->listed(directListedKey));
@@ -1109,6 +1158,46 @@ private:
             !validatorManifests.getSequence(mismatchedCandidate.masterPublic));
         BEAST_EXPECT(
             !validatorManifests.getSequence(invalidCandidate.masterPublic));
+
+        // Promotion is explicit: a candidate affects authoritative state only
+        // when its manifest appears in the validators tier. A newly listed
+        // signing alias remains a direct identity.
+        Validator const lateListedValidator{
+            lateListedKey.first, lateListedKey.first, {}};
+        Validator const graduatingListedValidator = graduatingCandidate;
+        Validator const revokedListedValidator = revokedCandidate;
+        auto const secondBlob = makeList(
+            {listedValidator,
+             lateListedValidator,
+             graduatingListedValidator,
+             revokedListedValidator},
+            2,
+            validUntil.time_since_epoch().count(),
+            {},
+            {candidate,
+             lateCollisionCandidate,
+             graduatingCandidate,
+             revokedCandidate});
+        auto const secondSignature = signList(secondBlob, publisherSigning);
+        BEAST_EXPECT(
+            trustedKeys
+                ->applyLists(
+                    publisherManifest,
+                    1,
+                    {{secondBlob, secondSignature, {}}},
+                    "testCandidates.test")
+                .bestDisposition() == ListDisposition::accepted);
+        BEAST_EXPECT(trustedKeys->listed(lateListedKey.first));
+        BEAST_EXPECT(
+            validatorManifests.getMasterKey(lateListedKey.first) ==
+            lateListedKey.first);
+        BEAST_EXPECT(
+            validatorManifests.getAuthoritativeSigningKey(
+                graduatingCandidate.masterPublic) ==
+            graduatingCandidate.signingPublic);
+        BEAST_EXPECT(trustedKeys->listed(graduatingCandidate.signingPublic));
+        BEAST_EXPECT(
+            validatorManifests.authoritativeRevoked(revokedCandidateMaster));
 
         trustedKeys->updateTrusted(
             {},
@@ -1124,7 +1213,7 @@ private:
         auto const expiredCandidate = randomValidator();
         auto const expiredBlob = makeList(
             {listedValidator},
-            2,
+            3,
             (env.timeKeeper().now() - 1s).time_since_epoch().count(),
             {},
             {expiredCandidate});
@@ -1139,6 +1228,9 @@ private:
             to_string(expiredResult.bestDisposition()));
         BEAST_EXPECT(
             !validatorManifests.getSequence(expiredCandidate.masterPublic));
+        BEAST_EXPECT(
+            validatorManifests.getMasterKey(candidate.signingPublic) ==
+            candidate.signingPublic);
 
         // An optional candidates member is accepted only as an array.
         auto invalidJson = base64_decode(blob);

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1263,8 +1263,15 @@ private:
             validatorManifests.getSequence(expiredValidator.masterPublic));
         BEAST_EXPECT(!trustedKeys->listed(expiredValidator.masterPublic));
 
-        // An optional candidates member is accepted only as an array.
-        auto invalidJson = base64_decode(blob);
+        // A malformed extension does not reject a newer legacy validator
+        // generation; it contributes no candidates.
+        auto const malformedShapeBlob = makeList(
+            {listedValidator},
+            5,
+            validUntil.time_since_epoch().count(),
+            {},
+            {candidate});
+        auto invalidJson = base64_decode(malformedShapeBlob);
         auto const pos = invalidJson.find("\"candidates\":[");
         BEAST_EXPECT(pos != std::string::npos);
         if (pos != std::string::npos)
@@ -1286,7 +1293,17 @@ private:
                             1,
                             {{invalidBlob, invalidSignature, {}}},
                             "testCandidates.test")
-                        .bestDisposition() == ListDisposition::invalid);
+                        .bestDisposition() == ListDisposition::accepted);
+                BEAST_EXPECT(
+                    trustedKeys->listed(listedValidator.signingPublic));
+                BEAST_EXPECT(
+                    trustedKeys
+                        ->lookupMonitoringIdentity(candidate.masterPublic)
+                        .status == ValidatorIdentityStatus::resolved);
+                BEAST_EXPECT(
+                    trustedKeys
+                        ->lookupMonitoringIdentity(candidate.masterPublic)
+                        .presentInOrdinaryState);
             }
         }
     }

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1178,6 +1178,108 @@ private:
     }
 
     void
+    testExpiredPendingAccounting()
+    {
+        testcase("Expired pending list preserves other publisher counts");
+        using namespace std::chrono_literals;
+
+        struct Publisher
+        {
+            PublicKey master;
+            std::pair<PublicKey, SecretKey> signing;
+            std::string manifest;
+        };
+
+        auto makePublisher = []() {
+            auto const masterSecret = randomSecretKey();
+            auto const master = derivePublicKey(KeyType::ed25519, masterSecret);
+            auto signing = randomKeyPair(KeyType::secp256k1);
+            auto manifest = base64_encode(makeManifestString(
+                master, masterSecret, signing.first, signing.second, 1));
+            return Publisher{master, std::move(signing), std::move(manifest)};
+        };
+
+        ManifestCache validatorManifests;
+        ManifestCache publisherManifests;
+        jtx::Env env(*this);
+        auto& app = env.app();
+        auto validators = std::make_unique<ValidatorList>(
+            validatorManifests,
+            publisherManifests,
+            env.timeKeeper(),
+            app.config().legacy("database_path"),
+            env.journal);
+
+        auto const publisherA = makePublisher();
+        auto const publisherB = makePublisher();
+        BEAST_EXPECT(validators->load(
+            {}, {}, {strHex(publisherA.master), strHex(publisherB.master)}));
+
+        auto const shared = randomValidator();
+        auto const replacement = randomValidator();
+        auto const now = env.timeKeeper().now();
+        std::string const siteUri = "expired-pending-accounting.test";
+
+        auto const currentBlob =
+            makeList({shared}, 1, (now + 1h).time_since_epoch().count());
+        auto const currentSig = signList(currentBlob, publisherB.signing);
+        checkResult(
+            validators->applyLists(
+                publisherB.manifest,
+                2,
+                {{currentBlob, currentSig, {}}},
+                siteUri),
+            publisherB.master,
+            ListDisposition::accepted,
+            ListDisposition::accepted);
+        BEAST_EXPECT(validators->listed(shared.masterPublic));
+
+        auto const pendingBlob = makeList(
+            {shared},
+            1,
+            (now + 20s).time_since_epoch().count(),
+            (now + 10s).time_since_epoch().count());
+        auto const pendingSig = signList(pendingBlob, publisherA.signing);
+        checkResult(
+            validators->applyLists(
+                publisherA.manifest,
+                2,
+                {{pendingBlob, pendingSig, {}}},
+                siteUri),
+            publisherA.master,
+            ListDisposition::pending,
+            ListDisposition::pending);
+
+        env.timeKeeper().set(now + 21s);
+        validators->updateTrusted(
+            {},
+            env.timeKeeper().now(),
+            app.getOPs(),
+            app.overlay(),
+            app.getHashRouter());
+        BEAST_EXPECT(app.getOPs().isUNLBlocked());
+        BEAST_EXPECT(validators->listed(shared.masterPublic));
+
+        auto const refreshBlob =
+            makeList({replacement}, 2, (now + 1h).time_since_epoch().count());
+        auto const refreshSig = signList(refreshBlob, publisherA.signing);
+        checkResult(
+            validators->applyLists(
+                publisherA.manifest,
+                2,
+                {{refreshBlob, refreshSig, {}}},
+                siteUri),
+            publisherA.master,
+            ListDisposition::accepted,
+            ListDisposition::accepted);
+
+        // Publisher A never contributed the shared key, so refreshing A must
+        // not remove publisher B's contribution.
+        BEAST_EXPECT(validators->listed(shared.masterPublic));
+        BEAST_EXPECT(validators->listed(replacement.masterPublic));
+    }
+
+    void
     testGetAvailable()
     {
         testcase("GetAvailable");
@@ -4334,6 +4436,7 @@ public:
         testConfigLoad();
         testApplyLists();
         testCandidates();
+        testExpiredPendingAccounting();
         testGetAvailable();
         testUpdateTrusted();
         testExpires();

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1074,6 +1074,34 @@ private:
                 lateListedKey.first,
                 lateListedKey.second,
                 1))};
+
+        auto const maskedCandidateMasterSecret = randomSecretKey();
+        auto const maskedCandidateMaster =
+            derivePublicKey(KeyType::ed25519, maskedCandidateMasterSecret);
+        auto const maskedCandidateSigning = randomKeyPair(KeyType::secp256k1);
+        Validator const maskedCandidate{
+            maskedCandidateMaster,
+            maskedCandidateSigning.first,
+            base64_encode(makeManifestString(
+                maskedCandidateMaster,
+                maskedCandidateMasterSecret,
+                maskedCandidateSigning.first,
+                maskedCandidateSigning.second,
+                1))};
+
+        auto const revokedMainMasterSecret = randomSecretKey();
+        auto const revokedMainMaster =
+            derivePublicKey(KeyType::ed25519, revokedMainMasterSecret);
+        auto const revokedMainSigning = randomKeyPair(KeyType::secp256k1);
+        Validator const revokedMainCandidate{
+            revokedMainMaster,
+            revokedMainSigning.first,
+            base64_encode(makeManifestString(
+                revokedMainMaster,
+                revokedMainMasterSecret,
+                revokedMainSigning.first,
+                revokedMainSigning.second,
+                1))};
         auto const graduatingCandidate = randomValidator();
 
         auto const revokedCandidateSecret = randomSecretKey();
@@ -1114,6 +1142,8 @@ private:
             {},
             {candidate,
              lateCollisionCandidate,
+             maskedCandidate,
+             revokedMainCandidate,
              graduatingCandidate,
              revokedCandidate,
              collidingCandidate,
@@ -1144,6 +1174,56 @@ private:
         BEAST_EXPECT(
             validatorManifests.getMasterKey(lateListedKey.first) ==
             lateCandidateMaster);
+
+        // Ordinary manifest state masks candidate state dynamically in both
+        // lookup directions. This is current-view priority, not retained
+        // shadow history.
+        auto const mainCollisionMasterSecret = randomSecretKey();
+        auto const mainCollisionMaster =
+            derivePublicKey(KeyType::ed25519, mainCollisionMasterSecret);
+        auto mainCollision = deserializeManifest(makeManifestString(
+            mainCollisionMaster,
+            mainCollisionMasterSecret,
+            maskedCandidateSigning.first,
+            maskedCandidateSigning.second,
+            1));
+        BEAST_EXPECT(mainCollision);
+        if (mainCollision)
+            BEAST_EXPECT(
+                validatorManifests.applyManifest(
+                    std::move(*mainCollision),
+                    ManifestRateLimitCapPolicy::Uncapped) ==
+                ManifestDisposition::accepted);
+        BEAST_EXPECT(
+            validatorManifests.getMasterKey(maskedCandidateSigning.first) ==
+            mainCollisionMaster);
+        BEAST_EXPECT(
+            validatorManifests.getSigningKey(maskedCandidateMaster) ==
+            maskedCandidateMaster);
+        BEAST_EXPECT(!validatorManifests.getSequence(maskedCandidateMaster));
+
+        auto mainRevocation = deserializeManifest(
+            makeRevocationString(revokedMainMaster, revokedMainMasterSecret));
+        BEAST_EXPECT(mainRevocation);
+        if (mainRevocation)
+            BEAST_EXPECT(
+                validatorManifests.applyManifest(
+                    std::move(*mainRevocation),
+                    ManifestRateLimitCapPolicy::Uncapped) ==
+                ManifestDisposition::accepted);
+        BEAST_EXPECT(validatorManifests.revoked(revokedMainMaster));
+        BEAST_EXPECT(
+            validatorManifests.getSigningKey(revokedMainMaster) ==
+            revokedMainMaster);
+        BEAST_EXPECT(!validatorManifests.getSequence(revokedMainMaster));
+        BEAST_EXPECT(!validatorManifests.getManifest(revokedMainMaster));
+
+        bool candidateRelayed = false;
+        validatorManifests.for_each_manifest([&](Manifest const& manifest) {
+            candidateRelayed = candidateRelayed ||
+                manifest.masterKey == candidate.masterPublic;
+        });
+        BEAST_EXPECT(!candidateRelayed);
         BEAST_EXPECT(
             validatorManifests.getMasterKey(
                 graduatingCandidate.signingPublic) ==

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1067,6 +1067,34 @@ private:
         auto const listedValidator = randomValidator();
         auto const candidate = randomValidator();
 
+        auto const equalSequenceMasterSecret = randomSecretKey();
+        auto const equalSequenceMaster =
+            derivePublicKey(KeyType::ed25519, equalSequenceMasterSecret);
+        auto const ordinaryEqualSigning = randomKeyPair(KeyType::secp256k1);
+        auto const candidateEqualSigning = randomKeyPair(KeyType::secp256k1);
+        auto ordinaryEqual = deserializeManifest(makeManifestString(
+            equalSequenceMaster,
+            equalSequenceMasterSecret,
+            ordinaryEqualSigning.first,
+            ordinaryEqualSigning.second,
+            1));
+        BEAST_EXPECT(ordinaryEqual);
+        if (ordinaryEqual)
+            BEAST_EXPECT(
+                validatorManifests.applyManifest(
+                    std::move(*ordinaryEqual),
+                    ManifestRateLimitCapPolicy::Uncapped) ==
+                ManifestDisposition::accepted);
+        Validator const equalSequenceCandidate{
+            equalSequenceMaster,
+            candidateEqualSigning.first,
+            base64_encode(makeManifestString(
+                equalSequenceMaster,
+                equalSequenceMasterSecret,
+                candidateEqualSigning.first,
+                candidateEqualSigning.second,
+                1))};
+
         auto const bareSecret = randomSecretKey();
         auto const bareMaster = derivePublicKey(KeyType::ed25519, bareSecret);
         Validator const bareCandidate{bareMaster, bareMaster, {}};
@@ -1098,7 +1126,11 @@ private:
             1,
             validUntil.time_since_epoch().count(),
             {},
-            {candidate, bareCandidate, revokedCandidate, collidingCandidate});
+            {candidate,
+             equalSequenceCandidate,
+             bareCandidate,
+             revokedCandidate,
+             collidingCandidate});
         auto const signature = signList(blob, publisherSigning);
 
         BEAST_EXPECT(
@@ -1140,6 +1172,18 @@ private:
             trustedKeys->resolveMonitoringSigner(candidate.signingPublic);
         BEAST_EXPECT(signer.status == ValidatorIdentityStatus::resolved);
         BEAST_EXPECT(signer.master == candidate.masterPublic);
+
+        // Same-master, same-sequence variants conflict symmetrically: neither
+        // signing key is attributed merely because it came from one layer.
+        BEAST_EXPECT(
+            trustedKeys->lookupMonitoringIdentity(equalSequenceMaster).status ==
+            ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(
+            trustedKeys->resolveMonitoringSigner(ordinaryEqualSigning.first)
+                .status == ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(
+            trustedKeys->resolveMonitoringSigner(candidateEqualSigning.first)
+                .status == ValidatorIdentityStatus::conflict);
 
         auto bare = trustedKeys->lookupMonitoringIdentity(bareMaster);
         BEAST_EXPECT(bare.status == ValidatorIdentityStatus::resolved);

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1183,6 +1183,115 @@ private:
     }
 
     void
+    testCandidateAggregateCap()
+    {
+        testcase("Publisher candidate aggregate cap");
+        using namespace std::chrono_literals;
+
+        struct Publisher
+        {
+            PublicKey master;
+            std::pair<PublicKey, SecretKey> signing;
+            std::string manifest;
+        };
+
+        auto makePublisher = []() {
+            auto const masterSecret = randomSecretKey();
+            auto const master = derivePublicKey(KeyType::ed25519, masterSecret);
+            auto signing = randomKeyPair(KeyType::secp256k1);
+            auto manifest = base64_encode(makeManifestString(
+                master, masterSecret, signing.first, signing.second, 1));
+            return Publisher{master, std::move(signing), std::move(manifest)};
+        };
+
+        std::array<Publisher, 2> const publishers{
+            makePublisher(), makePublisher()};
+        std::array<std::vector<Validator>, 2> candidates;
+        std::vector<PublicKey> candidateMasters;
+        candidateMasters.reserve(1200);
+        for (auto& publisherCandidates : candidates)
+        {
+            publisherCandidates.reserve(600);
+            for (std::size_t i = 0; i < 600; ++i)
+            {
+                auto candidate = randomValidator();
+                candidateMasters.push_back(candidate.masterPublic);
+                publisherCandidates.push_back(std::move(candidate));
+            }
+        }
+        std::sort(candidateMasters.begin(), candidateMasters.end());
+
+        jtx::Env env(*this);
+        auto const validUntil = env.timeKeeper().now() + 1h;
+        auto const listed = randomValidator();
+        std::array<std::string, 2> blobs;
+        std::array<std::string, 2> signatures;
+        for (std::size_t i = 0; i < publishers.size(); ++i)
+        {
+            blobs[i] = makeList(
+                {listed},
+                1,
+                validUntil.time_since_epoch().count(),
+                {},
+                candidates[i]);
+            signatures[i] = signList(blobs[i], publishers[i].signing);
+        }
+
+        auto checkOrder = [&](std::array<std::size_t, 2> const& order) {
+            ManifestCache validatorManifests;
+            ManifestCache publisherManifests;
+            auto trustedKeys = std::make_unique<ValidatorList>(
+                validatorManifests,
+                publisherManifests,
+                env.timeKeeper(),
+                env.app().config().legacy("database_path"),
+                env.journal);
+            BEAST_EXPECT(trustedKeys->load(
+                {},
+                {},
+                std::vector<std::string>{
+                    strHex(publishers[0].master),
+                    strHex(publishers[1].master)}));
+
+            for (auto const i : order)
+            {
+                BEAST_EXPECT(
+                    trustedKeys
+                        ->applyLists(
+                            publishers[i].manifest,
+                            1,
+                            {{blobs[i], signatures[i], {}}},
+                            "testCandidateAggregateCap.test")
+                        .bestDisposition() == ListDisposition::accepted);
+            }
+
+            hash_set<PublicKey> protectedMasters;
+            validatorManifests.for_each_manifest(
+                [&protectedMasters](std::size_t size) {
+                    protectedMasters.reserve(size);
+                },
+                [&protectedMasters](
+                    Manifest const& manifest, ManifestRetention retention) {
+                    if (retention == ManifestRetention::protected_)
+                        protectedMasters.insert(manifest.masterKey);
+                });
+
+            for (std::size_t i = 0; i < candidateMasters.size(); ++i)
+            {
+                auto const& master = candidateMasters[i];
+                auto const policy = trustedKeys->manifestPolicy(master);
+                bool const retained = i < ValidatorList::maxPublisherCandidates;
+                BEAST_EXPECT(policy.publisherCandidate == retained);
+                BEAST_EXPECT(policy.relayEligible() == retained);
+                BEAST_EXPECT(protectedMasters.contains(master) == retained);
+            }
+        };
+
+        checkOrder({0, 1});
+        checkOrder({1, 0});
+    }
+
+    void
     testExpiredPendingAccounting()
     {
         testcase("Expired pending list preserves other publisher counts");
@@ -4497,6 +4606,7 @@ public:
         testConfigLoad();
         testApplyLists();
         testCandidates();
+        testCandidateAggregateCap();
         testExpiredPendingAccounting();
         testGetAvailable();
         testUpdateTrusted();

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1095,6 +1095,77 @@ private:
                 candidateEqualSigning.second,
                 1))};
 
+        auto const ordinaryCrossMasterSecret = randomSecretKey();
+        auto const ordinaryCrossMaster =
+            derivePublicKey(KeyType::ed25519, ordinaryCrossMasterSecret);
+        auto const ordinaryCrossSigning = randomKeyPair(KeyType::secp256k1);
+        auto ordinaryCross = deserializeManifest(makeManifestString(
+            ordinaryCrossMaster,
+            ordinaryCrossMasterSecret,
+            ordinaryCrossSigning.first,
+            ordinaryCrossSigning.second,
+            1));
+        BEAST_EXPECT(ordinaryCross);
+        if (ordinaryCross)
+            BEAST_EXPECT(
+                validatorManifests.applyManifest(
+                    std::move(*ordinaryCross),
+                    ManifestRateLimitCapPolicy::Uncapped) ==
+                ManifestDisposition::accepted);
+
+        auto const candidateToOrdinaryMasterSecret = randomSecretKey();
+        auto const candidateToOrdinaryMaster =
+            derivePublicKey(KeyType::ed25519, candidateToOrdinaryMasterSecret);
+        Validator const candidateUsingOrdinaryMaster{
+            candidateToOrdinaryMaster,
+            ordinaryCrossMaster,
+            base64_encode(makeManifestString(
+                candidateToOrdinaryMaster,
+                candidateToOrdinaryMasterSecret,
+                ordinaryCrossMaster,
+                ordinaryCrossMasterSecret,
+                1))};
+        auto const candidateFromOrdinarySigning =
+            randomKeyPair(KeyType::secp256k1);
+        Validator const candidateUsingOrdinarySigningAsMaster{
+            ordinaryCrossSigning.first,
+            candidateFromOrdinarySigning.first,
+            base64_encode(makeManifestString(
+                ordinaryCrossSigning.first,
+                ordinaryCrossSigning.second,
+                candidateFromOrdinarySigning.first,
+                candidateFromOrdinarySigning.second,
+                1))};
+
+        auto const ordinaryRevocationOwnerSecret = randomSecretKey();
+        auto const ordinaryRevocationOwner =
+            derivePublicKey(KeyType::ed25519, ordinaryRevocationOwnerSecret);
+        auto const ordinaryRevokedAlias = randomKeyPair(KeyType::secp256k1);
+        auto ordinaryForRevocation = deserializeManifest(makeManifestString(
+            ordinaryRevocationOwner,
+            ordinaryRevocationOwnerSecret,
+            ordinaryRevokedAlias.first,
+            ordinaryRevokedAlias.second,
+            1));
+        BEAST_EXPECT(ordinaryForRevocation);
+        if (ordinaryForRevocation)
+            BEAST_EXPECT(
+                validatorManifests.applyManifest(
+                    std::move(*ordinaryForRevocation),
+                    ManifestRateLimitCapPolicy::Uncapped) ==
+                ManifestDisposition::accepted);
+        Validator const revokedOrdinaryAlias{
+            ordinaryRevokedAlias.first,
+            ordinaryRevokedAlias.first,
+            base64_encode(makeRevocationString(
+                ordinaryRevokedAlias.first, ordinaryRevokedAlias.second))};
+
+        auto const intersectingCandidate = randomValidator();
+        Validator const intersectingBareIdentity{
+            intersectingCandidate.signingPublic,
+            intersectingCandidate.signingPublic,
+            {}};
+
         auto const bareSecret = randomSecretKey();
         auto const bareMaster = derivePublicKey(KeyType::ed25519, bareSecret);
         Validator const bareCandidate{bareMaster, bareMaster, {}};
@@ -1128,6 +1199,11 @@ private:
             {},
             {candidate,
              equalSequenceCandidate,
+             candidateUsingOrdinaryMaster,
+             candidateUsingOrdinarySigningAsMaster,
+             revokedOrdinaryAlias,
+             intersectingCandidate,
+             intersectingBareIdentity,
              bareCandidate,
              revokedCandidate,
              collidingCandidate});
@@ -1184,6 +1260,47 @@ private:
         BEAST_EXPECT(
             trustedKeys->resolveMonitoringSigner(candidateEqualSigning.first)
                 .status == ValidatorIdentityStatus::conflict);
+
+        // Candidate roles cannot reuse current ordinary master/signing
+        // namespaces under another identity.
+        BEAST_EXPECT(
+            trustedKeys->resolveMonitoringSigner(ordinaryCrossMaster).status ==
+            ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(
+            trustedKeys
+                ->resolveMonitoringSigner(candidateFromOrdinarySigning.first)
+                .status == ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(
+            trustedKeys->lookupMonitoringIdentity(ordinaryRevokedAlias.first)
+                .status == ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(
+            trustedKeys->resolveMonitoringSigner(ordinaryRevokedAlias.first)
+                .status == ValidatorIdentityStatus::conflict);
+
+        // Candidate master/signing intersections are reported symmetrically.
+        auto const intersectionOwner = trustedKeys->lookupMonitoringIdentity(
+            intersectingCandidate.masterPublic);
+        auto const intersectionIdentity = trustedKeys->lookupMonitoringIdentity(
+            intersectingCandidate.signingPublic);
+        BEAST_EXPECT(
+            intersectionOwner.status == ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(
+            intersectionIdentity.status == ValidatorIdentityStatus::conflict);
+        for (auto const& result : {intersectionOwner, intersectionIdentity})
+        {
+            BEAST_EXPECT(
+                std::find(
+                    result.conflictingMasters.begin(),
+                    result.conflictingMasters.end(),
+                    intersectingCandidate.masterPublic) !=
+                result.conflictingMasters.end());
+            BEAST_EXPECT(
+                std::find(
+                    result.conflictingMasters.begin(),
+                    result.conflictingMasters.end(),
+                    intersectingCandidate.signingPublic) !=
+                result.conflictingMasters.end());
+        }
 
         auto bare = trustedKeys->lookupMonitoringIdentity(bareMaster);
         BEAST_EXPECT(bare.status == ValidatorIdentityStatus::resolved);
@@ -1349,6 +1466,145 @@ private:
                         ->lookupMonitoringIdentity(candidate.masterPublic)
                         .presentInOrdinaryState);
             }
+        }
+    }
+
+    void
+    testCandidateVariantDeterminism()
+    {
+        testcase("Publisher candidate variant determinism");
+        using namespace std::chrono_literals;
+
+        jtx::Env env(*this);
+        auto const listedValidator = randomValidator();
+        auto const candidateMasterSecret = randomSecretKey();
+        auto const candidateMaster =
+            derivePublicKey(KeyType::ed25519, candidateMasterSecret);
+
+        struct PublisherInput
+        {
+            PublicKey master;
+            std::pair<PublicKey, SecretKey> signing;
+            std::string manifest;
+        };
+        std::vector<PublisherInput> publishers;
+        for (int i = 0; i < 3; ++i)
+        {
+            auto const secret = randomSecretKey();
+            auto const master = derivePublicKey(KeyType::ed25519, secret);
+            auto const signing = randomKeyPair(KeyType::secp256k1);
+            publishers.push_back(PublisherInput{
+                master,
+                signing,
+                base64_encode(makeManifestString(
+                    master, secret, signing.first, signing.second, 1))});
+        }
+
+        struct VariantInput
+        {
+            Validator validator;
+            std::string serialized;
+        };
+        std::vector<VariantInput> variants;
+        for (int i = 0; i < 3; ++i)
+        {
+            auto const signing = randomKeyPair(KeyType::secp256k1);
+            auto const serialized = makeManifestString(
+                candidateMaster,
+                candidateMasterSecret,
+                signing.first,
+                signing.second,
+                7);
+            variants.push_back(VariantInput{
+                Validator{
+                    candidateMaster, signing.first, base64_encode(serialized)},
+                serialized});
+        }
+        std::sort(
+            variants.begin(),
+            variants.end(),
+            [](VariantInput const& lhs, VariantInput const& rhs) {
+                return lhs.serialized < rhs.serialized;
+            });
+
+        // Assign the largest variant to one of the first two unordered-map
+        // publishers. The pre-fix first-two policy therefore differs from the
+        // required lexicographically smallest-two policy deterministically.
+        hash_map<PublicKey, std::size_t> iterationProbe;
+        for (std::size_t i = 0; i < publishers.size(); ++i)
+            iterationProbe.emplace(publishers[i].master, i);
+        std::vector<std::size_t> iterationOrder;
+        for (auto const& [_, index] : iterationProbe)
+        {
+            (void)_;
+            iterationOrder.push_back(index);
+        }
+        BEAST_EXPECT(iterationOrder.size() == 3);
+        if (iterationOrder.size() != 3)
+            return;
+
+        std::vector<std::size_t> publisherVariant(3);
+        publisherVariant[iterationOrder[0]] = 0;
+        publisherVariant[iterationOrder[1]] = 2;
+        publisherVariant[iterationOrder[2]] = 1;
+
+        auto runOrder = [&](std::vector<std::size_t> const& applyOrder) {
+            ManifestCache validatorManifests;
+            ManifestCache publisherManifests;
+            ValidatorList trustedKeys(
+                validatorManifests,
+                publisherManifests,
+                env.timeKeeper(),
+                env.app().config().legacy("database_path"),
+                env.journal);
+
+            std::vector<std::string> publisherKeys;
+            for (auto const& publisher : publishers)
+                publisherKeys.push_back(strHex(publisher.master));
+            BEAST_EXPECT(trustedKeys.load({}, {}, publisherKeys));
+
+            auto const validUntil = env.timeKeeper().now() + 1h;
+            for (auto const index : applyOrder)
+            {
+                auto const blob = makeList(
+                    {listedValidator},
+                    1,
+                    validUntil.time_since_epoch().count(),
+                    {},
+                    {variants[publisherVariant[index]].validator});
+                auto const signature =
+                    signList(blob, publishers[index].signing);
+                BEAST_EXPECT(
+                    trustedKeys
+                        .applyLists(
+                            publishers[index].manifest,
+                            1,
+                            {{blob, signature, {}}},
+                            "testCandidateVariantDeterminism.test")
+                        .bestDisposition() == ListDisposition::accepted);
+            }
+
+            std::vector<ValidatorIdentityStatus> result;
+            for (auto const& variant : variants)
+                result.push_back(trustedKeys
+                                     .resolveMonitoringSigner(
+                                         variant.validator.signingPublic)
+                                     .status);
+            BEAST_EXPECT(
+                trustedKeys.lookupMonitoringIdentity(candidateMaster).status ==
+                ValidatorIdentityStatus::conflict);
+            return result;
+        };
+
+        auto const forward = runOrder({0, 1, 2});
+        auto const reverse = runOrder({2, 1, 0});
+        BEAST_EXPECT(forward == reverse);
+        BEAST_EXPECT(forward.size() == 3);
+        if (forward.size() == 3)
+        {
+            BEAST_EXPECT(forward[0] == ValidatorIdentityStatus::conflict);
+            BEAST_EXPECT(forward[1] == ValidatorIdentityStatus::conflict);
+            BEAST_EXPECT(forward[2] == ValidatorIdentityStatus::unknown);
         }
     }
 
@@ -4509,6 +4765,7 @@ public:
         testConfigLoad();
         testApplyLists();
         testCandidates();
+        testCandidateVariantDeterminism();
         testGetAvailable();
         testUpdateTrusted();
         testExpires();

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -135,7 +135,7 @@ private:
         std::string msg;
         bool ssl;
         bool failFetch = false;
-        bool failApply = false;
+        bool expectUnlisted = false;
         int serverVersion = 1;
         std::chrono::seconds expiresFromNow = detail::default_expires;
         std::chrono::seconds effectiveOverlap =
@@ -252,9 +252,11 @@ private:
             for (auto const& val : u.list)
             {
                 BEAST_EXPECT(
-                    trustedKeys.listed(val.masterPublic) != u.cfg.failApply);
+                    trustedKeys.listed(val.masterPublic) !=
+                    u.cfg.expectUnlisted);
                 BEAST_EXPECT(
-                    trustedKeys.listed(val.signingPublic) != u.cfg.failApply);
+                    trustedKeys.listed(val.signingPublic) !=
+                    u.cfg.expectUnlisted);
             }
 
             Json::Value myStatus;
@@ -570,7 +572,7 @@ public:
                   "Applied 1 expired validator list(s)",
                   ssl,
                   false,
-                  false,
+                  true,
                   1,
                   0s}});
             testFetchList(
@@ -579,7 +581,7 @@ public:
                   "Applied 1 expired validator list(s)",
                   ssl,
                   false,
-                  false,
+                  true,
                   1,
                   0s,
                   -1s}});

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -544,6 +544,49 @@ class Validations_test : public beast::unit_test::suite
     }
 
     void
+    testGetCurrentPublicKeys()
+    {
+        using namespace std::chrono_literals;
+        testcase("Current public keys");
+
+        LedgerHistoryHelper h;
+        Ledger ledgerA = h["a"];
+        Ledger ledgerAC = h["ac"];
+
+        TestHarness harness(h.oracle);
+        Node a = harness.makeNode(), b = harness.makeNode();
+        b.untrust();
+
+        for (auto const& node : {a, b})
+            BEAST_EXPECT(
+                ValStatus::current == harness.add(node.validate(ledgerA)));
+
+        {
+            hash_set<PeerID> const expectedKeys = {a.nodeID(), b.nodeID()};
+            BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
+        }
+
+        harness.clock().advance(3s);
+
+        // Change keys and issue partials
+        a.advanceKey();
+        b.advanceKey();
+
+        for (auto const& node : {a, b})
+            BEAST_EXPECT(
+                ValStatus::current == harness.add(node.partial(ledgerAC)));
+
+        {
+            hash_set<PeerID> const expectedKeys = {a.nodeID(), b.nodeID()};
+            BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
+        }
+
+        // Pass enough time for them to go stale
+        harness.clock().advance(harness.parms().validationCURRENT_LOCAL);
+        BEAST_EXPECT(harness.vals().getCurrentNodeIDs().empty());
+    }
+
+    void
     testTrustedByLedgerFunctions()
     {
         // Test the Validations functions that calculate a value by ledger ID
@@ -1089,6 +1132,7 @@ class Validations_test : public beast::unit_test::suite
         testOnStale();
         testGetNodesAfter();
         testCurrentTrusted();
+        testGetCurrentPublicKeys();
         testTrustedByLedgerFunctions();
         testExpire();
         testFlush();

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -544,58 +544,6 @@ class Validations_test : public beast::unit_test::suite
     }
 
     void
-    testGetCurrentPublicKeys()
-    {
-        using namespace std::chrono_literals;
-        testcase("Current public keys");
-
-        LedgerHistoryHelper h;
-        Ledger ledgerA = h["a"];
-        Ledger ledgerAC = h["ac"];
-
-        TestHarness harness(h.oracle);
-        Node a = harness.makeNode(), b = harness.makeNode();
-        b.untrust();
-
-        for (auto const& node : {a, b})
-            BEAST_EXPECT(
-                ValStatus::current == harness.add(node.validate(ledgerA)));
-
-        {
-            hash_set<PeerID> const expectedKeys = {a.nodeID(), b.nodeID()};
-            BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
-            hash_set<PeerKey> const expectedSigningKeys = {
-                a.currKey(), b.currKey()};
-            BEAST_EXPECT(
-                harness.vals().getCurrentNodeKeys() == expectedSigningKeys);
-        }
-
-        harness.clock().advance(3s);
-
-        // Change keys and issue partials
-        a.advanceKey();
-        b.advanceKey();
-
-        for (auto const& node : {a, b})
-            BEAST_EXPECT(
-                ValStatus::current == harness.add(node.partial(ledgerAC)));
-
-        {
-            hash_set<PeerID> const expectedKeys = {a.nodeID(), b.nodeID()};
-            BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
-            hash_set<PeerKey> const expectedSigningKeys = {
-                a.currKey(), b.currKey()};
-            BEAST_EXPECT(
-                harness.vals().getCurrentNodeKeys() == expectedSigningKeys);
-        }
-
-        // Pass enough time for them to go stale
-        harness.clock().advance(harness.parms().validationCURRENT_LOCAL);
-        BEAST_EXPECT(harness.vals().getCurrentNodeIDs().empty());
-        BEAST_EXPECT(harness.vals().getCurrentNodeKeys().empty());
-    }
-
-    void
     testTrustedByLedgerFunctions()
     {
         // Test the Validations functions that calculate a value by ledger ID
@@ -1141,7 +1089,6 @@ class Validations_test : public beast::unit_test::suite
         testOnStale();
         testGetNodesAfter();
         testCurrentTrusted();
-        testGetCurrentPublicKeys();
         testTrustedByLedgerFunctions();
         testExpire();
         testFlush();

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -564,6 +564,10 @@ class Validations_test : public beast::unit_test::suite
         {
             hash_set<PeerID> const expectedKeys = {a.nodeID(), b.nodeID()};
             BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
+            hash_set<PeerKey> const expectedSigningKeys = {
+                a.currKey(), b.currKey()};
+            BEAST_EXPECT(
+                harness.vals().getCurrentNodeKeys() == expectedSigningKeys);
         }
 
         harness.clock().advance(3s);
@@ -579,11 +583,16 @@ class Validations_test : public beast::unit_test::suite
         {
             hash_set<PeerID> const expectedKeys = {a.nodeID(), b.nodeID()};
             BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
+            hash_set<PeerKey> const expectedSigningKeys = {
+                a.currKey(), b.currKey()};
+            BEAST_EXPECT(
+                harness.vals().getCurrentNodeKeys() == expectedSigningKeys);
         }
 
         // Pass enough time for them to go stale
         harness.clock().advance(harness.parms().validationCURRENT_LOCAL);
         BEAST_EXPECT(harness.vals().getCurrentNodeIDs().empty());
+        BEAST_EXPECT(harness.vals().getCurrentNodeKeys().empty());
     }
 
     void

--- a/src/test/overlay/compression_test.cpp
+++ b/src/test/overlay/compression_test.cpp
@@ -45,6 +45,7 @@
 #include <boost/beast/core/multi_buffer.hpp>
 #include <boost/endian/conversion.hpp>
 #include <algorithm>
+#include <array>
 
 namespace ripple {
 
@@ -73,6 +74,95 @@ class compression_test : public beast::unit_test::suite
 {
     using Compressed = compression::Compressed;
     using Algorithm = compression::Algorithm;
+
+    class ProtocolHandler
+    {
+    public:
+        bool invoked = false;
+
+        bool
+        compressionEnabled() const
+        {
+            return true;
+        }
+
+        void
+        onMessageUnknown(std::uint16_t)
+        {
+            invoked = true;
+        }
+
+        void
+        onMessageBegin(
+            std::uint16_t,
+            std::shared_ptr<::google::protobuf::Message> const&,
+            std::size_t,
+            std::size_t,
+            bool)
+        {
+            invoked = true;
+        }
+
+        template <class T>
+        void
+        onMessage(std::shared_ptr<T> const&)
+        {
+            invoked = true;
+        }
+
+        void
+        onMessageEnd(
+            std::uint16_t,
+            std::shared_ptr<::google::protobuf::Message> const&)
+        {
+            invoked = true;
+        }
+    };
+
+    static void
+    put16(
+        std::vector<std::uint8_t>& frame,
+        std::size_t const offset,
+        std::uint16_t const value)
+    {
+        frame[offset] = static_cast<std::uint8_t>(value >> 8);
+        frame[offset + 1] = static_cast<std::uint8_t>(value);
+    }
+
+    static void
+    put32(
+        std::vector<std::uint8_t>& frame,
+        std::size_t const offset,
+        std::uint32_t const value)
+    {
+        frame[offset] = static_cast<std::uint8_t>(value >> 24);
+        frame[offset + 1] = static_cast<std::uint8_t>(value >> 16);
+        frame[offset + 2] = static_cast<std::uint8_t>(value >> 8);
+        frame[offset + 3] = static_cast<std::uint8_t>(value);
+    }
+
+    static std::vector<std::uint8_t>
+    uncompressedManifestFrame(std::size_t const payloadSize)
+    {
+        std::vector<std::uint8_t> frame(compression::headerBytes + payloadSize);
+        put32(frame, 0, static_cast<std::uint32_t>(payloadSize));
+        put16(frame, 4, protocol::mtMANIFESTS);
+        return frame;
+    }
+
+    static std::vector<std::uint8_t>
+    compressedManifestFrame(
+        std::size_t const payloadSize,
+        std::size_t const uncompressedSize)
+    {
+        std::vector<std::uint8_t> frame(
+            compression::headerBytesCompressed + payloadSize);
+        put32(frame, 0, static_cast<std::uint32_t>(payloadSize));
+        frame[0] |= static_cast<std::uint8_t>(Algorithm::LZ4);
+        put16(frame, 4, protocol::mtMANIFESTS);
+        put32(frame, 6, static_cast<std::uint32_t>(uncompressedSize));
+        return frame;
+    }
 
 public:
     compression_test()
@@ -530,10 +620,54 @@ public:
     }
 
     void
+    testManifestFrameLimit()
+    {
+        testcase("TMManifests frame limit");
+
+        auto invokeFrame = [](std::vector<std::uint8_t> const& frame,
+                              ProtocolHandler& handler) {
+            std::array<boost::asio::const_buffer, 1> const buffers{
+                boost::asio::buffer(frame)};
+            std::size_t hint = 0;
+            return invokeProtocolMessage(buffers, handler, hint);
+        };
+
+        {
+            auto const frame =
+                uncompressedManifestFrame(maximumManifestsMessageSize + 1);
+            ProtocolHandler handler;
+            auto const [consumed, ec] = invokeFrame(frame, handler);
+            BEAST_EXPECT(consumed == frame.size());
+            BEAST_EXPECT(!ec);
+            BEAST_EXPECT(!handler.invoked);
+        }
+        {
+            auto const frame =
+                compressedManifestFrame(1, maximumManifestsMessageSize + 1);
+            ProtocolHandler handler;
+            auto const [consumed, ec] = invokeFrame(frame, handler);
+            BEAST_EXPECT(consumed == frame.size());
+            BEAST_EXPECT(!ec);
+            BEAST_EXPECT(!handler.invoked);
+        }
+        {
+            auto const frame =
+                uncompressedManifestFrame(maximumManifestsMessageSize);
+            ProtocolHandler handler;
+            auto const [consumed, ec] = invokeFrame(frame, handler);
+            BEAST_EXPECT(consumed == frame.size());
+            BEAST_EXPECT(
+                ec == make_error_code(boost::system::errc::bad_message));
+            BEAST_EXPECT(!handler.invoked);
+        }
+    }
+
+    void
     run() override
     {
         testProtocol();
         testHandshake();
+        testManifestFrameLimit();
     }
 };
 

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -19,7 +19,6 @@
 
 #include <test/jtx.h>
 #include <test/jtx/Env.h>
-#include <xrpld/app/misc/HashRouter.h>
 #include <xrpld/app/misc/ValidatorList.h>
 #include <xrpld/overlay/detail/OverlayImpl.h>
 #include <xrpld/overlay/detail/PeerImp.h>
@@ -28,6 +27,9 @@
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/protocol/STExchange.h>
 #include <xrpl/protocol/Sign.h>
+
+#include <limits>
+#include <optional>
 
 namespace ripple {
 namespace test {
@@ -85,20 +87,22 @@ class manifest_relay_test : public beast::unit_test::suite
     {
         std::string serialized;
         PublicKey masterKey;
-        PublicKey signingKey;
-        uint256 hash;
+        std::optional<PublicKey> signingKey;
     };
 
     ManifestData
-    makeManifest(bool const large = false)
+    makeManifest(
+        SecretKey const& masterSecret,
+        std::uint32_t const sequence,
+        bool const large = false)
     {
-        auto const [masterPublic, masterSecret] =
-            randomKeyPair(KeyType::ed25519);
+        auto const masterPublic =
+            derivePublicKey(KeyType::ed25519, masterSecret);
         auto const [signingPublic, signingSecret] =
             randomKeyPair(KeyType::secp256k1);
 
         STObject st{sfGeneric};
-        st[sfSequence] = 0;
+        st[sfSequence] = sequence;
         st[sfPublicKey] = masterPublic;
         st[sfSigningPubKey] = signingPublic;
         if (large)
@@ -120,11 +124,39 @@ class manifest_relay_test : public beast::unit_test::suite
             static_cast<char const*>(serialized.data()), serialized.size()};
         auto manifest = deserializeManifest(bytes);
         BEAST_EXPECT(manifest.has_value());
-        return {
-            bytes,
-            masterPublic,
-            signingPublic,
-            manifest ? manifest->hash() : uint256{}};
+        return {bytes, masterPublic, signingPublic};
+    }
+
+    ManifestData
+    makeRevocation(SecretKey const& masterSecret)
+    {
+        auto const masterPublic =
+            derivePublicKey(KeyType::ed25519, masterSecret);
+
+        STObject st{sfGeneric};
+        st[sfSequence] = std::numeric_limits<std::uint32_t>::max();
+        st[sfPublicKey] = masterPublic;
+        sign(
+            st,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            masterSecret,
+            sfMasterSignature);
+
+        Serializer serialized;
+        st.add(serialized);
+        std::string const bytes{
+            static_cast<char const*>(serialized.data()), serialized.size()};
+        auto manifest = deserializeManifest(bytes);
+        BEAST_EXPECT(manifest.has_value());
+        BEAST_EXPECT(manifest && manifest->revoked());
+        return {bytes, masterPublic, std::nullopt};
+    }
+
+    ManifestData
+    makeManifest(bool const large = false)
+    {
+        return makeManifest(randomSecretKey(), 0, large);
     }
 
     std::shared_ptr<PeerTest>
@@ -218,7 +250,7 @@ class manifest_relay_test : public beast::unit_test::suite
             env.app().validatorManifests().sequence() ==
             before + kMaxManifestsPerMessage + 1);
         BEAST_EXPECT(source->sent_.empty());
-        expectBundle(destination, kMaxManifestsPerMessage + 1);
+        expectBundle(destination, 1);
 
         auto const snapshot = unpack(overlay.getManifestsMessage());
         BEAST_EXPECT(snapshot.has_value());
@@ -254,39 +286,87 @@ class manifest_relay_test : public beast::unit_test::suite
     }
 
     void
-    testRelaySkipIntersection()
+    testKnownUpdateRelays()
     {
-        testcase("relay skips only peers that have every bundled manifest");
+        testcase("known unlisted rotations relay");
 
         jtx::Env env{*this};
         auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
         auto const source = addPeer(env);
-        auto const partial = addPeer(env);
-        auto const complete = addPeer(env);
-        auto const fresh = addPeer(env);
-        auto const first = makeManifest();
-        auto const second = makeManifest();
-
-        auto& hashRouter = env.app().getHashRouter();
-        hashRouter.addSuppressionPeer(first.hash, partial->id());
-        hashRouter.addSuppressionPeer(first.hash, complete->id());
-        hashRouter.addSuppressionPeer(second.hash, complete->id());
+        auto const destination = addPeer(env);
+        auto const masterSecret = randomSecretKey();
+        auto const first = makeManifest(masterSecret, 0);
+        auto const second = makeManifest(masterSecret, 1);
 
         auto incoming = std::make_shared<protocol::TMManifests>();
         incoming->add_list()->set_stobject(first.serialized);
+        overlay.onManifests(incoming, source);
+
+        BEAST_EXPECT(source->sent_.empty());
+        BEAST_EXPECT(destination->sent_.empty());
+
+        incoming = std::make_shared<protocol::TMManifests>();
         incoming->add_list()->set_stobject(second.serialized);
         overlay.onManifests(incoming, source);
 
         BEAST_EXPECT(source->sent_.empty());
-        BEAST_EXPECT(complete->sent_.empty());
-        expectBundle(partial, 2);
-        expectBundle(fresh, 2);
+        expectBundle(destination, 1);
     }
 
     void
-    testEvictionDoesNotRearmRelay()
+    testRevocationRelay()
     {
-        testcase("eviction does not rearm relay suppression");
+        testcase("revocation relay follows retained and listed policy");
+
+        auto const retainedSecret = randomSecretKey();
+        auto const retained = makeManifest(retainedSecret, 0);
+        auto const retainedRevocation = makeRevocation(retainedSecret);
+        auto const firstSeenRevocation = makeRevocation(randomSecretKey());
+        auto const listedRevocation = makeRevocation(randomSecretKey());
+
+        jtx::Env env{
+            *this,
+            jtx::envconfig([&listedRevocation](std::unique_ptr<Config> config) {
+                config->section("validators")
+                    .append(toBase58(
+                        TokenType::NodePublic, listedRevocation.masterKey));
+                return config;
+            })};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const destination = addPeer(env);
+
+        auto send = [&](ManifestData const& data) {
+            auto incoming = std::make_shared<protocol::TMManifests>();
+            incoming->add_list()->set_stobject(data.serialized);
+            overlay.onManifests(incoming, source);
+        };
+
+        send(retained);
+        BEAST_EXPECT(destination->sent_.empty());
+
+        send(retainedRevocation);
+        expectBundle(destination, 1);
+        BEAST_EXPECT(
+            env.app().validatorManifests().revoked(retained.masterKey));
+        destination->sent_.clear();
+
+        send(firstSeenRevocation);
+        BEAST_EXPECT(destination->sent_.empty());
+        BEAST_EXPECT(env.app().validatorManifests().revoked(
+            firstSeenRevocation.masterKey));
+
+        send(listedRevocation);
+        expectBundle(destination, 1);
+        BEAST_EXPECT(
+            env.app().validatorManifests().revoked(listedRevocation.masterKey));
+        BEAST_EXPECT(source->sent_.empty());
+    }
+
+    void
+    testEvictedManifestStopsLocally()
+    {
+        testcase("reaccepted evicted manifest does not live relay");
 
         jtx::Env env{*this};
         auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
@@ -297,8 +377,8 @@ class manifest_relay_test : public beast::unit_test::suite
         auto incoming = std::make_shared<protocol::TMManifests>();
         incoming->add_list()->set_stobject(target.serialized);
         overlay.onManifests(incoming, source);
-        expectBundle(destination, 1);
-        destination->sent_.clear();
+        BEAST_EXPECT(source->sent_.empty());
+        BEAST_EXPECT(destination->sent_.empty());
 
         constexpr std::size_t untrustedCacheLimit = 1000;
         hash_set<PublicKey> activeSigningKeys;
@@ -307,7 +387,9 @@ class manifest_relay_test : public beast::unit_test::suite
         for (std::size_t i = 1; i < untrustedCacheLimit; ++i)
         {
             auto const filler = makeManifest();
-            activeSigningKeys.insert(filler.signingKey);
+            BEAST_EXPECT(filler.signingKey.has_value());
+            if (filler.signingKey)
+                activeSigningKeys.insert(*filler.signingKey);
             auto manifest = deserializeManifest(filler.serialized);
             BEAST_EXPECT(manifest.has_value());
             if (manifest)
@@ -326,9 +408,10 @@ class manifest_relay_test : public beast::unit_test::suite
         if (replacementManifest)
         {
             BEAST_EXPECT(
-                cache.applyManifestWithEviction(
-                    std::move(*replacementManifest), activeSigningKeys) ==
-                ManifestDisposition::accepted);
+                cache
+                    .applyManifestWithEviction(
+                        std::move(*replacementManifest), activeSigningKeys)
+                    .disposition == ManifestDisposition::accepted);
         }
         BEAST_EXPECT(!cache.getSequence(target.masterKey));
 
@@ -496,8 +579,9 @@ public:
     {
         testBoundedReceive();
         testTotalEntryLimit();
-        testRelaySkipIntersection();
-        testEvictionDoesNotRearmRelay();
+        testKnownUpdateRelays();
+        testRevocationRelay();
+        testEvictedManifestStopsLocally();
         testSnapshotByteBudget();
         testListingChangeInvalidatesSnapshot();
         testConfigListingPromotesRetention();

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -21,7 +21,6 @@
 #include <test/jtx/Env.h>
 #include <xrpld/app/misc/HashRouter.h>
 #include <xrpld/app/misc/ValidatorList.h>
-#include <xrpld/core/ConfigSections.h>
 #include <xrpld/overlay/detail/OverlayImpl.h>
 #include <xrpld/overlay/detail/PeerImp.h>
 #include <xrpld/peerfinder/detail/SlotImp.h>
@@ -194,7 +193,7 @@ class manifest_relay_test : public beast::unit_test::suite
         auto const trusted = makeManifest();
         jtx::Env env{
             *this, jtx::envconfig([&trusted](std::unique_ptr<Config> config) {
-                config->section(SECTION_VALIDATORS)
+                config->section("validators")
                     .append(toBase58(TokenType::NodePublic, trusted.masterKey));
                 return config;
             })};
@@ -274,7 +273,7 @@ class manifest_relay_test : public beast::unit_test::suite
 
         jtx::Env env{
             *this, jtx::envconfig([&trusted](std::unique_ptr<Config> config) {
-                auto& validators = config->section(SECTION_VALIDATORS);
+                auto& validators = config->section("validators");
                 for (auto const& manifest : trusted)
                 {
                     validators.append(

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -557,15 +557,13 @@ class manifest_relay_test : public beast::unit_test::suite
         BEAST_EXPECT(destination->sent_.empty());
 
         constexpr std::size_t untrustedCacheLimit = 1000;
-        hash_set<PublicKey> activeSigningKeys;
-        activeSigningKeys.reserve(untrustedCacheLimit - 1);
+        std::vector<ManifestData> retained;
+        retained.reserve(untrustedCacheLimit);
+        retained.push_back(target);
         auto& cache = env.app().validatorManifests();
         for (std::size_t i = 1; i < untrustedCacheLimit; ++i)
         {
             auto const filler = makeManifest();
-            BEAST_EXPECT(filler.signingKey.has_value());
-            if (filler.signingKey)
-                activeSigningKeys.insert(*filler.signingKey);
             auto manifest = deserializeManifest(filler.serialized);
             BEAST_EXPECT(manifest.has_value());
             if (manifest)
@@ -575,6 +573,7 @@ class manifest_relay_test : public beast::unit_test::suite
                         std::move(*manifest), ManifestRetention::evictable) ==
                     ManifestDisposition::accepted);
             }
+            retained.push_back(filler);
         }
 
         auto const replacement = makeManifest();
@@ -583,18 +582,23 @@ class manifest_relay_test : public beast::unit_test::suite
         if (replacementManifest)
         {
             BEAST_EXPECT(
-                cache
-                    .applyManifestWithEviction(
-                        std::move(*replacementManifest), activeSigningKeys)
+                cache.applyManifestWithEviction(std::move(*replacementManifest))
                     .disposition == ManifestDisposition::accepted);
         }
-        BEAST_EXPECT(!cache.getSequence(target.masterKey));
+
+        auto const evicted = std::find_if(
+            retained.begin(), retained.end(), [&cache](ManifestData const& m) {
+                return !cache.getSequence(m.masterKey);
+            });
+        BEAST_EXPECT(evicted != retained.end());
+        if (evicted == retained.end())
+            return;
 
         incoming = std::make_shared<protocol::TMManifests>();
-        incoming->add_list()->set_stobject(target.serialized);
+        incoming->add_list()->set_stobject(evicted->serialized);
         overlay.onManifests(incoming, source);
 
-        BEAST_EXPECT(cache.getSequence(target.masterKey) == 0);
+        BEAST_EXPECT(cache.getSequence(evicted->masterKey) == 0);
         BEAST_EXPECT(source->sent_.empty());
         BEAST_EXPECT(destination->sent_.empty());
     }

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -93,24 +93,23 @@ class manifest_relay_test : public beast::unit_test::suite
     ManifestData
     makeManifest(
         SecretKey const& masterSecret,
+        std::pair<PublicKey, SecretKey> const& signing,
         std::uint32_t const sequence,
         bool const large = false)
     {
         auto const masterPublic =
             derivePublicKey(KeyType::ed25519, masterSecret);
-        auto const [signingPublic, signingSecret] =
-            randomKeyPair(KeyType::secp256k1);
 
         STObject st{sfGeneric};
         st[sfSequence] = sequence;
         st[sfPublicKey] = masterPublic;
-        st[sfSigningPubKey] = signingPublic;
+        st[sfSigningPubKey] = signing.first;
         if (large)
         {
             st[sfDomain] =
                 makeSlice(std::string(63, 'a') + "." + std::string(63, 'b'));
         }
-        sign(st, HashPrefix::manifest, KeyType::secp256k1, signingSecret);
+        sign(st, HashPrefix::manifest, KeyType::secp256k1, signing.second);
         sign(
             st,
             HashPrefix::manifest,
@@ -124,7 +123,17 @@ class manifest_relay_test : public beast::unit_test::suite
             static_cast<char const*>(serialized.data()), serialized.size()};
         auto manifest = deserializeManifest(bytes);
         BEAST_EXPECT(manifest.has_value());
-        return {bytes, masterPublic, signingPublic};
+        return {bytes, masterPublic, signing.first};
+    }
+
+    ManifestData
+    makeManifest(
+        SecretKey const& masterSecret,
+        std::uint32_t const sequence,
+        bool const large = false)
+    {
+        return makeManifest(
+            masterSecret, randomKeyPair(KeyType::secp256k1), sequence, large);
     }
 
     ManifestData
@@ -219,6 +228,226 @@ class manifest_relay_test : public beast::unit_test::suite
         {
             BEAST_EXPECT(
                 static_cast<std::size_t>(relayed->list_size()) == count);
+        }
+    }
+
+    void
+    installCandidate(jtx::Env& env, ManifestData const& candidate)
+    {
+        auto const publisherMasterSecret = randomSecretKey();
+        auto const publisherMaster =
+            derivePublicKey(KeyType::ed25519, publisherMasterSecret);
+        auto const publisherSigning = randomKeyPair(KeyType::secp256k1);
+        auto const publisherManifest =
+            makeManifest(publisherMasterSecret, publisherSigning, 1);
+        auto const listed = makeManifest();
+
+        BEAST_EXPECT(env.app().validators().load(
+            {}, {}, std::vector<std::string>{strHex(publisherMaster)}));
+
+        auto const expiration = (env.timeKeeper().now() + std::chrono::hours{1})
+                                    .time_since_epoch()
+                                    .count();
+        std::string const payload =
+            "{\"sequence\":1,\"expiration\":" + std::to_string(expiration) +
+            ",\"validators\":[{\"validation_public_key\":\"" +
+            strHex(listed.masterKey) +
+            "\"}],\"candidates\":[{\"validation_public_key\":\"" +
+            strHex(candidate.masterKey) + "\",\"manifest\":\"" +
+            base64_encode(candidate.serialized) + "\"}]}";
+        auto const blob = base64_encode(payload);
+        auto const signature = strHex(sign(
+            publisherSigning.first,
+            publisherSigning.second,
+            makeSlice(payload)));
+
+        BEAST_EXPECT(
+            env.app()
+                .validators()
+                .applyLists(
+                    base64_encode(publisherManifest.serialized),
+                    1,
+                    {{blob, signature, {}}},
+                    "manifest_relay_test")
+                .bestDisposition() == ListDisposition::accepted);
+        auto const policy =
+            env.app().validators().manifestPolicy(candidate.masterKey);
+        BEAST_EXPECT(!policy.consensusListed);
+        BEAST_EXPECT(policy.publisherCandidate);
+        BEAST_EXPECT(policy.relayEligible());
+    }
+
+    void
+    testCandidateUpdateRelays()
+    {
+        testcase("publisher candidate rotations and revocations relay");
+
+        jtx::Env env{*this};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const destination = addPeer(env);
+        auto const masterSecret = randomSecretKey();
+        auto const published = makeManifest(masterSecret, 1);
+        auto const rotation = makeManifest(masterSecret, 2);
+        auto const revocation = makeRevocation(masterSecret);
+
+        installCandidate(env, published);
+        BEAST_EXPECT(!env.app().validators().listed(published.masterKey));
+        BEAST_EXPECT(!env.app().validators().trusted(published.masterKey));
+        BEAST_EXPECT(
+            !env.app().validatorManifests().getSequence(published.masterKey));
+
+        auto send = [&](ManifestData const& data) {
+            auto incoming = std::make_shared<protocol::TMManifests>();
+            incoming->add_list()->set_stobject(data.serialized);
+            overlay.onManifests(incoming, source);
+        };
+
+        send(rotation);
+        expectBundle(destination, 1);
+        BEAST_EXPECT(
+            !env.app().validatorManifests().getSequence(published.masterKey));
+        auto identity = env.app().validators().lookupMonitoringIdentity(
+            published.masterKey);
+        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::resolved);
+        BEAST_EXPECT(identity.signing == rotation.signingKey);
+        BEAST_EXPECT(identity.manifest && identity.manifest->sequence == 2);
+        BEAST_EXPECT(!identity.presentInOrdinaryState);
+        BEAST_EXPECT(!env.app().validators().listed(published.masterKey));
+        BEAST_EXPECT(!env.app().validators().trusted(published.masterKey));
+
+        auto snapshot = unpack(overlay.getManifestsMessage());
+        BEAST_EXPECT(snapshot.has_value());
+        if (snapshot)
+        {
+            BEAST_EXPECT(std::any_of(
+                snapshot->list().begin(),
+                snapshot->list().end(),
+                [&](auto const& entry) {
+                    return entry.stobject() == rotation.serialized;
+                }));
+        }
+
+        destination->sent_.clear();
+        send(revocation);
+        expectBundle(destination, 1);
+        BEAST_EXPECT(
+            !env.app().validatorManifests().getSequence(published.masterKey));
+        identity = env.app().validators().lookupMonitoringIdentity(
+            published.masterKey);
+        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::revoked);
+        BEAST_EXPECT(!identity.signing);
+        BEAST_EXPECT(identity.manifest && identity.manifest->revoked());
+        BEAST_EXPECT(!identity.presentInOrdinaryState);
+        BEAST_EXPECT(!env.app().validators().listed(published.masterKey));
+        BEAST_EXPECT(!env.app().validators().trusted(published.masterKey));
+    }
+
+    void
+    testCandidateCollisionDoesNotAffectConsensus()
+    {
+        testcase("candidate signing collision does not affect consensus");
+
+        auto const directSigning = randomKeyPair(KeyType::secp256k1);
+        jtx::Env env{
+            *this,
+            jtx::envconfig([&directSigning](std::unique_ptr<Config> config) {
+                config->section("validators")
+                    .append(
+                        toBase58(TokenType::NodePublic, directSigning.first));
+                return config;
+            })};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const destination = addPeer(env);
+        auto const candidateSecret = randomSecretKey();
+        auto const published = makeManifest(candidateSecret, 1);
+        auto const collision = makeManifest(candidateSecret, directSigning, 2);
+
+        installCandidate(env, published);
+        BEAST_EXPECT(env.app().validators().listed(directSigning.first));
+        BEAST_EXPECT(
+            env.app().validatorManifests().getMasterKey(directSigning.first) ==
+            directSigning.first);
+
+        auto incoming = std::make_shared<protocol::TMManifests>();
+        incoming->add_list()->set_stobject(collision.serialized);
+        overlay.onManifests(incoming, source);
+
+        expectBundle(destination, 1);
+        BEAST_EXPECT(env.app().validators().listed(directSigning.first));
+        BEAST_EXPECT(
+            env.app().validatorManifests().getMasterKey(directSigning.first) ==
+            directSigning.first);
+        BEAST_EXPECT(
+            !env.app().validatorManifests().getSequence(published.masterKey));
+        BEAST_EXPECT(
+            env.app()
+                .validators()
+                .lookupMonitoringIdentity(published.masterKey)
+                .status == ValidatorIdentityStatus::conflict);
+        BEAST_EXPECT(
+            env.app()
+                .validators()
+                .resolveMonitoringSigner(directSigning.first)
+                .status == ValidatorIdentityStatus::conflict);
+    }
+
+    void
+    testCandidateCannotRollbackOrdinaryHighWater()
+    {
+        testcase("candidate cannot roll back ordinary manifest high-water");
+
+        jtx::Env env{*this};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const destination = addPeer(env);
+        auto const masterSecret = randomSecretKey();
+        auto const published = makeManifest(masterSecret, 1);
+        auto const staleRotation = makeManifest(masterSecret, 2);
+        auto const revocation = makeRevocation(masterSecret);
+
+        auto ordinary = deserializeManifest(revocation.serialized);
+        BEAST_EXPECT(ordinary.has_value());
+        if (ordinary)
+        {
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*ordinary), ManifestRateLimitCapPolicy::Capped) ==
+                ManifestDisposition::accepted);
+        }
+        installCandidate(env, published);
+
+        auto incoming = std::make_shared<protocol::TMManifests>();
+        incoming->add_list()->set_stobject(staleRotation.serialized);
+        overlay.onManifests(incoming, source);
+
+        BEAST_EXPECT(destination->sent_.empty());
+        BEAST_EXPECT(
+            env.app().validators().candidateManifestOverrides().empty());
+        BEAST_EXPECT(
+            env.app().validatorManifests().revoked(published.masterKey));
+        auto const identity = env.app().validators().lookupMonitoringIdentity(
+            published.masterKey);
+        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::revoked);
+        BEAST_EXPECT(identity.manifest && identity.manifest->revoked());
+
+        auto const snapshot = unpack(overlay.getManifestsMessage());
+        BEAST_EXPECT(snapshot.has_value());
+        if (snapshot)
+        {
+            BEAST_EXPECT(std::any_of(
+                snapshot->list().begin(),
+                snapshot->list().end(),
+                [&](auto const& entry) {
+                    return entry.stobject() == revocation.serialized;
+                }));
+            BEAST_EXPECT(std::none_of(
+                snapshot->list().begin(),
+                snapshot->list().end(),
+                [&](auto const& entry) {
+                    return entry.stobject() == staleRotation.serialized;
+                }));
         }
     }
 
@@ -580,6 +809,9 @@ public:
         testBoundedReceive();
         testTotalEntryLimit();
         testKnownUpdateRelays();
+        testCandidateUpdateRelays();
+        testCandidateCollisionDoesNotAffectConsensus();
+        testCandidateCannotRollbackOrdinaryHighWater();
         testRevocationRelay();
         testEvictedManifestStopsLocally();
         testSnapshotByteBudget();

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -19,6 +19,9 @@
 
 #include <test/jtx.h>
 #include <test/jtx/Env.h>
+#include <xrpld/app/misc/HashRouter.h>
+#include <xrpld/app/misc/ValidatorList.h>
+#include <xrpld/core/ConfigSections.h>
 #include <xrpld/overlay/detail/OverlayImpl.h>
 #include <xrpld/overlay/detail/PeerImp.h>
 #include <xrpld/peerfinder/detail/SlotImp.h>
@@ -79,8 +82,15 @@ class manifest_relay_test : public beast::unit_test::suite
     std::shared_ptr<boost::asio::ssl::context> context_{make_SSLContext("")};
     std::uint16_t endpoint_{1};
 
-    static std::string
-    makeManifest()
+    struct ManifestData
+    {
+        std::string serialized;
+        PublicKey masterKey;
+        uint256 hash;
+    };
+
+    ManifestData
+    makeManifest(bool const large = false)
     {
         auto const [masterPublic, masterSecret] =
             randomKeyPair(KeyType::ed25519);
@@ -91,6 +101,11 @@ class manifest_relay_test : public beast::unit_test::suite
         st[sfSequence] = 0;
         st[sfPublicKey] = masterPublic;
         st[sfSigningPubKey] = signingPublic;
+        if (large)
+        {
+            st[sfDomain] =
+                makeSlice(std::string(63, 'a') + "." + std::string(63, 'b'));
+        }
         sign(st, HashPrefix::manifest, KeyType::secp256k1, signingSecret);
         sign(
             st,
@@ -101,7 +116,11 @@ class manifest_relay_test : public beast::unit_test::suite
 
         Serializer serialized;
         st.add(serialized);
-        return {static_cast<char const*>(serialized.data()), serialized.size()};
+        std::string const bytes{
+            static_cast<char const*>(serialized.data()), serialized.size()};
+        auto manifest = deserializeManifest(bytes);
+        BEAST_EXPECT(manifest.has_value());
+        return {bytes, masterPublic, manifest ? manifest->hash() : uint256{}};
     }
 
     std::shared_ptr<PeerTest>
@@ -151,42 +170,179 @@ class manifest_relay_test : public beast::unit_test::suite
         return manifests;
     }
 
-public:
     void
-    run() override
+    expectBundle(std::shared_ptr<PeerTest> const& peer, std::size_t const count)
     {
-        testcase("bounded receive, source suppression, and peer snapshot");
+        BEAST_EXPECT(peer->sent_.size() == 1);
+        if (peer->sent_.size() != 1)
+            return;
 
-        jtx::Env env{*this};
+        auto const relayed = unpack(peer->sent_.front());
+        BEAST_EXPECT(relayed.has_value());
+        if (relayed)
+        {
+            BEAST_EXPECT(
+                static_cast<std::size_t>(relayed->list_size()) == count);
+        }
+    }
+
+    void
+    testBoundedReceive()
+    {
+        testcase("bounded receive includes trusted entries after the cap");
+
+        auto const trusted = makeManifest();
+        jtx::Env env{
+            *this, jtx::envconfig([&trusted](std::unique_ptr<Config> config) {
+                config->section(SECTION_VALIDATORS)
+                    .append(toBase58(TokenType::NodePublic, trusted.masterKey));
+                return config;
+            })};
         auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
         auto const source = addPeer(env);
         auto const destination = addPeer(env);
 
         auto incoming = std::make_shared<protocol::TMManifests>();
         for (std::size_t i = 0; i < kMaxManifestsPerMessage + 1; ++i)
-            incoming->add_list()->set_stobject(makeManifest());
+            incoming->add_list()->set_stobject(makeManifest().serialized);
+        incoming->add_list()->set_stobject(trusted.serialized);
 
         auto const before = env.app().validatorManifests().sequence();
         overlay.onManifests(incoming, source);
 
         BEAST_EXPECT(
             env.app().validatorManifests().sequence() ==
-            before + kMaxManifestsPerMessage);
+            before + kMaxManifestsPerMessage + 1);
         BEAST_EXPECT(source->sent_.empty());
-        BEAST_EXPECT(destination->sent_.size() == 1);
-
-        if (destination->sent_.size() == 1)
-        {
-            auto const relayed = unpack(destination->sent_.front());
-            BEAST_EXPECT(relayed.has_value());
-            if (relayed)
-                BEAST_EXPECT(relayed->list_size() == kMaxManifestsPerMessage);
-        }
+        expectBundle(destination, kMaxManifestsPerMessage + 1);
 
         auto const snapshot = unpack(overlay.getManifestsMessage());
         BEAST_EXPECT(snapshot.has_value());
         if (snapshot)
-            BEAST_EXPECT(snapshot->list_size() == kMaxManifestsPerMessage);
+        {
+            BEAST_EXPECT(snapshot->list_size() == kMaxManifestsPerMessage + 1);
+            BEAST_EXPECT(
+                Message::messageSize(*snapshot) <= maximumManifestsMessageSize);
+        }
+    }
+
+    void
+    testRelaySkipIntersection()
+    {
+        testcase("relay skips only peers that have every bundled manifest");
+
+        jtx::Env env{*this};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const partial = addPeer(env);
+        auto const complete = addPeer(env);
+        auto const fresh = addPeer(env);
+        auto const first = makeManifest();
+        auto const second = makeManifest();
+
+        auto& hashRouter = env.app().getHashRouter();
+        hashRouter.addSuppressionPeer(first.hash, partial->id());
+        hashRouter.addSuppressionPeer(first.hash, complete->id());
+        hashRouter.addSuppressionPeer(second.hash, complete->id());
+
+        auto incoming = std::make_shared<protocol::TMManifests>();
+        incoming->add_list()->set_stobject(first.serialized);
+        incoming->add_list()->set_stobject(second.serialized);
+        overlay.onManifests(incoming, source);
+
+        BEAST_EXPECT(source->sent_.empty());
+        BEAST_EXPECT(complete->sent_.empty());
+        expectBundle(partial, 2);
+        expectBundle(fresh, 2);
+    }
+
+    void
+    testSnapshotByteBudget()
+    {
+        testcase("snapshot prioritizes trusted entries within byte budget");
+
+        constexpr std::size_t trustedCount = 300;
+        constexpr std::size_t untrustedCount = 100;
+        std::vector<ManifestData> trusted;
+        std::vector<ManifestData> untrusted;
+        trusted.reserve(trustedCount);
+        untrusted.reserve(untrustedCount);
+        for (std::size_t i = 0; i < trustedCount; ++i)
+            trusted.push_back(makeManifest(true));
+        for (std::size_t i = 0; i < untrustedCount; ++i)
+            untrusted.push_back(makeManifest());
+
+        jtx::Env env{
+            *this, jtx::envconfig([&trusted](std::unique_ptr<Config> config) {
+                auto& validators = config->section(SECTION_VALIDATORS);
+                for (auto const& manifest : trusted)
+                {
+                    validators.append(
+                        toBase58(TokenType::NodePublic, manifest.masterKey));
+                }
+                return config;
+            })};
+
+        hash_set<PublicKey> trustedMasters;
+        trustedMasters.reserve(trusted.size());
+        auto& cache = env.app().validatorManifests();
+        for (auto const& data : trusted)
+        {
+            BEAST_EXPECT(env.app().validators().listed(data.masterKey));
+            trustedMasters.insert(data.masterKey);
+            auto manifest = deserializeManifest(data.serialized);
+            BEAST_EXPECT(manifest.has_value());
+            if (manifest)
+            {
+                BEAST_EXPECT(
+                    cache.applyManifest(
+                        std::move(*manifest),
+                        ManifestRateLimitCapPolicy::Uncapped) ==
+                    ManifestDisposition::accepted);
+            }
+        }
+        for (auto const& data : untrusted)
+        {
+            BEAST_EXPECT(!env.app().validators().listed(data.masterKey));
+            auto manifest = deserializeManifest(data.serialized);
+            BEAST_EXPECT(manifest.has_value());
+            if (manifest)
+            {
+                BEAST_EXPECT(
+                    cache.applyManifest(
+                        std::move(*manifest),
+                        ManifestRateLimitCapPolicy::Capped) ==
+                    ManifestDisposition::accepted);
+            }
+        }
+
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const snapshot = unpack(overlay.getManifestsMessage());
+        BEAST_EXPECT(snapshot.has_value());
+        if (!snapshot)
+            return;
+
+        BEAST_EXPECT(snapshot->list_size() > 0);
+        BEAST_EXPECT(
+            static_cast<std::size_t>(snapshot->list_size()) < trustedCount);
+        BEAST_EXPECT(
+            Message::messageSize(*snapshot) <= maximumManifestsMessageSize);
+        for (auto const& entry : snapshot->list())
+        {
+            auto manifest = deserializeManifest(entry.stobject());
+            BEAST_EXPECT(manifest.has_value());
+            if (manifest)
+                BEAST_EXPECT(trustedMasters.contains(manifest->masterKey));
+        }
+    }
+
+public:
+    void
+    run() override
+    {
+        testBoundedReceive();
+        testRelaySkipIntersection();
+        testSnapshotByteBudget();
     }
 };
 

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -215,6 +215,14 @@ class manifest_relay_test : public beast::unit_test::suite
         return manifests;
     }
 
+    static std::optional<protocol::TMManifests>
+    unpackFirst(std::vector<std::shared_ptr<Message>> const& messages)
+    {
+        if (messages.empty())
+            return std::nullopt;
+        return unpack(messages.front());
+    }
+
     void
     expectBundle(std::shared_ptr<PeerTest> const& peer, std::size_t const count)
     {
@@ -295,7 +303,8 @@ class manifest_relay_test : public beast::unit_test::suite
         BEAST_EXPECT(!env.app().validators().listed(published.masterKey));
         BEAST_EXPECT(!env.app().validators().trusted(published.masterKey));
         BEAST_EXPECT(
-            !env.app().validatorManifests().getSequence(published.masterKey));
+            env.app().validatorManifests().getSequence(published.masterKey) ==
+            1);
 
         auto send = [&](ManifestData const& data) {
             auto incoming = std::make_shared<protocol::TMManifests>();
@@ -306,17 +315,15 @@ class manifest_relay_test : public beast::unit_test::suite
         send(rotation);
         expectBundle(destination, 1);
         BEAST_EXPECT(
-            !env.app().validatorManifests().getSequence(published.masterKey));
-        auto identity = env.app().validators().lookupMonitoringIdentity(
-            published.masterKey);
-        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::resolved);
-        BEAST_EXPECT(identity.signing == rotation.signingKey);
-        BEAST_EXPECT(identity.manifest && identity.manifest->sequence == 2);
-        BEAST_EXPECT(!identity.presentInOrdinaryState);
+            env.app().validatorManifests().getSequence(published.masterKey) ==
+            2);
+        BEAST_EXPECT(
+            env.app().validatorManifests().getSigningKey(published.masterKey) ==
+            rotation.signingKey);
         BEAST_EXPECT(!env.app().validators().listed(published.masterKey));
         BEAST_EXPECT(!env.app().validators().trusted(published.masterKey));
 
-        auto snapshot = unpack(overlay.getManifestsMessage());
+        auto snapshot = unpackFirst(overlay.getManifestsMessages());
         BEAST_EXPECT(snapshot.has_value());
         if (snapshot)
         {
@@ -333,64 +340,10 @@ class manifest_relay_test : public beast::unit_test::suite
         expectBundle(destination, 1);
         BEAST_EXPECT(
             !env.app().validatorManifests().getSequence(published.masterKey));
-        identity = env.app().validators().lookupMonitoringIdentity(
-            published.masterKey);
-        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::revoked);
-        BEAST_EXPECT(!identity.signing);
-        BEAST_EXPECT(identity.manifest && identity.manifest->revoked());
-        BEAST_EXPECT(!identity.presentInOrdinaryState);
+        BEAST_EXPECT(
+            env.app().validatorManifests().revoked(published.masterKey));
         BEAST_EXPECT(!env.app().validators().listed(published.masterKey));
         BEAST_EXPECT(!env.app().validators().trusted(published.masterKey));
-    }
-
-    void
-    testCandidateCollisionDoesNotAffectConsensus()
-    {
-        testcase("candidate signing collision does not affect consensus");
-
-        auto const directSigning = randomKeyPair(KeyType::secp256k1);
-        jtx::Env env{
-            *this,
-            jtx::envconfig([&directSigning](std::unique_ptr<Config> config) {
-                config->section("validators")
-                    .append(
-                        toBase58(TokenType::NodePublic, directSigning.first));
-                return config;
-            })};
-        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
-        auto const source = addPeer(env);
-        auto const destination = addPeer(env);
-        auto const candidateSecret = randomSecretKey();
-        auto const published = makeManifest(candidateSecret, 1);
-        auto const collision = makeManifest(candidateSecret, directSigning, 2);
-
-        installCandidate(env, published);
-        BEAST_EXPECT(env.app().validators().listed(directSigning.first));
-        BEAST_EXPECT(
-            env.app().validatorManifests().getMasterKey(directSigning.first) ==
-            directSigning.first);
-
-        auto incoming = std::make_shared<protocol::TMManifests>();
-        incoming->add_list()->set_stobject(collision.serialized);
-        overlay.onManifests(incoming, source);
-
-        expectBundle(destination, 1);
-        BEAST_EXPECT(env.app().validators().listed(directSigning.first));
-        BEAST_EXPECT(
-            env.app().validatorManifests().getMasterKey(directSigning.first) ==
-            directSigning.first);
-        BEAST_EXPECT(
-            !env.app().validatorManifests().getSequence(published.masterKey));
-        BEAST_EXPECT(
-            env.app()
-                .validators()
-                .lookupMonitoringIdentity(published.masterKey)
-                .status == ValidatorIdentityStatus::conflict);
-        BEAST_EXPECT(
-            env.app()
-                .validators()
-                .resolveMonitoringSigner(directSigning.first)
-                .status == ValidatorIdentityStatus::conflict);
     }
 
     void
@@ -413,7 +366,7 @@ class manifest_relay_test : public beast::unit_test::suite
         {
             BEAST_EXPECT(
                 env.app().validatorManifests().applyManifest(
-                    std::move(*ordinary), ManifestRateLimitCapPolicy::Capped) ==
+                    std::move(*ordinary), ManifestRetention::evictable) ==
                 ManifestDisposition::accepted);
         }
         installCandidate(env, published);
@@ -424,15 +377,9 @@ class manifest_relay_test : public beast::unit_test::suite
 
         BEAST_EXPECT(destination->sent_.empty());
         BEAST_EXPECT(
-            env.app().validators().candidateManifestOverrides().empty());
-        BEAST_EXPECT(
             env.app().validatorManifests().revoked(published.masterKey));
-        auto const identity = env.app().validators().lookupMonitoringIdentity(
-            published.masterKey);
-        BEAST_EXPECT(identity.status == ValidatorIdentityStatus::revoked);
-        BEAST_EXPECT(identity.manifest && identity.manifest->revoked());
 
-        auto const snapshot = unpack(overlay.getManifestsMessage());
+        auto const snapshot = unpackFirst(overlay.getManifestsMessages());
         BEAST_EXPECT(snapshot.has_value());
         if (snapshot)
         {
@@ -481,7 +428,7 @@ class manifest_relay_test : public beast::unit_test::suite
         BEAST_EXPECT(source->sent_.empty());
         expectBundle(destination, 1);
 
-        auto const snapshot = unpack(overlay.getManifestsMessage());
+        auto const snapshot = unpackFirst(overlay.getManifestsMessages());
         BEAST_EXPECT(snapshot.has_value());
         if (snapshot)
         {
@@ -625,8 +572,7 @@ class manifest_relay_test : public beast::unit_test::suite
             {
                 BEAST_EXPECT(
                     cache.applyManifest(
-                        std::move(*manifest),
-                        ManifestRateLimitCapPolicy::Capped) ==
+                        std::move(*manifest), ManifestRetention::evictable) ==
                     ManifestDisposition::accepted);
             }
         }
@@ -656,7 +602,7 @@ class manifest_relay_test : public beast::unit_test::suite
     void
     testSnapshotByteBudget()
     {
-        testcase("snapshot prioritizes trusted entries within byte budget");
+        testcase("snapshot chunks every protected entry within byte budget");
 
         constexpr std::size_t trustedCount = 300;
         constexpr std::size_t untrustedCount = 100;
@@ -693,8 +639,7 @@ class manifest_relay_test : public beast::unit_test::suite
             {
                 BEAST_EXPECT(
                     cache.applyManifest(
-                        std::move(*manifest),
-                        ManifestRateLimitCapPolicy::Uncapped) ==
+                        std::move(*manifest), ManifestRetention::protected_) ==
                     ManifestDisposition::accepted);
             }
         }
@@ -707,36 +652,48 @@ class manifest_relay_test : public beast::unit_test::suite
             {
                 BEAST_EXPECT(
                     cache.applyManifest(
-                        std::move(*manifest),
-                        ManifestRateLimitCapPolicy::Capped) ==
+                        std::move(*manifest), ManifestRetention::evictable) ==
                     ManifestDisposition::accepted);
             }
         }
 
         auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
-        auto const snapshot = unpack(overlay.getManifestsMessage());
-        BEAST_EXPECT(snapshot.has_value());
-        if (!snapshot)
-            return;
+        auto const messages = overlay.getManifestsMessages();
+        BEAST_EXPECT(messages.size() > 1);
 
-        BEAST_EXPECT(snapshot->list_size() > 0);
-        BEAST_EXPECT(
-            static_cast<std::size_t>(snapshot->list_size()) < trustedCount);
-        BEAST_EXPECT(
-            Message::messageSize(*snapshot) <= maximumManifestsMessageSize);
-        for (auto const& entry : snapshot->list())
+        hash_set<PublicKey> seenTrusted;
+        std::size_t seenUntrusted = 0;
+        for (auto const& message : messages)
         {
-            auto manifest = deserializeManifest(entry.stobject());
-            BEAST_EXPECT(manifest.has_value());
-            if (manifest)
-                BEAST_EXPECT(trustedMasters.contains(manifest->masterKey));
+            auto const snapshot = unpack(message);
+            BEAST_EXPECT(snapshot.has_value());
+            if (!snapshot)
+                continue;
+            BEAST_EXPECT(
+                Message::messageSize(*snapshot) <= maximumManifestsMessageSize);
+            BEAST_EXPECT(
+                static_cast<std::size_t>(snapshot->list_size()) <=
+                kMaxManifestEntriesPerMessage);
+            for (auto const& entry : snapshot->list())
+            {
+                auto manifest = deserializeManifest(entry.stobject());
+                BEAST_EXPECT(manifest.has_value());
+                if (!manifest)
+                    continue;
+                if (trustedMasters.contains(manifest->masterKey))
+                    seenTrusted.insert(manifest->masterKey);
+                else
+                    ++seenUntrusted;
+            }
         }
+        BEAST_EXPECT(seenTrusted.size() == trustedCount);
+        BEAST_EXPECT(seenUntrusted <= untrustedCount);
     }
 
     void
     testListingChangeInvalidatesSnapshot()
     {
-        testcase("listing change invalidates cached snapshot");
+        testcase("retention change invalidates cached snapshot");
 
         jtx::Env env{*this};
         auto const target = makeManifest();
@@ -748,14 +705,13 @@ class manifest_relay_test : public beast::unit_test::suite
         auto& cache = env.app().validatorManifests();
         BEAST_EXPECT(
             cache.applyManifest(
-                std::move(*manifest), ManifestRateLimitCapPolicy::Uncapped) ==
+                std::move(*manifest), ManifestRetention::evictable) ==
             ManifestDisposition::accepted);
 
         auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
-        auto const first = overlay.getManifestsMessage();
-        BEAST_EXPECT(first != nullptr);
+        auto const first = overlay.getManifestsMessages();
+        BEAST_EXPECT(first.size() == 1);
         auto const manifestSeq = cache.sequence();
-        auto const listingSeq = env.app().validators().listingSequence();
 
         BEAST_EXPECT(env.app().validators().load(
             std::nullopt,
@@ -763,12 +719,12 @@ class manifest_relay_test : public beast::unit_test::suite
             {},
             std::nullopt));
         BEAST_EXPECT(env.app().validators().listed(target.masterKey));
-        BEAST_EXPECT(cache.sequence() == manifestSeq);
-        BEAST_EXPECT(env.app().validators().listingSequence() > listingSeq);
+        BEAST_EXPECT(cache.sequence() == manifestSeq + 1);
 
-        auto const second = overlay.getManifestsMessage();
-        BEAST_EXPECT(second != nullptr);
-        BEAST_EXPECT(second != first);
+        auto const second = overlay.getManifestsMessages();
+        BEAST_EXPECT(second.size() == 1);
+        if (first.size() == 1 && second.size() == 1)
+            BEAST_EXPECT(second.front() != first.front());
     }
 
     void
@@ -786,7 +742,7 @@ class manifest_relay_test : public beast::unit_test::suite
         auto& cache = env.app().validatorManifests();
         BEAST_EXPECT(
             cache.applyManifest(
-                std::move(*manifest), ManifestRateLimitCapPolicy::Capped) ==
+                std::move(*manifest), ManifestRetention::evictable) ==
             ManifestDisposition::accepted);
         auto const before = cache.sequence();
 
@@ -798,7 +754,7 @@ class manifest_relay_test : public beast::unit_test::suite
         BEAST_EXPECT(env.app().validators().listed(target.masterKey));
         BEAST_EXPECT(cache.sequence() == before + 1);
 
-        cache.promoteToTrusted(target.masterKey);
+        cache.setRetention(target.masterKey, ManifestRetention::protected_);
         BEAST_EXPECT(cache.sequence() == before + 1);
     }
 
@@ -810,7 +766,6 @@ public:
         testTotalEntryLimit();
         testKnownUpdateRelays();
         testCandidateUpdateRelays();
-        testCandidateCollisionDoesNotAffectConsensus();
         testCandidateCannotRollbackOrdinaryHighWater();
         testRevocationRelay();
         testEvictedManifestStopsLocally();

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -1,0 +1,196 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright 2026 Xahau Ledger Foundation.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <test/jtx.h>
+#include <test/jtx/Env.h>
+#include <xrpld/overlay/detail/OverlayImpl.h>
+#include <xrpld/overlay/detail/PeerImp.h>
+#include <xrpld/peerfinder/detail/SlotImp.h>
+#include <xrpl/basics/make_SSLContext.h>
+#include <xrpl/beast/unit_test.h>
+#include <xrpl/protocol/STExchange.h>
+#include <xrpl/protocol/Sign.h>
+
+namespace ripple {
+namespace test {
+
+class manifest_relay_test : public beast::unit_test::suite
+{
+    using socket_type = boost::asio::ip::tcp::socket;
+    using middle_type = boost::beast::tcp_stream;
+    using stream_type = boost::beast::ssl_stream<middle_type>;
+
+    class PeerTest : public PeerImp
+    {
+    public:
+        PeerTest(
+            Application& app,
+            std::shared_ptr<PeerFinder::Slot> const& slot,
+            http_request_type&& request,
+            PublicKey const& publicKey,
+            ProtocolVersion protocol,
+            Resource::Consumer consumer,
+            std::unique_ptr<manifest_relay_test::stream_type>&& stream,
+            OverlayImpl& overlay)
+            : PeerImp(
+                  app,
+                  nextId_++,
+                  slot,
+                  std::move(request),
+                  publicKey,
+                  protocol,
+                  consumer,
+                  std::move(stream),
+                  overlay)
+        {
+        }
+
+        void
+        run() override
+        {
+        }
+
+        void
+        send(std::shared_ptr<Message> const& message) override
+        {
+            sent_.push_back(message);
+        }
+
+        std::vector<std::shared_ptr<Message>> sent_;
+        inline static Peer::id_t nextId_ = 1;
+    };
+
+    std::shared_ptr<boost::asio::ssl::context> context_{make_SSLContext("")};
+    std::uint16_t endpoint_{1};
+
+    static std::string
+    makeManifest()
+    {
+        auto const [masterPublic, masterSecret] =
+            randomKeyPair(KeyType::ed25519);
+        auto const [signingPublic, signingSecret] =
+            randomKeyPair(KeyType::secp256k1);
+
+        STObject st{sfGeneric};
+        st[sfSequence] = 0;
+        st[sfPublicKey] = masterPublic;
+        st[sfSigningPubKey] = signingPublic;
+        sign(st, HashPrefix::manifest, KeyType::secp256k1, signingSecret);
+        sign(
+            st,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            masterSecret,
+            sfMasterSignature);
+
+        Serializer serialized;
+        st.add(serialized);
+        return {static_cast<char const*>(serialized.data()), serialized.size()};
+    }
+
+    std::shared_ptr<PeerTest>
+    addPeer(jtx::Env& env)
+    {
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        boost::beast::http::request<boost::beast::http::dynamic_body> request;
+        auto stream = std::make_unique<stream_type>(
+            socket_type(env.app().getIOService()), *context_);
+
+        auto const octet = endpoint_++;
+        beast::IP::Endpoint const local{beast::IP::Address::from_string(
+            "172.1.1." + std::to_string(octet))};
+        beast::IP::Endpoint const remote{beast::IP::Address::from_string(
+            "172.1.2." + std::to_string(octet))};
+        auto const peerPublic = std::get<0>(randomKeyPair(KeyType::ed25519));
+        auto consumer = overlay.resourceManager().newInboundEndpoint(remote);
+        auto slot = overlay.peerFinder().new_inbound_slot(local, remote);
+        auto peer = std::make_shared<PeerTest>(
+            env.app(),
+            slot,
+            std::move(request),
+            peerPublic,
+            ProtocolVersion{1, 7},
+            consumer,
+            std::move(stream),
+            overlay);
+        overlay.add_active(peer);
+        return peer;
+    }
+
+    static std::optional<protocol::TMManifests>
+    unpack(std::shared_ptr<Message> const& message)
+    {
+        if (!message)
+            return std::nullopt;
+
+        auto const& buffer = message->getBuffer(compression::Compressed::Off);
+        if (buffer.size() <= compression::headerBytes)
+            return std::nullopt;
+
+        protocol::TMManifests manifests;
+        if (!manifests.ParseFromArray(
+                buffer.data() + compression::headerBytes,
+                static_cast<int>(buffer.size() - compression::headerBytes)))
+            return std::nullopt;
+        return manifests;
+    }
+
+public:
+    void
+    run() override
+    {
+        testcase("bounded receive, source suppression, and peer snapshot");
+
+        jtx::Env env{*this};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const destination = addPeer(env);
+
+        auto incoming = std::make_shared<protocol::TMManifests>();
+        for (std::size_t i = 0; i < kMaxManifestsPerMessage + 1; ++i)
+            incoming->add_list()->set_stobject(makeManifest());
+
+        auto const before = env.app().validatorManifests().sequence();
+        overlay.onManifests(incoming, source);
+
+        BEAST_EXPECT(
+            env.app().validatorManifests().sequence() ==
+            before + kMaxManifestsPerMessage);
+        BEAST_EXPECT(source->sent_.empty());
+        BEAST_EXPECT(destination->sent_.size() == 1);
+
+        if (destination->sent_.size() == 1)
+        {
+            auto const relayed = unpack(destination->sent_.front());
+            BEAST_EXPECT(relayed.has_value());
+            if (relayed)
+                BEAST_EXPECT(relayed->list_size() == kMaxManifestsPerMessage);
+        }
+
+        auto const snapshot = unpack(overlay.getManifestsMessage());
+        BEAST_EXPECT(snapshot.has_value());
+        if (snapshot)
+            BEAST_EXPECT(snapshot->list_size() == kMaxManifestsPerMessage);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(manifest_relay, overlay, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/overlay/manifest_relay_test.cpp
+++ b/src/test/overlay/manifest_relay_test.cpp
@@ -85,6 +85,7 @@ class manifest_relay_test : public beast::unit_test::suite
     {
         std::string serialized;
         PublicKey masterKey;
+        PublicKey signingKey;
         uint256 hash;
     };
 
@@ -119,7 +120,11 @@ class manifest_relay_test : public beast::unit_test::suite
             static_cast<char const*>(serialized.data()), serialized.size()};
         auto manifest = deserializeManifest(bytes);
         BEAST_EXPECT(manifest.has_value());
-        return {bytes, masterPublic, manifest ? manifest->hash() : uint256{}};
+        return {
+            bytes,
+            masterPublic,
+            signingPublic,
+            manifest ? manifest->hash() : uint256{}};
     }
 
     std::shared_ptr<PeerTest>
@@ -226,6 +231,29 @@ class manifest_relay_test : public beast::unit_test::suite
     }
 
     void
+    testTotalEntryLimit()
+    {
+        testcase("total entry limit bounds malformed work");
+
+        jtx::Env env{*this};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const destination = addPeer(env);
+
+        auto incoming = std::make_shared<protocol::TMManifests>();
+        for (std::size_t i = 0; i < kMaxManifestEntriesPerMessage + 1; ++i)
+            incoming->add_list()->set_stobject("");
+
+        BEAST_EXPECT(incoming->IsInitialized());
+        auto const before = env.app().validatorManifests().sequence();
+        overlay.onManifests(incoming, source);
+
+        BEAST_EXPECT(env.app().validatorManifests().sequence() == before);
+        BEAST_EXPECT(source->sent_.empty());
+        BEAST_EXPECT(destination->sent_.empty());
+    }
+
+    void
     testRelaySkipIntersection()
     {
         testcase("relay skips only peers that have every bundled manifest");
@@ -253,6 +281,64 @@ class manifest_relay_test : public beast::unit_test::suite
         BEAST_EXPECT(complete->sent_.empty());
         expectBundle(partial, 2);
         expectBundle(fresh, 2);
+    }
+
+    void
+    testEvictionDoesNotRearmRelay()
+    {
+        testcase("eviction does not rearm relay suppression");
+
+        jtx::Env env{*this};
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const source = addPeer(env);
+        auto const destination = addPeer(env);
+        auto const target = makeManifest();
+
+        auto incoming = std::make_shared<protocol::TMManifests>();
+        incoming->add_list()->set_stobject(target.serialized);
+        overlay.onManifests(incoming, source);
+        expectBundle(destination, 1);
+        destination->sent_.clear();
+
+        constexpr std::size_t untrustedCacheLimit = 1000;
+        hash_set<PublicKey> activeSigningKeys;
+        activeSigningKeys.reserve(untrustedCacheLimit - 1);
+        auto& cache = env.app().validatorManifests();
+        for (std::size_t i = 1; i < untrustedCacheLimit; ++i)
+        {
+            auto const filler = makeManifest();
+            activeSigningKeys.insert(filler.signingKey);
+            auto manifest = deserializeManifest(filler.serialized);
+            BEAST_EXPECT(manifest.has_value());
+            if (manifest)
+            {
+                BEAST_EXPECT(
+                    cache.applyManifest(
+                        std::move(*manifest),
+                        ManifestRateLimitCapPolicy::Capped) ==
+                    ManifestDisposition::accepted);
+            }
+        }
+
+        auto const replacement = makeManifest();
+        auto replacementManifest = deserializeManifest(replacement.serialized);
+        BEAST_EXPECT(replacementManifest.has_value());
+        if (replacementManifest)
+        {
+            BEAST_EXPECT(
+                cache.applyManifestWithEviction(
+                    std::move(*replacementManifest), activeSigningKeys) ==
+                ManifestDisposition::accepted);
+        }
+        BEAST_EXPECT(!cache.getSequence(target.masterKey));
+
+        incoming = std::make_shared<protocol::TMManifests>();
+        incoming->add_list()->set_stobject(target.serialized);
+        overlay.onManifests(incoming, source);
+
+        BEAST_EXPECT(cache.getSequence(target.masterKey) == 0);
+        BEAST_EXPECT(source->sent_.empty());
+        BEAST_EXPECT(destination->sent_.empty());
     }
 
     void
@@ -335,13 +421,86 @@ class manifest_relay_test : public beast::unit_test::suite
         }
     }
 
+    void
+    testListingChangeInvalidatesSnapshot()
+    {
+        testcase("listing change invalidates cached snapshot");
+
+        jtx::Env env{*this};
+        auto const target = makeManifest();
+        auto manifest = deserializeManifest(target.serialized);
+        BEAST_EXPECT(manifest.has_value());
+        if (!manifest)
+            return;
+
+        auto& cache = env.app().validatorManifests();
+        BEAST_EXPECT(
+            cache.applyManifest(
+                std::move(*manifest), ManifestRateLimitCapPolicy::Uncapped) ==
+            ManifestDisposition::accepted);
+
+        auto& overlay = dynamic_cast<OverlayImpl&>(env.app().overlay());
+        auto const first = overlay.getManifestsMessage();
+        BEAST_EXPECT(first != nullptr);
+        auto const manifestSeq = cache.sequence();
+        auto const listingSeq = env.app().validators().listingSequence();
+
+        BEAST_EXPECT(env.app().validators().load(
+            std::nullopt,
+            {toBase58(TokenType::NodePublic, target.masterKey)},
+            {},
+            std::nullopt));
+        BEAST_EXPECT(env.app().validators().listed(target.masterKey));
+        BEAST_EXPECT(cache.sequence() == manifestSeq);
+        BEAST_EXPECT(env.app().validators().listingSequence() > listingSeq);
+
+        auto const second = overlay.getManifestsMessage();
+        BEAST_EXPECT(second != nullptr);
+        BEAST_EXPECT(second != first);
+    }
+
+    void
+    testConfigListingPromotesRetention()
+    {
+        testcase("config listing promotes retained manifest");
+
+        jtx::Env env{*this};
+        auto const target = makeManifest();
+        auto manifest = deserializeManifest(target.serialized);
+        BEAST_EXPECT(manifest.has_value());
+        if (!manifest)
+            return;
+
+        auto& cache = env.app().validatorManifests();
+        BEAST_EXPECT(
+            cache.applyManifest(
+                std::move(*manifest), ManifestRateLimitCapPolicy::Capped) ==
+            ManifestDisposition::accepted);
+        auto const before = cache.sequence();
+
+        BEAST_EXPECT(env.app().validators().load(
+            std::nullopt,
+            {toBase58(TokenType::NodePublic, target.masterKey)},
+            {},
+            std::nullopt));
+        BEAST_EXPECT(env.app().validators().listed(target.masterKey));
+        BEAST_EXPECT(cache.sequence() == before + 1);
+
+        cache.promoteToTrusted(target.masterKey);
+        BEAST_EXPECT(cache.sequence() == before + 1);
+    }
+
 public:
     void
     run() override
     {
         testBoundedReceive();
+        testTotalEntryLimit();
         testRelaySkipIntersection();
+        testEvictionDoesNotRearmRelay();
         testSnapshotByteBudget();
+        testListingChangeInvalidatesSnapshot();
+        testConfigListingPromotesRetention();
     }
 };
 

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -263,6 +263,18 @@ enum class ManifestDisposition {
     untrustedCapacity
 };
 
+/** Result of bounded untrusted-manifest admission.
+
+    `acceptedUpdate` is meaningful only when `disposition` is `accepted`. It is
+    computed under the cache write lock and distinguishes an update of a
+    retained identity from admission as a new identity.
+*/
+struct ManifestApplyResult
+{
+    ManifestDisposition disposition;
+    bool acceptedUpdate;
+};
+
 inline std::string
 to_string(ManifestDisposition m)
 {
@@ -301,16 +313,20 @@ class DatabaseCon;
     Entries admitted uncapped, or later promoted, are outside the eviction
     population. For unlisted validators, recent validation activity is only an
     eviction preference; it does not confer trust and cannot prevent eviction
-    when every candidate is active. Relay suppression must therefore be
-    maintained independently of this cache.
+    when every candidate is active.
 
     This is not complete adversarial containment. Once full, the cache gives
-    valid novel identities a small eviction budget, bounding cache churn and
-    corresponding relays. A candidate is verified before consuming a permit;
-    when no permit or refill is available, it is rejected before verification.
-    HashRouter separately suppresses repeat relay of the same manifest hash.
-    A sustained sender can monopolize the global eviction budget and delay a
-    legitimate novel untrusted validator; protected validators are unaffected.
+    valid novel identities a small eviction budget, bounding admitted identity
+    churn. Capacity rejection normally avoids verification when no permit is
+    available, although concurrent callers may race on observed availability.
+    Updates to an already retained identity do not consume the budget.
+    First-seen unlisted identities are not relayed live. A bounded selected
+    subset propagates through the cached connection snapshot.
+    Later rotations and revocations relay while the identity remains resident.
+    If eviction forgets one, its reappearance is first-seen again and therefore
+    does not immediately relay. A sustained sender can monopolize the eviction
+    budget and delay a legitimate novel untrusted validator; protected
+    validators are unaffected.
 */
 class ManifestCache
 {
@@ -352,7 +368,8 @@ private:
     applyManifestImpl(
         Manifest m,
         ManifestRateLimitCapPolicy cap,
-        hash_set<PublicKey> const* currentValidationKeys);
+        hash_set<PublicKey> const* currentValidationKeys,
+        bool* acceptedUpdate);
 
 public:
     explicit ManifestCache(
@@ -465,8 +482,11 @@ public:
         @param m Manifest to add
         @param currentValidationKeys Signing keys with current validations;
                these are eviction preferences, not trusted identities
+
+        @return disposition and an atomic indication that an accepted manifest
+                updated an identity retained at admission time
     */
-    ManifestDisposition
+    ManifestApplyResult
     applyManifestWithEviction(
         Manifest m,
         hash_set<PublicKey> const& currentValidationKeys);

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -66,9 +66,11 @@ namespace ripple {
     added to the manifest cache.  Other manifests are added as "gossip"
     received from rippled peers, including ones for validators this node does
     not trust. Manifests for untrusted validators are capped
-    (kMaxUntrustedCount) so peer gossip cannot grow the cache without bound;
-    trusted validators are not capped. Entries are never evicted, so a stored
-    revocation is permanent.
+    (kMaxUntrustedCount) so peer gossip cannot grow the cache without bound.
+    Entries admitted as trusted, or later promoted to trusted, are not capped
+    or evicted. Promotion is one-way. At capacity, an untrusted entry is
+    evicted to admit a new valid manifest; entries whose signing keys have
+    current validations are avoided while a dormant victim exists.
 
     When an ephemeral key is compromised, a new signing key pair is created,
     along with a new manifest vouching for it (with a higher sequence number),
@@ -278,7 +280,25 @@ enum class ManifestRateLimitCapPolicy : std::uint8_t { Capped, Uncapped };
 
 class DatabaseCon;
 
-/** Remembers manifests with the highest sequence number. */
+/** Remembers manifests with the highest sequence number.
+
+    This is protocol state, not merely a payload cache. While an entry remains
+    resident, it supplies the sequence high-water mark, revocation state, and
+    master/signing-key collision checks for that validator. Evicting an
+    untrusted entry necessarily forgets those facts and can make an old
+    manifest cache-new again.
+
+    Entries admitted uncapped, or later promoted, are outside the eviction
+    population. For unlisted validators, recent validation activity is only an
+    eviction preference; it does not confer trust and cannot prevent eviction
+    when every candidate is active. Relay suppression must therefore be
+    maintained independently of this cache.
+
+    This is a retained-state bound, not complete adversarial containment. A
+    stream of unique, valid identities can still consume signature checks,
+    victim-selection work, and relay bandwidth. HashRouter suppresses repeat
+    relay of the same manifest hash; it does not bound novel-hash amplification.
+*/
 class ManifestCache
 {
 private:
@@ -297,13 +317,19 @@ private:
     hash_set<PublicKey> untrustedKeys_;
 
     /** Maximum number of untrusted master keys retained in memory. */
-    static constexpr std::size_t kMaxUntrustedCount = 100;
+    static constexpr std::size_t kMaxUntrustedCount = 1000;
 
     /** Number of manifests rejected because the untrusted cache was full. */
     std::atomic<std::uint64_t> untrustedRejectCount_{0};
 
     /** Number of capacity rejections between warning summaries. */
     static constexpr std::uint64_t kUntrustedRejectCount = 10000;
+
+    ManifestDisposition
+    applyManifestImpl(
+        Manifest m,
+        ManifestRateLimitCapPolicy cap,
+        hash_set<PublicKey> const* currentValidationKeys);
 
 public:
     explicit ManifestCache(
@@ -395,6 +421,22 @@ public:
     */
     ManifestDisposition
     applyManifest(Manifest m, ManifestRateLimitCapPolicy cap);
+
+    /** Add an untrusted manifest, evicting another at capacity.
+
+        A dormant untrusted entry is chosen at random when possible. If all
+        retained untrusted signing keys have current validations, any
+        untrusted entry may be chosen. The candidate is fully verified before
+        eviction.
+
+        @param m Manifest to add
+        @param currentValidationKeys Signing keys with current validations;
+               these are eviction preferences, not trusted identities
+    */
+    ManifestDisposition
+    applyManifestWithEviction(
+        Manifest m,
+        hash_set<PublicKey> const& currentValidationKeys);
 
     /** Stop counting a cached master key against the untrusted cap. */
     void

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -327,6 +327,17 @@ private:
     /** Master public keys stored by current ephemeral public key. */
     hash_map<PublicKey, PublicKey> signingToMasterKeys_;
 
+    /** Current monitoring-only manifests supplied by trusted VL publishers.
+
+        This is a source-aware overlay rather than part of `map_`: candidates
+        must remain available while their publisher generation is effective,
+        but must not consume trust, interfere with authoritative manifests,
+        enter peer gossip/SQLite persistence, or survive replacement of that
+        generation.
+    */
+    hash_map<PublicKey, Manifest> publisherCandidates_;
+    hash_map<PublicKey, PublicKey> candidateSigningToMasterKeys_;
+
     std::atomic<std::uint32_t> seq_{0};
 
     /** Master keys currently counted against the untrusted cache cap. */
@@ -354,6 +365,9 @@ private:
         hash_set<PublicKey> const* currentValidationKeys);
 
 public:
+    /** Maximum number of current publisher candidates retained globally. */
+    static constexpr std::size_t maxPublisherCandidates = 1000;
+
     explicit ManifestCache(
         beast::Journal j = beast::Journal(beast::Journal::getNullSink()),
         Now now = [] { return std::chrono::steady_clock::now(); })
@@ -393,6 +407,22 @@ public:
     */
     PublicKey
     getMasterKey(PublicKey const& pk) const;
+
+    /** Resolve an ephemeral key using only the authoritative manifest cache.
+
+        Publisher candidates are intentionally excluded. Consensus trust and
+        quorum policy must use this accessor rather than the monitoring view.
+    */
+    PublicKey
+    getAuthoritativeMasterKey(PublicKey const& pk) const;
+
+    /** Return a signing key using only the authoritative manifest cache. */
+    std::optional<PublicKey>
+    getAuthoritativeSigningKey(PublicKey const& pk) const;
+
+    /** Return revocation state from only the authoritative manifest cache. */
+    bool
+    authoritativeRevoked(PublicKey const& pk) const;
 
     /** Returns master key's current manifest sequence.
 
@@ -460,6 +490,25 @@ public:
     applyManifestWithEviction(
         Manifest m,
         hash_set<PublicKey> const& currentValidationKeys);
+
+    /** Atomically replace the monitoring-only publisher-candidate view.
+
+        Candidate manifests are verified, deduplicated by master/sequence,
+        checked for internal key collisions, and filtered against listed
+        master keys and their current authoritative signing keys. The result
+        is deterministically capped at `maxPublisherCandidates`.
+
+        Candidate entries affect monitoring lookup only. They are excluded
+        from normal manifest collision state, relay enumeration, and
+        persistence. This current-generation view does not enforce historical
+        signing-key non-reuse; doing that requires durable tombstones or
+        ledger history. Promotion is explicit through the ordinary validators
+        tier, never inferred from this overlay.
+    */
+    void
+    replacePublisherCandidates(
+        std::vector<Manifest> candidates,
+        hash_set<PublicKey> const& listedMasterKeys);
 
     /** Stop counting a cached master key against the untrusted cap. */
     void

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -73,8 +73,7 @@ namespace ripple {
     Entries admitted as protected, or later reclassified as protected, are not
     capped or evicted. Entries return to the evictable population when their
     protected source disappears. At capacity, an evictable entry is evicted to
-    admit a new valid manifest; entries whose signing keys have current
-    validations are avoided while a dormant victim exists.
+    admit a new valid manifest.
 
     When an ephemeral key is compromised, a new signing key pair is created,
     along with a new manifest vouching for it (with a higher sequence number),
@@ -317,10 +316,9 @@ class DatabaseCon;
     manifest cache-new again.
 
     Entries admitted with protected retention, or later reclassified as
-    protected, are outside the eviction population. For other validators,
-    recent validation activity is only an
-    eviction preference; it does not confer trust and cannot prevent eviction
-    when every candidate is active.
+    protected, are outside the eviction population. Other validators are
+    evictable regardless of recent validation activity; tier-2 publisher
+    provenance is the explicit way to protect a monitored candidate.
 
     This is not complete adversarial containment. Once full, the cache gives
     valid novel identities a small eviction budget, bounding admitted identity
@@ -378,7 +376,7 @@ private:
     applyManifestImpl(
         Manifest m,
         ManifestRetention retention,
-        hash_set<PublicKey> const* currentValidationKeys,
+        bool mayEvict,
         bool* acceptedUpdate);
 
 public:
@@ -475,22 +473,16 @@ public:
 
     /** Add an untrusted manifest, evicting another at capacity.
 
-        A dormant untrusted entry is chosen at random when possible. If all
-        retained untrusted signing keys have current validations, any
-        untrusted entry may be chosen. The candidate is fully verified before
-        eviction.
+        An evictable entry is chosen at random. The candidate is fully
+        verified before eviction.
 
         @param m Manifest to add
-        @param currentValidationKeys Signing keys with current validations;
-               these are eviction preferences, not trusted identities
 
         @return disposition and an atomic indication that an accepted manifest
                 updated an identity retained at admission time
     */
     ManifestApplyResult
-    applyManifestWithEviction(
-        Manifest m,
-        hash_set<PublicKey> const& currentValidationKeys);
+    applyManifestWithEviction(Manifest m);
 
     /** Change the retention class of an already cached master.
 

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -21,10 +21,15 @@
 #define RIPPLE_APP_MISC_MANIFEST_H_INCLUDED
 
 #include <xrpl/basics/UnorderedContainers.h>
+#include <xrpl/basics/base64.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/SecretKey.h>
 
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -54,12 +59,16 @@ namespace ripple {
     dynamically generates the signatureless form when it needs to verify
     the signature.
 
-    An instance of ManifestCache stores, for each trusted validator, (a) its
+    An instance of ManifestCache stores, for each known validator, (a) its
     master public key, and (b) the most senior of all valid manifests it has
     seen for that validator, if any.  On startup, the [validator_token] config
     entry (which contains the manifest for this validator) is decoded and
     added to the manifest cache.  Other manifests are added as "gossip"
-    received from rippled peers.
+    received from rippled peers, including ones for validators this node does
+    not trust. Manifests for untrusted validators are capped
+    (kMaxUntrustedCount) so peer gossip cannot grow the cache without bound;
+    trusted validators are not capped. Entries are never evicted, so a stored
+    revocation is permanent.
 
     When an ephemeral key is compromised, a new signing key pair is created,
     along with a new manifest vouching for it (with a higher sequence number),
@@ -151,6 +160,16 @@ struct Manifest
 std::string
 to_string(Manifest const& m);
 
+/** Largest a valid manifest can be, in decoded bytes. */
+constexpr std::size_t kMaxManifestBytes = 358;
+
+/** Largest a valid manifest can be, in base64 characters. */
+constexpr std::size_t kMaxManifestBase64 =
+    base64::encoded_size(kMaxManifestBytes);
+
+/** Maximum number of untrusted manifests processed from one message. */
+constexpr std::size_t kMaxManifestsPerMessage = 200;
+
 /** Constructs Manifest from serialized string
 
     @param s Serialized manifest string
@@ -226,7 +245,10 @@ enum class ManifestDisposition {
     badEphemeralKey,
 
     /// Timely, but invalid signature
-    invalid
+    invalid,
+
+    /// Unlisted and limit reached
+    untrustedCapacity
 };
 
 inline std::string
@@ -244,10 +266,15 @@ to_string(ManifestDisposition m)
             return "badEphemeralKey";
         case ManifestDisposition::invalid:
             return "invalid";
+        case ManifestDisposition::untrustedCapacity:
+            return "untrustedCapacity";
         default:
             return "unknown";
     }
 }
+
+/** Whether a manifest counts against the untrusted cache cap. */
+enum class ManifestRateLimitCapPolicy : std::uint8_t { Capped, Uncapped };
 
 class DatabaseCon;
 
@@ -265,6 +292,18 @@ private:
     hash_map<PublicKey, PublicKey> signingToMasterKeys_;
 
     std::atomic<std::uint32_t> seq_{0};
+
+    /** Master keys currently counted against the untrusted cache cap. */
+    hash_set<PublicKey> untrustedKeys_;
+
+    /** Maximum number of untrusted master keys retained in memory. */
+    static constexpr std::size_t kMaxUntrustedCount = 100;
+
+    /** Number of manifests rejected because the untrusted cache was full. */
+    std::atomic<std::uint64_t> untrustedRejectCount_{0};
+
+    /** Number of capacity rejections between warning summaries. */
+    static constexpr std::uint64_t kUntrustedRejectCount = 10000;
 
 public:
     explicit ManifestCache(
@@ -345,6 +384,8 @@ public:
 
         @param m Manifest to add
 
+        @param cap Whether a new master key counts against the untrusted cap
+
         @return `ManifestDisposition::accepted` if successful, or
                 `stale` or `invalid` otherwise
 
@@ -353,7 +394,11 @@ public:
         May be called concurrently
     */
     ManifestDisposition
-    applyManifest(Manifest m);
+    applyManifest(Manifest m, ManifestRateLimitCapPolicy cap);
+
+    /** Stop counting a cached master key against the untrusted cap. */
+    void
+    promoteToTrusted(PublicKey const& pk);
 
     /** Populate manifest cache with manifests in database and config.
 

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -32,6 +32,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -73,7 +74,8 @@ namespace ripple {
     Entries admitted as protected, or later reclassified as protected, are not
     capped or evicted. Entries return to the evictable population when their
     protected source disappears. At capacity, an evictable entry is evicted to
-    admit a new valid manifest.
+    admit a new valid manifest, preferring one with no current validation when
+    activity information is available.
 
     When an ephemeral key is compromised, a new signing key pair is created,
     along with a new manifest vouching for it (with a higher sequence number),
@@ -316,9 +318,12 @@ class DatabaseCon;
     manifest cache-new again.
 
     Entries admitted with protected retention, or later reclassified as
-    protected, are outside the eviction population. Other validators are
-    evictable regardless of recent validation activity; tier-2 publisher
-    provenance is the explicit way to protect a monitored candidate.
+    protected, are outside the eviction population. For other validators,
+    recent validation activity is an eviction preference, not a retention
+    guarantee or source of consensus trust. Tier-2 publisher provenance is the
+    explicit way to protect a monitored candidate. This preference makes an
+    actively validating untrusted identity harder to displace than a quiet one;
+    if every evictable identity appears active, selection is uniformly random.
 
     This is not complete adversarial containment. Once full, the cache gives
     valid novel identities a small eviction budget, bounding admitted identity
@@ -341,6 +346,18 @@ private:
 
     beast::Journal j_;
     Now now_;
+
+    /** Serialize post-verification admission of evictable manifests.
+
+        Signature verification remains concurrent. Once verified, evictable
+        admissions pass through this mutex so only the caller that can consume
+        an eviction permit samples activity and selects a victim. When both
+        mutexes are needed, this mutex is acquired before `mutex_`; caller code
+        is never invoked while `mutex_` is held. Manifest jobs use the shared
+        JobQueue worker pool, so work in this section must remain small.
+    */
+    std::mutex evictionAdmissionMutex_;
+
     std::shared_mutex mutable mutex_;
 
     /** Active manifests stored by master public key. */
@@ -377,6 +394,7 @@ private:
         Manifest m,
         ManifestRetention retention,
         bool mayEvict,
+        std::function<hash_set<PublicKey>()> const& currentValidationKeys,
         bool* acceptedUpdate);
 
 public:
@@ -473,16 +491,29 @@ public:
 
     /** Add an untrusted manifest, evicting another at capacity.
 
-        An evictable entry is chosen at random. The candidate is fully
-        verified before eviction.
+        A dormant evictable entry is chosen at random when possible. If every
+        retained evictable signing key has a current validation, any evictable
+        entry may be chosen. The candidate is fully verified before current
+        validations are sampled or an entry is evicted.
+
+        Activity is matched to the manifest's current signing key. Immediately
+        after rotation, an evictable identity appears dormant until a
+        validation from its new key arrives.
 
         @param m Manifest to add
+        @param currentValidationKeys Supplies signing keys with current
+               validations. It is called only when a verified novel manifest
+               needs and is permitted to evict an entry after serialized
+               admission rechecks. If omitted, victim selection is uniformly
+               random. The callback must not re-enter this method.
 
         @return disposition and an atomic indication that an accepted manifest
                 updated an identity retained at admission time
     */
     ManifestApplyResult
-    applyManifestWithEviction(Manifest m);
+    applyManifestWithEviction(
+        Manifest m,
+        std::function<hash_set<PublicKey>()> const& currentValidationKeys = {});
 
     /** Change the retention class of an already cached master.
 

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -70,10 +70,11 @@ namespace ripple {
     received from rippled peers, including ones for validators this node does
     not trust. Manifests for untrusted validators are capped
     (kMaxUntrustedCount) so peer gossip cannot grow the cache without bound.
-    Entries admitted as trusted, or later promoted to trusted, are not capped
-    or evicted. Promotion is one-way. At capacity, an untrusted entry is
-    evicted to admit a new valid manifest; entries whose signing keys have
-    current validations are avoided while a dormant victim exists.
+    Entries admitted as protected, or later reclassified as protected, are not
+    capped or evicted. Entries return to the evictable population when their
+    protected source disappears. At capacity, an evictable entry is evicted to
+    admit a new valid manifest; entries whose signing keys have current
+    validations are avoided while a dormant victim exists.
 
     When an ephemeral key is compromised, a new signing key pair is created,
     along with a new manifest vouching for it (with a higher sequence number),
@@ -297,8 +298,13 @@ to_string(ManifestDisposition m)
     }
 }
 
-/** Whether a manifest counts against the untrusted cache cap. */
-enum class ManifestRateLimitCapPolicy : std::uint8_t { Capped, Uncapped };
+/** Retention policy for an accepted manifest.
+
+    This is deliberately independent of validator-list membership and
+    consensus trust. Protected entries are not part of the bounded eviction
+    population; evictable entries are.
+*/
+enum class ManifestRetention : std::uint8_t { evictable, protected_ };
 
 class DatabaseCon;
 
@@ -310,8 +316,9 @@ class DatabaseCon;
     untrusted entry necessarily forgets those facts and can make an old
     manifest cache-new again.
 
-    Entries admitted uncapped, or later promoted, are outside the eviction
-    population. For unlisted validators, recent validation activity is only an
+    Entries admitted with protected retention, or later reclassified as
+    protected, are outside the eviction population. For other validators,
+    recent validation activity is only an
     eviction preference; it does not confer trust and cannot prevent eviction
     when every candidate is active.
 
@@ -346,8 +353,11 @@ private:
 
     std::atomic<std::uint32_t> seq_{0};
 
-    /** Master keys currently counted against the untrusted cache cap. */
-    hash_set<PublicKey> untrustedKeys_;
+    /** Master keys currently counted against the bounded eviction cap. */
+    hash_set<PublicKey> evictableKeys_;
+
+    /** Master keys explicitly protected by local validator configuration. */
+    hash_set<PublicKey> configuredKeys_;
 
     /** Maximum number of untrusted master keys retained in memory. */
     static constexpr std::size_t kMaxUntrustedCount = 1000;
@@ -367,7 +377,7 @@ private:
     ManifestDisposition
     applyManifestImpl(
         Manifest m,
-        ManifestRateLimitCapPolicy cap,
+        ManifestRetention retention,
         hash_set<PublicKey> const* currentValidationKeys,
         bool* acceptedUpdate);
 
@@ -436,15 +446,6 @@ public:
     std::optional<std::string>
     getManifest(PublicKey const& pk) const;
 
-    /** Return a copy of the ordinary manifest for a master key.
-
-        Unlike `getManifest`, this includes terminal revocations. The returned
-        copy can safely be composed with monitoring-only publisher state after
-        the cache lock is released.
-    */
-    std::shared_ptr<Manifest const>
-    getManifestByMaster(PublicKey const& pk) const;
-
     /** Returns `true` if master key has been revoked in a manifest.
 
         @param pk Master public key
@@ -460,7 +461,7 @@ public:
 
         @param m Manifest to add
 
-        @param cap Whether a new master key counts against the untrusted cap
+        @param retention Whether the entry is protected or evictable
 
         @return `ManifestDisposition::accepted` if successful, or
                 `stale` or `invalid` otherwise
@@ -470,7 +471,7 @@ public:
         May be called concurrently
     */
     ManifestDisposition
-    applyManifest(Manifest m, ManifestRateLimitCapPolicy cap);
+    applyManifest(Manifest m, ManifestRetention retention);
 
     /** Add an untrusted manifest, evicting another at capacity.
 
@@ -491,9 +492,26 @@ public:
         Manifest m,
         hash_set<PublicKey> const& currentValidationKeys);
 
-    /** Stop counting a cached master key against the untrusted cap. */
+    /** Change the retention class of an already cached master.
+
+        Consensus trust is not changed. If an entry becomes evictable while
+        the bounded population is full, it is discarded and can later be
+        reacquired from its signed source.
+    */
     void
-    promoteToTrusted(PublicKey const& pk);
+    setRetention(PublicKey const& pk, ManifestRetention retention);
+
+    /** Reconcile cached retention against the current protected-master set.
+
+        This changes retention only; it never grants validator-list membership
+        or consensus weight. Cached entries outside `protectedMasters` and
+        local validator configuration become evictable, subject to the
+        ordinary bounded population. Terminal revocations are treated like
+        other current high-water state: once every protected source
+        disappears, they become evictable.
+    */
+    void
+    reconcileRetention(hash_set<PublicKey> const& protectedMasters);
 
     /** Populate manifest cache with manifests in database and config.
 
@@ -582,7 +600,7 @@ public:
         @param pf Pre-function called with the maximum number of times f will be
             called (useful for memory allocations)
 
-        @param f Function called for each manifest
+        @param f Function called for each manifest and its retention class
 
         @par Thread Safety
 
@@ -594,10 +612,11 @@ public:
     {
         std::shared_lock lock{mutex_};
         pf(map_.size());
-        for (auto const& [_, manifest] : map_)
+        for (auto const& [master, manifest] : map_)
         {
-            (void)_;
-            f(manifest);
+            f(manifest,
+              evictableKeys_.contains(master) ? ManifestRetention::evictable
+                                              : ManifestRetention::protected_);
         }
     }
 };

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -174,6 +174,13 @@ constexpr std::size_t kMaxManifestBase64 =
 /** Maximum number of untrusted manifests processed from one message. */
 constexpr std::size_t kMaxManifestsPerMessage = 200;
 
+/** Maximum total manifest entries processed from one message.
+
+    This is separate from the wire-byte limit and the valid-untrusted limit:
+    malformed entries can be only a few bytes each and never reach the latter.
+ */
+constexpr std::size_t kMaxManifestEntriesPerMessage = 1000;
+
 /** Constructs Manifest from serialized string
 
     @param s Serialized manifest string

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -27,12 +27,14 @@
 #include <xrpl/protocol/SecretKey.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <shared_mutex>
 #include <string>
+#include <utility>
 
 namespace ripple {
 
@@ -294,15 +296,22 @@ class DatabaseCon;
     when every candidate is active. Relay suppression must therefore be
     maintained independently of this cache.
 
-    This is a retained-state bound, not complete adversarial containment. A
-    stream of unique, valid identities can still consume signature checks,
-    victim-selection work, and relay bandwidth. HashRouter suppresses repeat
-    relay of the same manifest hash; it does not bound novel-hash amplification.
+    This is not complete adversarial containment. Once full, the cache gives
+    valid novel identities a small eviction budget, bounding cache churn and
+    corresponding relays. A candidate is verified before consuming a permit;
+    when no permit or refill is available, it is rejected before verification.
+    HashRouter separately suppresses repeat relay of the same manifest hash.
+    A sustained sender can monopolize the global eviction budget and delay a
+    legitimate novel untrusted validator; protected validators are unaffected.
 */
 class ManifestCache
 {
 private:
+    using TimePoint = std::chrono::steady_clock::time_point;
+    using Now = std::function<TimePoint()>;
+
     beast::Journal j_;
+    Now now_;
     std::shared_mutex mutable mutex_;
 
     /** Active manifests stored by master public key. */
@@ -319,6 +328,12 @@ private:
     /** Maximum number of untrusted master keys retained in memory. */
     static constexpr std::size_t kMaxUntrustedCount = 1000;
 
+    /** Burst and refill rate for evictions after the untrusted cache fills. */
+    static constexpr std::size_t kMaxEvictionPermits = 10;
+    static constexpr std::chrono::seconds kEvictionPermitInterval{1};
+    std::size_t evictionPermits_ = kMaxEvictionPermits;
+    TimePoint evictionBudgetUpdated_;
+
     /** Number of manifests rejected because the untrusted cache was full. */
     std::atomic<std::uint64_t> untrustedRejectCount_{0};
 
@@ -333,8 +348,9 @@ private:
 
 public:
     explicit ManifestCache(
-        beast::Journal j = beast::Journal(beast::Journal::getNullSink()))
-        : j_(j)
+        beast::Journal j = beast::Journal(beast::Journal::getNullSink()),
+        Now now = [] { return std::chrono::steady_clock::now(); })
+        : j_(j), now_(std::move(now)), evictionBudgetUpdated_(now_())
     {
     }
 

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -364,6 +364,17 @@ private:
         ManifestRateLimitCapPolicy cap,
         hash_set<PublicKey> const* currentValidationKeys);
 
+    /** Whether a candidate is unambiguous against current ordinary state.
+
+        The caller must hold `mutex_`. Ordinary state always masks candidate
+        state, including revocation. This is deliberately a live visibility
+        rule, not a retained high-water or historical non-reuse guarantee.
+    */
+    bool
+    publisherCandidateVisible(
+        PublicKey const& master,
+        Manifest const& candidate) const;
+
 public:
     /** Maximum number of current publisher candidates retained globally. */
     static constexpr std::size_t maxPublisherCandidates = 1000;

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -327,17 +328,6 @@ private:
     /** Master public keys stored by current ephemeral public key. */
     hash_map<PublicKey, PublicKey> signingToMasterKeys_;
 
-    /** Current monitoring-only manifests supplied by trusted VL publishers.
-
-        This is a source-aware overlay rather than part of `map_`: candidates
-        must remain available while their publisher generation is effective,
-        but must not consume trust, interfere with authoritative manifests,
-        enter peer gossip/SQLite persistence, or survive replacement of that
-        generation.
-    */
-    hash_map<PublicKey, Manifest> publisherCandidates_;
-    hash_map<PublicKey, PublicKey> candidateSigningToMasterKeys_;
-
     std::atomic<std::uint32_t> seq_{0};
 
     /** Master keys currently counted against the untrusted cache cap. */
@@ -364,21 +354,7 @@ private:
         ManifestRateLimitCapPolicy cap,
         hash_set<PublicKey> const* currentValidationKeys);
 
-    /** Whether a candidate is unambiguous against current ordinary state.
-
-        The caller must hold `mutex_`. Ordinary state always masks candidate
-        state, including revocation. This is deliberately a live visibility
-        rule, not a retained high-water or historical non-reuse guarantee.
-    */
-    bool
-    publisherCandidateVisible(
-        PublicKey const& master,
-        Manifest const& candidate) const;
-
 public:
-    /** Maximum number of current publisher candidates retained globally. */
-    static constexpr std::size_t maxPublisherCandidates = 1000;
-
     explicit ManifestCache(
         beast::Journal j = beast::Journal(beast::Journal::getNullSink()),
         Now now = [] { return std::chrono::steady_clock::now(); })
@@ -419,22 +395,6 @@ public:
     PublicKey
     getMasterKey(PublicKey const& pk) const;
 
-    /** Resolve an ephemeral key using only the authoritative manifest cache.
-
-        Publisher candidates are intentionally excluded. Consensus trust and
-        quorum policy must use this accessor rather than the monitoring view.
-    */
-    PublicKey
-    getAuthoritativeMasterKey(PublicKey const& pk) const;
-
-    /** Return a signing key using only the authoritative manifest cache. */
-    std::optional<PublicKey>
-    getAuthoritativeSigningKey(PublicKey const& pk) const;
-
-    /** Return revocation state from only the authoritative manifest cache. */
-    bool
-    authoritativeRevoked(PublicKey const& pk) const;
-
     /** Returns master key's current manifest sequence.
 
         @return sequence corresponding to Master public key
@@ -458,6 +418,15 @@ public:
     */
     std::optional<std::string>
     getManifest(PublicKey const& pk) const;
+
+    /** Return a copy of the ordinary manifest for a master key.
+
+        Unlike `getManifest`, this includes terminal revocations. The returned
+        copy can safely be composed with monitoring-only publisher state after
+        the cache lock is released.
+    */
+    std::shared_ptr<Manifest const>
+    getManifestByMaster(PublicKey const& pk) const;
 
     /** Returns `true` if master key has been revoked in a manifest.
 
@@ -501,25 +470,6 @@ public:
     applyManifestWithEviction(
         Manifest m,
         hash_set<PublicKey> const& currentValidationKeys);
-
-    /** Atomically replace the monitoring-only publisher-candidate view.
-
-        Candidate manifests are verified, deduplicated by master/sequence,
-        checked for internal key collisions, and filtered against listed
-        master keys and their current authoritative signing keys. The result
-        is deterministically capped at `maxPublisherCandidates`.
-
-        Candidate entries affect monitoring lookup only. They are excluded
-        from normal manifest collision state, relay enumeration, and
-        persistence. This current-generation view does not enforce historical
-        signing-key non-reuse; doing that requires durable tombstones or
-        ledger history. Promotion is explicit through the ordinary validators
-        tier, never inferred from this overlay.
-    */
-    void
-    replacePublisherCandidates(
-        std::vector<Manifest> candidates,
-        hash_set<PublicKey> const& listedMasterKeys);
 
     /** Stop counting a cached master key against the untrusted cap. */
     void

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -2178,22 +2178,14 @@ NetworkOPsImp::pubConsensus(ConsensusPhase phase)
 void
 NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
 {
-    {
-        std::lock_guard sl(mSubLock);
-        if (mStreamMaps[sValidations].empty())
-            return;
-    }
-
-    auto const signerPublic = val->getSignerPublic();
-    auto const identity =
-        app_.validators().resolveMonitoringSigner(signerPublic);
-
     // VFALCO consider std::shared_mutex
     std::lock_guard sl(mSubLock);
 
     if (!mStreamMaps[sValidations].empty())
     {
         Json::Value jvObj(Json::objectValue);
+
+        auto const signerPublic = val->getSignerPublic();
 
         jvObj[jss::type] = "validationReceived";
         jvObj[jss::validation_public_key] =
@@ -2214,10 +2206,11 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
         if (auto hash = (*val)[~sfValidatedHash])
             jvObj[jss::validated_hash] = strHex(*hash);
 
-        if (identity.status == ValidatorIdentityStatus::resolved &&
-            identity.master && *identity.master != signerPublic)
-            jvObj[jss::master_key] =
-                toBase58(TokenType::NodePublic, *identity.master);
+        auto const masterKey =
+            app_.validatorManifests().getMasterKey(signerPublic);
+
+        if (masterKey != signerPublic)
+            jvObj[jss::master_key] = toBase58(TokenType::NodePublic, masterKey);
 
         // NOTE *seq is a number, but old API versions used string. We replace
         // number with a string using MultiApiJson near end of this function

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -2178,14 +2178,22 @@ NetworkOPsImp::pubConsensus(ConsensusPhase phase)
 void
 NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
 {
+    {
+        std::lock_guard sl(mSubLock);
+        if (mStreamMaps[sValidations].empty())
+            return;
+    }
+
+    auto const signerPublic = val->getSignerPublic();
+    auto const identity =
+        app_.validators().resolveMonitoringSigner(signerPublic);
+
     // VFALCO consider std::shared_mutex
     std::lock_guard sl(mSubLock);
 
     if (!mStreamMaps[sValidations].empty())
     {
         Json::Value jvObj(Json::objectValue);
-
-        auto const signerPublic = val->getSignerPublic();
 
         jvObj[jss::type] = "validationReceived";
         jvObj[jss::validation_public_key] =
@@ -2206,8 +2214,6 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
         if (auto hash = (*val)[~sfValidatedHash])
             jvObj[jss::validated_hash] = strHex(*hash);
 
-        auto const identity =
-            app_.validators().resolveMonitoringSigner(signerPublic);
         if (identity.status == ValidatorIdentityStatus::resolved &&
             identity.master && *identity.master != signerPublic)
             jvObj[jss::master_key] =

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -2206,11 +2206,12 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
         if (auto hash = (*val)[~sfValidatedHash])
             jvObj[jss::validated_hash] = strHex(*hash);
 
-        auto const masterKey =
-            app_.validatorManifests().getMasterKey(signerPublic);
-
-        if (masterKey != signerPublic)
-            jvObj[jss::master_key] = toBase58(TokenType::NodePublic, masterKey);
+        auto const identity =
+            app_.validators().resolveMonitoringSigner(signerPublic);
+        if (identity.status == ValidatorIdentityStatus::resolved &&
+            identity.master && *identity.master != signerPublic)
+            jvObj[jss::master_key] =
+                toBase58(TokenType::NodePublic, *identity.master);
 
         // NOTE *seq is a number, but old API versions used string. We replace
         // number with a string using MultiApiJson near end of this function

--- a/src/xrpld/app/misc/ValidatorList.h
+++ b/src/xrpld/app/misc/ValidatorList.h
@@ -155,6 +155,23 @@ struct ValidatorIdentity
     hash_set<PublicKey> candidateManifestPublishers;
 };
 
+/** Manifest transport/admission policy for a master key.
+
+    Publisher candidates are eligible for bounded cache admission and relay,
+    but are not listed or trusted for consensus.
+*/
+struct ValidatorManifestPolicy
+{
+    bool consensusListed = false;
+    bool publisherCandidate = false;
+
+    bool
+    relayEligible() const
+    {
+        return consensusListed || publisherCandidate;
+    }
+};
+
 /**
     Trusted Validators List
     -----------------------
@@ -309,6 +326,13 @@ class ValidatorList
     // Monitoring-only current candidate snapshot. It is owned by the
     // ValidatorList lifecycle and never enters ManifestCache.
     PublisherCandidateIndex publisherCandidates_;
+
+    // Newer manifests learned by gossip for masters in the current signed
+    // candidate set. At most one is retained per current candidate master;
+    // rebuildPublisherCandidates removes entries whose membership disappears
+    // or whose publisher manifest catches up. This state is monitoring-only.
+    hash_map<PublicKey, std::shared_ptr<Manifest const>>
+        candidateManifestOverrides_;
 
     // Listed master public keys with the number of lists they appear on
     hash_map<PublicKey, std::size_t> keyListings_;
@@ -646,6 +670,28 @@ public:
     */
     std::optional<PublicKey>
     getListedKey(PublicKey const& identity) const;
+
+    /** Return manifest admission/relay policy for an asserted master key.
+
+        This is deliberately distinct from consensus listing and trust.
+        Current publisher candidates may relay valid self-signed manifest
+        updates, but never gain validation weight through this API.
+    */
+    ValidatorManifestPolicy
+    manifestPolicy(PublicKey const& master) const;
+
+    /** Apply a manifest only if its master is a current publisher candidate.
+
+        The returned optional is empty when candidate membership changed before
+        admission. An accepted manifest updates only the monitoring view and
+        never enters the consensus ManifestCache.
+    */
+    std::optional<ManifestDisposition>
+    applyCandidateManifest(Manifest m);
+
+    /** Return the current live candidate-manifest overrides for peer sync. */
+    std::vector<std::shared_ptr<Manifest const>>
+    candidateManifestOverrides() const;
 
     /** Compose ordinary and current publisher-candidate state for a master.
 

--- a/src/xrpld/app/misc/ValidatorList.h
+++ b/src/xrpld/app/misc/ValidatorList.h
@@ -35,6 +35,7 @@
 #include <mutex>
 #include <numeric>
 #include <shared_mutex>
+#include <utility>
 
 namespace protocol {
 class TMValidatorList;
@@ -180,8 +181,7 @@ class ValidatorList
         std::vector<std::string> manifests;
         // Validators published for monitoring only. They never contribute to
         // keyListings_, the trusted UNL, or quorum.
-        std::vector<PublicKey> candidates;
-        std::vector<std::string> candidateManifests;
+        std::vector<std::pair<PublicKey, std::string>> candidates;
         std::size_t sequence;
         TimeKeeper::time_point validFrom;
         TimeKeeper::time_point validUntil;
@@ -814,6 +814,7 @@ private:
         PublicKey const& pubKey,
         PublisherList const& current,
         std::vector<PublicKey> const& oldList,
+        bool applyCandidates,
         lock_guard const&);
 
     static void

--- a/src/xrpld/app/misc/ValidatorList.h
+++ b/src/xrpld/app/misc/ValidatorList.h
@@ -178,6 +178,10 @@ class ValidatorList
 
         std::vector<PublicKey> list;
         std::vector<std::string> manifests;
+        // Validators published for monitoring only. They never contribute to
+        // keyListings_, the trusted UNL, or quorum.
+        std::vector<PublicKey> candidates;
+        std::vector<std::string> candidateManifests;
         std::size_t sequence;
         TimeKeeper::time_point validFrom;
         TimeKeeper::time_point validUntil;

--- a/src/xrpld/app/misc/ValidatorList.h
+++ b/src/xrpld/app/misc/ValidatorList.h
@@ -127,38 +127,10 @@ struct ValidatorBlobInfo
     std::optional<std::string> manifest;
 };
 
-/** Result of explicitly composing ordinary and publisher-candidate identity
-    state for monitoring. This type must not be used for trust or quorum. */
-enum class ValidatorIdentityStatus {
-    resolved,
-    revoked,
-    conflict,
-    unknown,
-    unstable
-};
-
-struct ValidatorIdentity
-{
-    explicit ValidatorIdentity(PublicKey const& requested_)
-        : requested(requested_)
-    {
-    }
-
-    ValidatorIdentityStatus status = ValidatorIdentityStatus::unknown;
-    PublicKey requested;
-    std::optional<PublicKey> master;
-    std::vector<PublicKey> conflictingMasters;
-    std::optional<PublicKey> signing;
-    std::shared_ptr<Manifest const> manifest;
-    bool presentInOrdinaryState = false;
-    hash_set<PublicKey> candidateIdentityPublishers;
-    hash_set<PublicKey> candidateManifestPublishers;
-};
-
 /** Manifest transport/admission policy for a master key.
 
-    Publisher candidates are eligible for bounded cache admission and relay,
-    but are not listed or trusted for consensus.
+    Publisher candidates receive protected manifest retention and relay, but
+    are not listed or trusted for consensus.
 */
 struct ValidatorManifestPolicy
 {
@@ -283,31 +255,6 @@ class ValidatorList
         std::uint32_t rawVersion = 0;
     };
 
-    struct CandidateVariant
-    {
-        std::shared_ptr<Manifest const> manifest;
-        hash_set<PublicKey> publishers;
-    };
-
-    struct CandidateRecord
-    {
-        explicit CandidateRecord(PublicKey const& master_) : master(master_)
-        {
-        }
-
-        PublicKey master;
-        hash_set<PublicKey> identityPublishers;
-        std::vector<CandidateVariant> highestSequenceVariants;
-    };
-
-    struct PublisherCandidateIndex
-    {
-        hash_map<PublicKey, CandidateRecord> byMaster;
-        hash_map<PublicKey, hash_set<PublicKey>> signingOwners;
-        hash_set<PublicKey> conflictedMasters;
-        std::uint64_t revision = 0;
-    };
-
     ManifestCache& validatorManifests_;
     ManifestCache& publisherManifests_;
     TimeKeeper& timeKeeper_;
@@ -323,23 +270,13 @@ class ValidatorList
     // Published lists stored by publisher master public key
     hash_map<PublicKey, PublisherListCollection> publisherLists_;
 
-    // Monitoring-only current candidate snapshot. It is owned by the
-    // ValidatorList lifecycle and never enters ManifestCache.
-    PublisherCandidateIndex publisherCandidates_;
-
-    // Newer manifests learned by gossip for masters in the current signed
-    // candidate set. At most one is retained per current candidate master;
-    // rebuildPublisherCandidates removes entries whose membership disappears
-    // or whose publisher manifest catches up. This state is monitoring-only.
-    hash_map<PublicKey, std::shared_ptr<Manifest const>>
-        candidateManifestOverrides_;
+    // Current publisher-selected candidate masters. Candidate manifests use
+    // the ordinary ManifestCache: tier membership changes retention and relay
+    // policy, not identity-resolution semantics.
+    hash_set<PublicKey> publisherCandidateMasters_;
 
     // Listed master public keys with the number of lists they appear on
     hash_map<PublicKey, std::size_t> keyListings_;
-
-    // Incremented when a master key becomes listed or ceases to be listed.
-    // Consumers use this to invalidate policy-dependent cached views.
-    std::atomic<std::uint64_t> listingSequence_{0};
 
     // The current list of trusted master keys
     hash_set<PublicKey> trustedMasterKeys_;
@@ -635,16 +572,6 @@ public:
     bool
     listed(PublicKey const& identity) const;
 
-    /** Returns a sequence that changes when listed-key membership changes.
-
-        May be called concurrently.
-    */
-    std::uint64_t
-    listingSequence() const
-    {
-        return listingSequence_.load();
-    }
-
     /** Returns master public key if public key is trusted
 
         @param identity Validation public key
@@ -679,36 +606,6 @@ public:
     */
     ValidatorManifestPolicy
     manifestPolicy(PublicKey const& master) const;
-
-    /** Apply a manifest only if its master is a current publisher candidate.
-
-        The returned optional is empty when candidate membership changed before
-        admission. An accepted manifest updates only the monitoring view and
-        never enters the consensus ManifestCache.
-    */
-    std::optional<ManifestDisposition>
-    applyCandidateManifest(Manifest m);
-
-    /** Return the current live candidate-manifest overrides for peer sync. */
-    std::vector<std::shared_ptr<Manifest const>>
-    candidateManifestOverrides() const;
-
-    /** Compose ordinary and current publisher-candidate state for a master.
-
-        Monitoring only: callers must not use this result for trust, quorum,
-        negative-UNL scoring or consensus identity.
-    */
-    ValidatorIdentity
-    lookupMonitoringIdentity(PublicKey const& master) const;
-
-    /** Resolve a validation signing key through the monitoring-only composed
-        identity view. */
-    ValidatorIdentity
-    resolveMonitoringSigner(PublicKey const& signingKey) const;
-
-    /** Revision of the current publisher candidate snapshot. */
-    std::uint64_t
-    publisherCandidateRevision() const;
 
     /** Returns `true` if public key is a trusted publisher
 
@@ -957,20 +854,11 @@ private:
         PublisherList const& current,
         lock_guard const&);
 
-    bool
+    void
     rebuildPublisherCandidates(lock_guard const&);
 
     static std::vector<PublicKey>
     validatorMasters(PublisherList const& list);
-
-    static ValidatorIdentity
-    composeMonitoringIdentity(
-        PublicKey const& master,
-        std::shared_ptr<Manifest const> const& ordinary,
-        std::optional<CandidateRecord> const& candidate,
-        bool directListed,
-        bool candidateConflict,
-        std::vector<PublicKey> conflictingMasters = {});
 
     static void
     buildBlobInfos(

--- a/src/xrpld/app/misc/ValidatorList.h
+++ b/src/xrpld/app/misc/ValidatorList.h
@@ -814,8 +814,10 @@ private:
         PublicKey const& pubKey,
         PublisherList const& current,
         std::vector<PublicKey> const& oldList,
-        bool applyCandidates,
         lock_guard const&);
+
+    void
+    rebuildPublisherCandidates(lock_guard const&);
 
     static void
     buildBlobInfos(

--- a/src/xrpld/app/misc/ValidatorList.h
+++ b/src/xrpld/app/misc/ValidatorList.h
@@ -31,6 +31,7 @@
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/range/adaptors.hpp>
 #include <boost/thread/shared_mutex.hpp>
+#include <atomic>
 #include <mutex>
 #include <numeric>
 #include <shared_mutex>
@@ -238,6 +239,10 @@ class ValidatorList
 
     // Listed master public keys with the number of lists they appear on
     hash_map<PublicKey, std::size_t> keyListings_;
+
+    // Incremented when a master key becomes listed or ceases to be listed.
+    // Consumers use this to invalidate policy-dependent cached views.
+    std::atomic<std::uint64_t> listingSequence_{0};
 
     // The current list of trusted master keys
     hash_set<PublicKey> trustedMasterKeys_;
@@ -529,6 +534,16 @@ public:
     */
     bool
     listed(PublicKey const& identity) const;
+
+    /** Returns a sequence that changes when listed-key membership changes.
+
+        May be called concurrently.
+    */
+    std::uint64_t
+    listingSequence() const
+    {
+        return listingSequence_.load();
+    }
 
     /** Returns master public key if public key is trusted
 

--- a/src/xrpld/app/misc/ValidatorList.h
+++ b/src/xrpld/app/misc/ValidatorList.h
@@ -32,6 +32,7 @@
 #include <boost/range/adaptors.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <numeric>
 #include <shared_mutex>
@@ -126,6 +127,34 @@ struct ValidatorBlobInfo
     std::optional<std::string> manifest;
 };
 
+/** Result of explicitly composing ordinary and publisher-candidate identity
+    state for monitoring. This type must not be used for trust or quorum. */
+enum class ValidatorIdentityStatus {
+    resolved,
+    revoked,
+    conflict,
+    unknown,
+    unstable
+};
+
+struct ValidatorIdentity
+{
+    explicit ValidatorIdentity(PublicKey const& requested_)
+        : requested(requested_)
+    {
+    }
+
+    ValidatorIdentityStatus status = ValidatorIdentityStatus::unknown;
+    PublicKey requested;
+    std::optional<PublicKey> master;
+    std::vector<PublicKey> conflictingMasters;
+    std::optional<PublicKey> signing;
+    std::shared_ptr<Manifest const> manifest;
+    bool presentInOrdinaryState = false;
+    hash_set<PublicKey> candidateIdentityPublishers;
+    hash_set<PublicKey> candidateManifestPublishers;
+};
+
 /**
     Trusted Validators List
     -----------------------
@@ -173,15 +202,26 @@ struct ValidatorBlobInfo
 */
 class ValidatorList
 {
+    struct PublisherValidator
+    {
+        PublicKey master;
+        std::shared_ptr<Manifest const> manifest;
+    };
+
+    struct PublisherCandidate
+    {
+        PublicKey master;
+        std::shared_ptr<Manifest const> manifest;
+    };
+
     struct PublisherList
     {
         explicit PublisherList() = default;
 
-        std::vector<PublicKey> list;
-        std::vector<std::string> manifests;
+        std::vector<PublisherValidator> validators;
         // Validators published for monitoring only. They never contribute to
         // keyListings_, the trusted UNL, or quorum.
-        std::vector<std::pair<PublicKey, std::string>> candidates;
+        std::vector<PublisherCandidate> candidates;
         std::size_t sequence;
         TimeKeeper::time_point validFrom;
         TimeKeeper::time_point validUntil;
@@ -226,6 +266,31 @@ class ValidatorList
         std::uint32_t rawVersion = 0;
     };
 
+    struct CandidateVariant
+    {
+        std::shared_ptr<Manifest const> manifest;
+        hash_set<PublicKey> publishers;
+    };
+
+    struct CandidateRecord
+    {
+        explicit CandidateRecord(PublicKey const& master_) : master(master_)
+        {
+        }
+
+        PublicKey master;
+        hash_set<PublicKey> identityPublishers;
+        std::vector<CandidateVariant> highestSequenceVariants;
+    };
+
+    struct PublisherCandidateIndex
+    {
+        hash_map<PublicKey, CandidateRecord> byMaster;
+        hash_map<PublicKey, hash_set<PublicKey>> signingOwners;
+        hash_set<PublicKey> conflictedMasters;
+        std::uint64_t revision = 0;
+    };
+
     ManifestCache& validatorManifests_;
     ManifestCache& publisherManifests_;
     TimeKeeper& timeKeeper_;
@@ -240,6 +305,10 @@ class ValidatorList
 
     // Published lists stored by publisher master public key
     hash_map<PublicKey, PublisherListCollection> publisherLists_;
+
+    // Monitoring-only current candidate snapshot. It is owned by the
+    // ValidatorList lifecycle and never enters ManifestCache.
+    PublisherCandidateIndex publisherCandidates_;
 
     // Listed master public keys with the number of lists they appear on
     hash_map<PublicKey, std::size_t> keyListings_;
@@ -283,6 +352,9 @@ class ValidatorList
     static const std::string filePrefix_;
 
 public:
+    /** Per-generation and aggregate bound for monitoring candidates. */
+    static constexpr std::size_t maxPublisherCandidates = 1000;
+
     ValidatorList(
         ManifestCache& validatorManifests,
         ManifestCache& publisherManifests,
@@ -575,6 +647,23 @@ public:
     std::optional<PublicKey>
     getListedKey(PublicKey const& identity) const;
 
+    /** Compose ordinary and current publisher-candidate state for a master.
+
+        Monitoring only: callers must not use this result for trust, quorum,
+        negative-UNL scoring or consensus identity.
+    */
+    ValidatorIdentity
+    lookupMonitoringIdentity(PublicKey const& master) const;
+
+    /** Resolve a validation signing key through the monitoring-only composed
+        identity view. */
+    ValidatorIdentity
+    resolveMonitoringSigner(PublicKey const& signingKey) const;
+
+    /** Revision of the current publisher candidate snapshot. */
+    std::uint64_t
+    publisherCandidateRevision() const;
+
     /** Returns `true` if public key is a trusted publisher
 
         @param identity Publisher public key
@@ -812,12 +901,30 @@ private:
     void
     updatePublisherList(
         PublicKey const& pubKey,
-        PublisherList const& current,
+        std::vector<PublicKey> const& current,
         std::vector<PublicKey> const& oldList,
         lock_guard const&);
 
     void
+    ingestPublisherManifests(
+        PublicKey const& pubKey,
+        PublisherList const& current,
+        lock_guard const&);
+
+    bool
     rebuildPublisherCandidates(lock_guard const&);
+
+    static std::vector<PublicKey>
+    validatorMasters(PublisherList const& list);
+
+    static ValidatorIdentity
+    composeMonitoringIdentity(
+        PublicKey const& master,
+        std::shared_ptr<Manifest const> const& ordinary,
+        std::optional<CandidateRecord> const& candidate,
+        bool directListed,
+        bool candidateConflict,
+        std::vector<PublicKey> conflictingMasters = {});
 
     static void
     buildBlobInfos(

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -23,14 +23,17 @@
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/StringUtilities.h>
 #include <xrpl/basics/base64.h>
+#include <xrpl/basics/random.h>
 #include <xrpl/json/json_reader.h>
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/Sign.h>
 
 #include <boost/algorithm/string/trim.hpp>
 
+#include <iterator>
 #include <numeric>
 #include <stdexcept>
+#include <vector>
 
 namespace ripple {
 
@@ -372,6 +375,26 @@ ManifestCache::revoked(PublicKey const& pk) const
 ManifestDisposition
 ManifestCache::applyManifest(Manifest m, ManifestRateLimitCapPolicy const cap)
 {
+    return applyManifestImpl(std::move(m), cap, nullptr);
+}
+
+ManifestDisposition
+ManifestCache::applyManifestWithEviction(
+    Manifest m,
+    hash_set<PublicKey> const& currentValidationKeys)
+{
+    return applyManifestImpl(
+        std::move(m),
+        ManifestRateLimitCapPolicy::Capped,
+        &currentValidationKeys);
+}
+
+ManifestDisposition
+ManifestCache::applyManifestImpl(
+    Manifest m,
+    ManifestRateLimitCapPolicy const cap,
+    hash_set<PublicKey> const* const currentValidationKeys)
+{
     bool const uncapped = cap == ManifestRateLimitCapPolicy::Uncapped;
     bool checkSignature = true;
 
@@ -479,34 +502,33 @@ ManifestCache::applyManifest(Manifest m, ManifestRateLimitCapPolicy const cap)
         return std::nullopt;
     };
 
-    auto atUntrustedCap = [this, &m, uncapped](
-                              auto const& iter, auto const& lock) {
+    auto atUntrustedCap = [this, uncapped](auto const& iter, auto const& lock) {
         XRPL_ASSERT(
             lock.owns_lock(),
             "ripple::ManifestCache::applyManifest::atUntrustedCap : locked");
         (void)lock;
-        if (iter == map_.end() && !uncapped &&
-            untrustedKeys_.size() >= kMaxUntrustedCount)
+        return iter == map_.end() && !uncapped &&
+            untrustedKeys_.size() >= kMaxUntrustedCount;
+    };
+
+    auto rejectAtUntrustedCap = [this, &m]() {
+        if (auto stream = j_.debug())
+            LOG_MANIFEST_ACTION(
+                stream, "UntrustedCapacity", m.masterKey, m.sequence);
+        if (auto const n = untrustedRejectCount_.fetch_add(1) + 1;
+            n % kUntrustedRejectCount == 0)
         {
-            if (auto stream = j_.debug())
-                LOG_MANIFEST_ACTION(
-                    stream, "UntrustedCapacity", m.masterKey, m.sequence);
-            if (auto const n = untrustedRejectCount_.fetch_add(1) + 1;
-                n % kUntrustedRejectCount == 0)
-            {
-                JLOG(j_.warn()) << "Untrusted manifest cap reached; " << n
-                                << " manifests rejected so far";
-            }
-            return true;
+            JLOG(j_.warn()) << "Untrusted manifest cap reached; " << n
+                            << " manifests rejected so far";
         }
-        return false;
+        return ManifestDisposition::untrustedCapacity;
     };
 
     {
         std::shared_lock sl{mutex_};
         auto const iter = map_.find(m.masterKey);
-        if (atUntrustedCap(iter, sl))
-            return ManifestDisposition::untrustedCapacity;
+        if (atUntrustedCap(iter, sl) && !currentValidationKeys)
+            return rejectAtUntrustedCap();
         if (auto d = prewriteCheck(iter, sl); d.has_value())
             return *d;
     }
@@ -514,8 +536,9 @@ ManifestCache::applyManifest(Manifest m, ManifestRateLimitCapPolicy const cap)
     std::unique_lock sl{mutex_};
     auto const iter = map_.find(m.masterKey);
 
-    if (atUntrustedCap(iter, sl))
-        return ManifestDisposition::untrustedCapacity;
+    bool const needsEviction = atUntrustedCap(iter, sl);
+    if (needsEviction && !currentValidationKeys)
+        return rejectAtUntrustedCap();
     // Since we released the previously held read lock, it's possible that the
     // collections have been written to. This means we need to run
     // `prewriteCheck` again. This re-does work, but `prewriteCheck` is
@@ -527,6 +550,51 @@ ManifestCache::applyManifest(Manifest m, ManifestRateLimitCapPolicy const cap)
     // deadlock.
     if (auto d = prewriteCheck(iter, sl); d.has_value())
         return *d;
+
+    if (needsEviction)
+    {
+        XRPL_ASSERT(
+            currentValidationKeys && !untrustedKeys_.empty(),
+            "ripple::ManifestCache::applyManifestImpl : eviction inputs");
+
+        std::vector<PublicKey> dormant;
+        dormant.reserve(untrustedKeys_.size());
+        for (auto const& master : untrustedKeys_)
+        {
+            auto const victim = map_.find(master);
+            XRPL_ASSERT(
+                victim != map_.end(),
+                "ripple::ManifestCache::applyManifestImpl : untrusted key "
+                "retained");
+            if (victim == map_.end())
+                continue;
+            if (!victim->second.signingKey ||
+                !currentValidationKeys->contains(*victim->second.signingKey))
+            {
+                dormant.push_back(master);
+            }
+        }
+
+        PublicKey const victimMaster = [&]() {
+            if (!dormant.empty())
+                return dormant[rand_int(dormant.size() - 1)];
+            auto victim = untrustedKeys_.begin();
+            std::advance(victim, rand_int(untrustedKeys_.size() - 1));
+            return *victim;
+        }();
+
+        auto const victim = map_.find(victimMaster);
+        XRPL_ASSERT(
+            victim != map_.end(),
+            "ripple::ManifestCache::applyManifestImpl : victim retained");
+        if (victim == map_.end())
+            return rejectAtUntrustedCap();
+
+        if (victim->second.signingKey)
+            signingToMasterKeys_.erase(*victim->second.signingKey);
+        map_.erase(victim);
+        untrustedKeys_.erase(victimMaster);
+    }
 
     bool const revoked = m.revoked();
     // This is the first manifest we are seeing for a master key. This should

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -304,19 +304,10 @@ std::optional<PublicKey>
 ManifestCache::getSigningKey(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end())
-    {
-        if (authoritative->second.revoked())
-            return pk;
-        return authoritative->second.signingKey;
-    }
+    auto const iter = map_.find(pk);
 
-    auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() &&
-        publisherCandidateVisible(pk, candidate->second) &&
-        !candidate->second.revoked())
-        return candidate->second.signingKey;
+    if (iter != map_.end() && !iter->second.revoked())
+        return iter->second.signingKey;
 
     return pk;
 }
@@ -326,67 +317,21 @@ ManifestCache::getMasterKey(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
 
-    if (auto const authoritative = signingToMasterKeys_.find(pk);
-        authoritative != signingToMasterKeys_.end())
-        return authoritative->second;
-
-    if (auto const candidate = candidateSigningToMasterKeys_.find(pk);
-        candidate != candidateSigningToMasterKeys_.end())
-    {
-        auto const manifest = publisherCandidates_.find(candidate->second);
-        if (manifest != publisherCandidates_.end() &&
-            publisherCandidateVisible(manifest->first, manifest->second))
-            return candidate->second;
-    }
-
-    return pk;
-}
-
-PublicKey
-ManifestCache::getAuthoritativeMasterKey(PublicKey const& pk) const
-{
-    std::shared_lock lock{mutex_};
     if (auto const iter = signingToMasterKeys_.find(pk);
         iter != signingToMasterKeys_.end())
         return iter->second;
-    return pk;
-}
 
-std::optional<PublicKey>
-ManifestCache::getAuthoritativeSigningKey(PublicKey const& pk) const
-{
-    std::shared_lock lock{mutex_};
-    auto const iter = map_.find(pk);
-    if (iter != map_.end() && !iter->second.revoked())
-        return iter->second.signingKey;
     return pk;
-}
-
-bool
-ManifestCache::authoritativeRevoked(PublicKey const& pk) const
-{
-    std::shared_lock lock{mutex_};
-    auto const iter = map_.find(pk);
-    return iter != map_.end() && iter->second.revoked();
 }
 
 std::optional<std::uint32_t>
 ManifestCache::getSequence(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end())
-    {
-        if (authoritative->second.revoked())
-            return std::nullopt;
-        return authoritative->second.sequence;
-    }
+    auto const iter = map_.find(pk);
 
-    auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() &&
-        publisherCandidateVisible(pk, candidate->second) &&
-        !candidate->second.revoked())
-        return candidate->second.sequence;
+    if (iter != map_.end() && !iter->second.revoked())
+        return iter->second.sequence;
 
     return std::nullopt;
 }
@@ -395,19 +340,10 @@ std::optional<std::string>
 ManifestCache::getDomain(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end())
-    {
-        if (authoritative->second.revoked())
-            return std::nullopt;
-        return authoritative->second.domain;
-    }
+    auto const iter = map_.find(pk);
 
-    auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() &&
-        publisherCandidateVisible(pk, candidate->second) &&
-        !candidate->second.revoked())
-        return candidate->second.domain;
+    if (iter != map_.end() && !iter->second.revoked())
+        return iter->second.domain;
 
     return std::nullopt;
 }
@@ -416,52 +352,37 @@ std::optional<std::string>
 ManifestCache::getManifest(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end())
-    {
-        if (authoritative->second.revoked())
-            return std::nullopt;
-        return authoritative->second.serialized;
-    }
+    auto const iter = map_.find(pk);
 
-    auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() &&
-        publisherCandidateVisible(pk, candidate->second) &&
-        !candidate->second.revoked())
-        return candidate->second.serialized;
+    if (iter != map_.end() && !iter->second.revoked())
+        return iter->second.serialized;
 
     return std::nullopt;
+}
+
+std::shared_ptr<Manifest const>
+ManifestCache::getManifestByMaster(PublicKey const& pk) const
+{
+    std::shared_lock lock{mutex_};
+    if (auto const iter = map_.find(pk); iter != map_.end())
+    {
+        auto const& m = iter->second;
+        return std::make_shared<Manifest const>(
+            m.serialized, m.masterKey, m.signingKey, m.sequence, m.domain);
+    }
+    return {};
 }
 
 bool
 ManifestCache::revoked(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end())
-        return authoritative->second.revoked();
+    auto const iter = map_.find(pk);
 
-    auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() &&
-        publisherCandidateVisible(pk, candidate->second))
-        return candidate->second.revoked();
+    if (iter != map_.end())
+        return iter->second.revoked();
 
     return false;
-}
-
-bool
-ManifestCache::publisherCandidateVisible(
-    PublicKey const& master,
-    Manifest const& candidate) const
-{
-    if (map_.contains(master) || signingToMasterKeys_.contains(master))
-        return false;
-
-    if (!candidate.signingKey)
-        return true;
-
-    auto const& signing = *candidate.signingKey;
-    return !map_.contains(signing) && !signingToMasterKeys_.contains(signing);
 }
 
 ManifestDisposition
@@ -479,139 +400,6 @@ ManifestCache::applyManifestWithEviction(
         std::move(m),
         ManifestRateLimitCapPolicy::Capped,
         &currentValidationKeys);
-}
-
-void
-ManifestCache::replacePublisherCandidates(
-    std::vector<Manifest> candidates,
-    hash_set<PublicKey> const& listedMasterKeys)
-{
-    candidates.erase(
-        std::remove_if(
-            candidates.begin(),
-            candidates.end(),
-            [](Manifest const& m) { return !m.verify(); }),
-        candidates.end());
-    std::sort(
-        candidates.begin(),
-        candidates.end(),
-        [](Manifest const& lhs, Manifest const& rhs) {
-            if (lhs.masterKey != rhs.masterKey)
-                return lhs.masterKey < rhs.masterKey;
-            if (lhs.sequence != rhs.sequence)
-                return lhs.sequence > rhs.sequence;
-            return lhs.serialized < rhs.serialized;
-        });
-
-    hash_map<PublicKey, Manifest> coalesced;
-    for (std::size_t i = 0; i < candidates.size();)
-    {
-        auto const master = candidates[i].masterKey;
-        auto const sequence = candidates[i].sequence;
-        std::size_t next = i + 1;
-        while (next < candidates.size() && candidates[next].masterKey == master)
-            ++next;
-
-        bool sameSequenceConflict = false;
-        for (auto j = i + 1; j < next && candidates[j].sequence == sequence;
-             ++j)
-        {
-            if (candidates[j].serialized != candidates[i].serialized)
-            {
-                sameSequenceConflict = true;
-                break;
-            }
-        }
-        if (!sameSequenceConflict)
-            coalesced.emplace(master, std::move(candidates[i]));
-        i = next;
-    }
-
-    std::unique_lock lock{mutex_};
-
-    hash_set<PublicKey> protectedKeys = listedMasterKeys;
-    for (auto const& master : listedMasterKeys)
-    {
-        if (auto const authoritative = map_.find(master);
-            authoritative != map_.end() && authoritative->second.signingKey)
-            protectedKeys.insert(*authoritative->second.signingKey);
-    }
-
-    hash_set<PublicKey> conflicts;
-    hash_map<PublicKey, PublicKey> candidateSigningOwners;
-    for (auto const& [master, candidate] : coalesced)
-    {
-        if (protectedKeys.contains(master) ||
-            (candidate.signingKey &&
-             protectedKeys.contains(*candidate.signingKey)))
-        {
-            conflicts.insert(master);
-            continue;
-        }
-
-        if (!candidate.signingKey)
-            continue;
-
-        if (auto const [owner, inserted] =
-                candidateSigningOwners.emplace(*candidate.signingKey, master);
-            !inserted && owner->second != master)
-        {
-            conflicts.insert(master);
-            conflicts.insert(owner->second);
-        }
-        if (auto const otherMaster = coalesced.find(*candidate.signingKey);
-            otherMaster != coalesced.end() && otherMaster->first != master)
-        {
-            conflicts.insert(master);
-            conflicts.insert(otherMaster->first);
-        }
-    }
-
-    std::vector<PublicKey> acceptedMasters;
-    acceptedMasters.reserve(coalesced.size());
-    for (auto const& [master, _] : coalesced)
-    {
-        (void)_;
-        if (!conflicts.contains(master))
-            acceptedMasters.push_back(master);
-    }
-    std::sort(acceptedMasters.begin(), acceptedMasters.end());
-    if (acceptedMasters.size() > maxPublisherCandidates)
-        acceptedMasters.erase(
-            acceptedMasters.begin() + maxPublisherCandidates,
-            acceptedMasters.end());
-
-    hash_map<PublicKey, Manifest> nextCandidates;
-    hash_map<PublicKey, PublicKey> nextSigningToMaster;
-    nextCandidates.reserve(acceptedMasters.size());
-    nextSigningToMaster.reserve(acceptedMasters.size());
-    for (auto const& master : acceptedMasters)
-    {
-        auto node = coalesced.extract(master);
-        if (node.mapped().signingKey)
-            nextSigningToMaster.emplace(*node.mapped().signingKey, master);
-        nextCandidates.insert(std::move(node));
-    }
-
-    bool unchanged = nextCandidates.size() == publisherCandidates_.size();
-    if (unchanged)
-    {
-        for (auto const& [master, candidate] : nextCandidates)
-        {
-            auto const old = publisherCandidates_.find(master);
-            if (old == publisherCandidates_.end() || old->second != candidate)
-            {
-                unchanged = false;
-                break;
-            }
-        }
-    }
-    if (unchanged)
-        return;
-
-    publisherCandidates_ = std::move(nextCandidates);
-    candidateSigningToMasterKeys_ = std::move(nextSigningToMaster);
-    ++seq_;
 }
 
 ManifestDisposition
@@ -1004,10 +792,25 @@ ManifestCache::save(
     std::string const& dbTable,
     std::function<bool(PublicKey const&)> const& isTrusted)
 {
-    std::shared_lock lock{mutex_};
+    hash_map<PublicKey, Manifest> manifests;
+    {
+        std::shared_lock lock{mutex_};
+        manifests.reserve(map_.size());
+        for (auto const& [master, m] : map_)
+        {
+            manifests.emplace(
+                master,
+                Manifest{
+                    m.serialized,
+                    m.masterKey,
+                    m.signingKey,
+                    m.sequence,
+                    m.domain});
+        }
+    }
     auto db = dbCon.checkoutDb();
 
-    saveManifests(*db, dbTable, isTrusted, map_, j_);
+    saveManifests(*db, dbTable, isTrusted, manifests, j_);
 }
 
 // Clean up macros to avoid namespace pollution

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -55,6 +55,9 @@ deserializeManifest(Slice s, beast::Journal journal)
     if (s.empty())
         return std::nullopt;
 
+    if (s.size() > kMaxManifestBytes)
+        return std::nullopt;
+
     static SOTemplate const manifestFormat{
         // A manifest must include:
         // - the master public key
@@ -367,8 +370,11 @@ ManifestCache::revoked(PublicKey const& pk) const
 }
 
 ManifestDisposition
-ManifestCache::applyManifest(Manifest m)
+ManifestCache::applyManifest(Manifest m, ManifestRateLimitCapPolicy const cap)
 {
+    bool const uncapped = cap == ManifestRateLimitCapPolicy::Uncapped;
+    bool checkSignature = true;
+
     // Check the manifest against the conditions that do not require a
     // `unique_lock` (write lock) on the `mutex_`. Since the signature can be
     // relatively expensive, the `checkSignature` parameter determines if the
@@ -376,8 +382,9 @@ ManifestCache::applyManifest(Manifest m)
     // comment below), `checkSignature` only needs to be set to true on the
     // first run.
     auto prewriteCheck =
-        [this, &m](auto const& iter, bool checkSignature, auto const& lock)
-        -> std::optional<ManifestDisposition> {
+        [this, &m, &checkSignature](
+            auto const& iter,
+            auto const& lock) -> std::optional<ManifestDisposition> {
         XRPL_ASSERT(
             lock.owns_lock(),
             "ripple::ManifestCache::applyManifest::prewriteCheck : locked");
@@ -399,11 +406,16 @@ ManifestCache::applyManifest(Manifest m)
             return ManifestDisposition::stale;
         }
 
-        if (checkSignature && !m.verify())
+        if (checkSignature)
         {
-            if (auto stream = j_.warn())
-                LOG_MANIFEST_ACTION(stream, "Invalid", m.masterKey, m.sequence);
-            return ManifestDisposition::invalid;
+            checkSignature = false;
+            if (!m.verify())
+            {
+                if (auto stream = j_.warn())
+                    LOG_MANIFEST_ACTION(
+                        stream, "Invalid", m.masterKey, m.sequence);
+                return ManifestDisposition::invalid;
+            }
         }
 
         // If the master key associated with a manifest is or might be
@@ -467,15 +479,43 @@ ManifestCache::applyManifest(Manifest m)
         return std::nullopt;
     };
 
+    auto atUntrustedCap = [this, &m, uncapped](
+                              auto const& iter, auto const& lock) {
+        XRPL_ASSERT(
+            lock.owns_lock(),
+            "ripple::ManifestCache::applyManifest::atUntrustedCap : locked");
+        (void)lock;
+        if (iter == map_.end() && !uncapped &&
+            untrustedKeys_.size() >= kMaxUntrustedCount)
+        {
+            if (auto stream = j_.debug())
+                LOG_MANIFEST_ACTION(
+                    stream, "UntrustedCapacity", m.masterKey, m.sequence);
+            if (auto const n = untrustedRejectCount_.fetch_add(1) + 1;
+                n % kUntrustedRejectCount == 0)
+            {
+                JLOG(j_.warn()) << "Untrusted manifest cap reached; " << n
+                                << " manifests rejected so far";
+            }
+            return true;
+        }
+        return false;
+    };
+
     {
         std::shared_lock sl{mutex_};
-        if (auto d =
-                prewriteCheck(map_.find(m.masterKey), /*checkSig*/ true, sl))
+        auto const iter = map_.find(m.masterKey);
+        if (atUntrustedCap(iter, sl))
+            return ManifestDisposition::untrustedCapacity;
+        if (auto d = prewriteCheck(iter, sl); d.has_value())
             return *d;
     }
 
     std::unique_lock sl{mutex_};
     auto const iter = map_.find(m.masterKey);
+
+    if (atUntrustedCap(iter, sl))
+        return ManifestDisposition::untrustedCapacity;
     // Since we released the previously held read lock, it's possible that the
     // collections have been written to. This means we need to run
     // `prewriteCheck` again. This re-does work, but `prewriteCheck` is
@@ -485,7 +525,7 @@ ManifestCache::applyManifest(Manifest m)
     // doesn't need to happen again (signature checks are somewhat expensive).
     // Note: It's a mistake to use an upgradable lock. This is a recipe for
     // deadlock.
-    if (auto d = prewriteCheck(iter, /*checkSig*/ false, sl))
+    if (auto d = prewriteCheck(iter, sl); d.has_value())
         return *d;
 
     bool const revoked = m.revoked();
@@ -500,6 +540,8 @@ ManifestCache::applyManifest(Manifest m)
             signingToMasterKeys_.emplace(*m.signingKey, m.masterKey);
 
         auto masterKey = m.masterKey;
+        if (!uncapped)
+            untrustedKeys_.insert(masterKey);
         map_.emplace(std::move(masterKey), std::move(m));
 
         // Increment sequence to invalidate cached manifest messages
@@ -518,6 +560,9 @@ ManifestCache::applyManifest(Manifest m)
             m.sequence,
             iter->second.sequence);
 
+    if (uncapped)
+        untrustedKeys_.erase(m.masterKey);
+
     signingToMasterKeys_.erase(*iter->second.signingKey);
 
     if (!revoked)
@@ -529,6 +574,13 @@ ManifestCache::applyManifest(Manifest m)
     seq_++;
 
     return ManifestDisposition::accepted;
+}
+
+void
+ManifestCache::promoteToTrusted(PublicKey const& pk)
+{
+    std::unique_lock sl{mutex_};
+    untrustedKeys_.erase(pk);
 }
 
 void
@@ -561,7 +613,9 @@ ManifestCache::load(
             JLOG(j_.warn()) << "Configured manifest revokes public key";
         }
 
-        if (applyManifest(std::move(*mo)) == ManifestDisposition::invalid)
+        if (applyManifest(
+                std::move(*mo), ManifestRateLimitCapPolicy::Uncapped) ==
+            ManifestDisposition::invalid)
         {
             JLOG(j_.error()) << "Manifest in config was rejected";
             return false;
@@ -585,7 +639,9 @@ ManifestCache::load(
         auto mo = deserializeManifest(base64_decode(revocationStr));
 
         if (!mo || !mo->revoked() ||
-            applyManifest(std::move(*mo)) == ManifestDisposition::invalid)
+            applyManifest(
+                std::move(*mo), ManifestRateLimitCapPolicy::Uncapped) ==
+                ManifestDisposition::invalid)
         {
             JLOG(j_.error()) << "Invalid validator key revocation in config";
             return false;

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -375,15 +375,21 @@ ManifestCache::revoked(PublicKey const& pk) const
 ManifestDisposition
 ManifestCache::applyManifest(Manifest m, ManifestRetention const retention)
 {
-    return applyManifestImpl(std::move(m), retention, false, nullptr);
+    return applyManifestImpl(std::move(m), retention, false, {}, nullptr);
 }
 
 ManifestApplyResult
-ManifestCache::applyManifestWithEviction(Manifest m)
+ManifestCache::applyManifestWithEviction(
+    Manifest m,
+    std::function<hash_set<PublicKey>()> const& currentValidationKeys)
 {
     bool acceptedUpdate = false;
     auto const disposition = applyManifestImpl(
-        std::move(m), ManifestRetention::evictable, true, &acceptedUpdate);
+        std::move(m),
+        ManifestRetention::evictable,
+        true,
+        currentValidationKeys,
+        &acceptedUpdate);
     return {disposition, acceptedUpdate};
 }
 
@@ -392,6 +398,7 @@ ManifestCache::applyManifestImpl(
     Manifest m,
     ManifestRetention const retention,
     bool const mayEvict,
+    std::function<hash_set<PublicKey>()> const& currentValidationKeys,
     bool* const acceptedUpdate)
 {
     if (acceptedUpdate)
@@ -556,6 +563,33 @@ ManifestCache::applyManifestImpl(
         }
     }
 
+    // Signature verification above remains concurrent. Serialize the short
+    // post-verification admission path so racing callers cannot all sample
+    // activity after observing the same eviction permit. This lock is always
+    // acquired before mutex_, and caller code runs with mutex_ released.
+    std::unique_lock<std::mutex> evictionAdmissionLock{
+        evictionAdmissionMutex_, std::defer_lock};
+    if (mayEvict)
+        evictionAdmissionLock.lock();
+
+    bool needsCurrentValidationKeys = false;
+    if (mayEvict)
+    {
+        std::shared_lock sl{mutex_};
+        auto const iter = map_.find(m.masterKey);
+        if (atEvictableCap(iter, sl))
+        {
+            if (!evictionPermitAvailable(sl))
+                return rejectAtUntrustedCap();
+            needsCurrentValidationKeys =
+                static_cast<bool>(currentValidationKeys);
+        }
+    }
+
+    std::optional<hash_set<PublicKey>> activeSigningKeys;
+    if (needsCurrentValidationKeys)
+        activeSigningKeys = currentValidationKeys();
+
     std::unique_lock sl{mutex_};
     auto const iter = map_.find(m.masterKey);
 
@@ -605,10 +639,37 @@ ManifestCache::applyManifestImpl(
             return rejectAtUntrustedCap();
         --evictionPermits_;
 
-        auto victimKey = evictableKeys_.begin();
-        if (evictableKeys_.size() > 1)
-            std::advance(victimKey, rand_int(evictableKeys_.size() - 1));
-        PublicKey const victimMaster = *victimKey;
+        std::optional<PublicKey> dormantVictim;
+        std::size_t dormantSeen = 0;
+        if (activeSigningKeys)
+        {
+            for (auto const& master : evictableKeys_)
+            {
+                auto const candidate = map_.find(master);
+                XRPL_ASSERT(
+                    candidate != map_.end(),
+                    "ripple::ManifestCache::applyManifestImpl : evictable "
+                    "key retained");
+                if (candidate == map_.end())
+                    continue;
+                if (!candidate->second.signingKey ||
+                    !activeSigningKeys->contains(*candidate->second.signingKey))
+                {
+                    ++dormantSeen;
+                    if (dormantSeen == 1 || rand_int(dormantSeen - 1) == 0)
+                        dormantVictim = master;
+                }
+            }
+        }
+
+        PublicKey const victimMaster = [&]() {
+            if (dormantVictim)
+                return *dormantVictim;
+            auto victim = evictableKeys_.begin();
+            if (evictableKeys_.size() > 1)
+                std::advance(victim, rand_int(evictableKeys_.size() - 1));
+            return *victim;
+        }();
 
         auto const victim = map_.find(victimMaster);
         XRPL_ASSERT(

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -304,10 +304,13 @@ std::optional<PublicKey>
 ManifestCache::getSigningKey(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const iter = map_.find(pk);
+    auto const authoritative = map_.find(pk);
+    if (authoritative != map_.end() && !authoritative->second.revoked())
+        return authoritative->second.signingKey;
 
-    if (iter != map_.end() && !iter->second.revoked())
-        return iter->second.signingKey;
+    auto const candidate = publisherCandidates_.find(pk);
+    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+        return candidate->second.signingKey;
 
     return pk;
 }
@@ -317,21 +320,56 @@ ManifestCache::getMasterKey(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
 
+    if (auto const authoritative = signingToMasterKeys_.find(pk);
+        authoritative != signingToMasterKeys_.end())
+        return authoritative->second;
+
+    if (auto const candidate = candidateSigningToMasterKeys_.find(pk);
+        candidate != candidateSigningToMasterKeys_.end())
+        return candidate->second;
+
+    return pk;
+}
+
+PublicKey
+ManifestCache::getAuthoritativeMasterKey(PublicKey const& pk) const
+{
+    std::shared_lock lock{mutex_};
     if (auto const iter = signingToMasterKeys_.find(pk);
         iter != signingToMasterKeys_.end())
         return iter->second;
-
     return pk;
+}
+
+std::optional<PublicKey>
+ManifestCache::getAuthoritativeSigningKey(PublicKey const& pk) const
+{
+    std::shared_lock lock{mutex_};
+    auto const iter = map_.find(pk);
+    if (iter != map_.end() && !iter->second.revoked())
+        return iter->second.signingKey;
+    return pk;
+}
+
+bool
+ManifestCache::authoritativeRevoked(PublicKey const& pk) const
+{
+    std::shared_lock lock{mutex_};
+    auto const iter = map_.find(pk);
+    return iter != map_.end() && iter->second.revoked();
 }
 
 std::optional<std::uint32_t>
 ManifestCache::getSequence(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const iter = map_.find(pk);
+    auto const authoritative = map_.find(pk);
+    if (authoritative != map_.end() && !authoritative->second.revoked())
+        return authoritative->second.sequence;
 
-    if (iter != map_.end() && !iter->second.revoked())
-        return iter->second.sequence;
+    auto const candidate = publisherCandidates_.find(pk);
+    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+        return candidate->second.sequence;
 
     return std::nullopt;
 }
@@ -340,10 +378,13 @@ std::optional<std::string>
 ManifestCache::getDomain(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const iter = map_.find(pk);
+    auto const authoritative = map_.find(pk);
+    if (authoritative != map_.end() && !authoritative->second.revoked())
+        return authoritative->second.domain;
 
-    if (iter != map_.end() && !iter->second.revoked())
-        return iter->second.domain;
+    auto const candidate = publisherCandidates_.find(pk);
+    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+        return candidate->second.domain;
 
     return std::nullopt;
 }
@@ -352,10 +393,13 @@ std::optional<std::string>
 ManifestCache::getManifest(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const iter = map_.find(pk);
+    auto const authoritative = map_.find(pk);
+    if (authoritative != map_.end() && !authoritative->second.revoked())
+        return authoritative->second.serialized;
 
-    if (iter != map_.end() && !iter->second.revoked())
-        return iter->second.serialized;
+    auto const candidate = publisherCandidates_.find(pk);
+    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+        return candidate->second.serialized;
 
     return std::nullopt;
 }
@@ -364,10 +408,13 @@ bool
 ManifestCache::revoked(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
-    auto const iter = map_.find(pk);
+    auto const authoritative = map_.find(pk);
+    if (authoritative != map_.end())
+        return authoritative->second.revoked();
 
-    if (iter != map_.end())
-        return iter->second.revoked();
+    auto const candidate = publisherCandidates_.find(pk);
+    if (candidate != publisherCandidates_.end())
+        return candidate->second.revoked();
 
     return false;
 }
@@ -387,6 +434,151 @@ ManifestCache::applyManifestWithEviction(
         std::move(m),
         ManifestRateLimitCapPolicy::Capped,
         &currentValidationKeys);
+}
+
+void
+ManifestCache::replacePublisherCandidates(
+    std::vector<Manifest> candidates,
+    hash_set<PublicKey> const& listedMasterKeys)
+{
+    candidates.erase(
+        std::remove_if(
+            candidates.begin(),
+            candidates.end(),
+            [](Manifest const& m) { return !m.verify(); }),
+        candidates.end());
+    std::sort(
+        candidates.begin(),
+        candidates.end(),
+        [](Manifest const& lhs, Manifest const& rhs) {
+            if (lhs.masterKey != rhs.masterKey)
+                return lhs.masterKey < rhs.masterKey;
+            if (lhs.sequence != rhs.sequence)
+                return lhs.sequence > rhs.sequence;
+            return lhs.serialized < rhs.serialized;
+        });
+
+    hash_map<PublicKey, Manifest> coalesced;
+    for (std::size_t i = 0; i < candidates.size();)
+    {
+        auto const master = candidates[i].masterKey;
+        auto const sequence = candidates[i].sequence;
+        std::size_t next = i + 1;
+        while (next < candidates.size() && candidates[next].masterKey == master)
+            ++next;
+
+        bool sameSequenceConflict = false;
+        for (auto j = i + 1; j < next && candidates[j].sequence == sequence;
+             ++j)
+        {
+            if (candidates[j].serialized != candidates[i].serialized)
+            {
+                sameSequenceConflict = true;
+                break;
+            }
+        }
+        if (!sameSequenceConflict)
+            coalesced.emplace(master, std::move(candidates[i]));
+        i = next;
+    }
+
+    std::unique_lock lock{mutex_};
+
+    hash_set<PublicKey> protectedKeys = listedMasterKeys;
+    for (auto const& master : listedMasterKeys)
+    {
+        if (auto const authoritative = map_.find(master);
+            authoritative != map_.end() && authoritative->second.signingKey)
+            protectedKeys.insert(*authoritative->second.signingKey);
+    }
+
+    hash_set<PublicKey> conflicts;
+    hash_map<PublicKey, PublicKey> candidateSigningOwners;
+    for (auto const& [master, candidate] : coalesced)
+    {
+        if (protectedKeys.contains(master) ||
+            (candidate.signingKey &&
+             protectedKeys.contains(*candidate.signingKey)))
+        {
+            conflicts.insert(master);
+            continue;
+        }
+
+        // Main-cache state wins every cross-master collision. Sequence
+        // numbers are comparable only for manifests with the same master.
+        if (auto const owner = signingToMasterKeys_.find(master);
+            owner != signingToMasterKeys_.end() && owner->second != master)
+            conflicts.insert(master);
+        if (!candidate.signingKey)
+            continue;
+        if (auto const authoritativeMaster = map_.find(*candidate.signingKey);
+            authoritativeMaster != map_.end() &&
+            authoritativeMaster->first != master)
+            conflicts.insert(master);
+        if (auto const owner = signingToMasterKeys_.find(*candidate.signingKey);
+            owner != signingToMasterKeys_.end() && owner->second != master)
+            conflicts.insert(master);
+
+        if (auto const [owner, inserted] =
+                candidateSigningOwners.emplace(*candidate.signingKey, master);
+            !inserted && owner->second != master)
+        {
+            conflicts.insert(master);
+            conflicts.insert(owner->second);
+        }
+        if (auto const otherMaster = coalesced.find(*candidate.signingKey);
+            otherMaster != coalesced.end() && otherMaster->first != master)
+        {
+            conflicts.insert(master);
+            conflicts.insert(otherMaster->first);
+        }
+    }
+
+    std::vector<PublicKey> acceptedMasters;
+    acceptedMasters.reserve(coalesced.size());
+    for (auto const& [master, _] : coalesced)
+    {
+        (void)_;
+        if (!conflicts.contains(master))
+            acceptedMasters.push_back(master);
+    }
+    std::sort(acceptedMasters.begin(), acceptedMasters.end());
+    if (acceptedMasters.size() > maxPublisherCandidates)
+        acceptedMasters.erase(
+            acceptedMasters.begin() + maxPublisherCandidates,
+            acceptedMasters.end());
+
+    hash_map<PublicKey, Manifest> nextCandidates;
+    hash_map<PublicKey, PublicKey> nextSigningToMaster;
+    nextCandidates.reserve(acceptedMasters.size());
+    nextSigningToMaster.reserve(acceptedMasters.size());
+    for (auto const& master : acceptedMasters)
+    {
+        auto node = coalesced.extract(master);
+        if (node.mapped().signingKey)
+            nextSigningToMaster.emplace(*node.mapped().signingKey, master);
+        nextCandidates.insert(std::move(node));
+    }
+
+    bool unchanged = nextCandidates.size() == publisherCandidates_.size();
+    if (unchanged)
+    {
+        for (auto const& [master, candidate] : nextCandidates)
+        {
+            auto const old = publisherCandidates_.find(master);
+            if (old == publisherCandidates_.end() || old->second != candidate)
+            {
+                unchanged = false;
+                break;
+            }
+        }
+    }
+    if (unchanged)
+        return;
+
+    publisherCandidates_ = std::move(nextCandidates);
+    candidateSigningToMasterKeys_ = std::move(nextSigningToMaster);
+    ++seq_;
 }
 
 ManifestDisposition

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -305,11 +305,17 @@ ManifestCache::getSigningKey(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
     auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end() && !authoritative->second.revoked())
+    if (authoritative != map_.end())
+    {
+        if (authoritative->second.revoked())
+            return pk;
         return authoritative->second.signingKey;
+    }
 
     auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+    if (candidate != publisherCandidates_.end() &&
+        publisherCandidateVisible(pk, candidate->second) &&
+        !candidate->second.revoked())
         return candidate->second.signingKey;
 
     return pk;
@@ -326,7 +332,12 @@ ManifestCache::getMasterKey(PublicKey const& pk) const
 
     if (auto const candidate = candidateSigningToMasterKeys_.find(pk);
         candidate != candidateSigningToMasterKeys_.end())
-        return candidate->second;
+    {
+        auto const manifest = publisherCandidates_.find(candidate->second);
+        if (manifest != publisherCandidates_.end() &&
+            publisherCandidateVisible(manifest->first, manifest->second))
+            return candidate->second;
+    }
 
     return pk;
 }
@@ -364,11 +375,17 @@ ManifestCache::getSequence(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
     auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end() && !authoritative->second.revoked())
+    if (authoritative != map_.end())
+    {
+        if (authoritative->second.revoked())
+            return std::nullopt;
         return authoritative->second.sequence;
+    }
 
     auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+    if (candidate != publisherCandidates_.end() &&
+        publisherCandidateVisible(pk, candidate->second) &&
+        !candidate->second.revoked())
         return candidate->second.sequence;
 
     return std::nullopt;
@@ -379,11 +396,17 @@ ManifestCache::getDomain(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
     auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end() && !authoritative->second.revoked())
+    if (authoritative != map_.end())
+    {
+        if (authoritative->second.revoked())
+            return std::nullopt;
         return authoritative->second.domain;
+    }
 
     auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+    if (candidate != publisherCandidates_.end() &&
+        publisherCandidateVisible(pk, candidate->second) &&
+        !candidate->second.revoked())
         return candidate->second.domain;
 
     return std::nullopt;
@@ -394,11 +417,17 @@ ManifestCache::getManifest(PublicKey const& pk) const
 {
     std::shared_lock lock{mutex_};
     auto const authoritative = map_.find(pk);
-    if (authoritative != map_.end() && !authoritative->second.revoked())
+    if (authoritative != map_.end())
+    {
+        if (authoritative->second.revoked())
+            return std::nullopt;
         return authoritative->second.serialized;
+    }
 
     auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end() && !candidate->second.revoked())
+    if (candidate != publisherCandidates_.end() &&
+        publisherCandidateVisible(pk, candidate->second) &&
+        !candidate->second.revoked())
         return candidate->second.serialized;
 
     return std::nullopt;
@@ -413,10 +442,26 @@ ManifestCache::revoked(PublicKey const& pk) const
         return authoritative->second.revoked();
 
     auto const candidate = publisherCandidates_.find(pk);
-    if (candidate != publisherCandidates_.end())
+    if (candidate != publisherCandidates_.end() &&
+        publisherCandidateVisible(pk, candidate->second))
         return candidate->second.revoked();
 
     return false;
+}
+
+bool
+ManifestCache::publisherCandidateVisible(
+    PublicKey const& master,
+    Manifest const& candidate) const
+{
+    if (map_.contains(master) || signingToMasterKeys_.contains(master))
+        return false;
+
+    if (!candidate.signingKey)
+        return true;
+
+    auto const& signing = *candidate.signingKey;
+    return !map_.contains(signing) && !signingToMasterKeys_.contains(signing);
 }
 
 ManifestDisposition
@@ -504,20 +549,8 @@ ManifestCache::replacePublisherCandidates(
             continue;
         }
 
-        // Main-cache state wins every cross-master collision. Sequence
-        // numbers are comparable only for manifests with the same master.
-        if (auto const owner = signingToMasterKeys_.find(master);
-            owner != signingToMasterKeys_.end() && owner->second != master)
-            conflicts.insert(master);
         if (!candidate.signingKey)
             continue;
-        if (auto const authoritativeMaster = map_.find(*candidate.signingKey);
-            authoritativeMaster != map_.end() &&
-            authoritativeMaster->first != master)
-            conflicts.insert(master);
-        if (auto const owner = signingToMasterKeys_.find(*candidate.signingKey);
-            owner != signingToMasterKeys_.end() && owner->second != master)
-            conflicts.insert(master);
 
         if (auto const [owner, inserted] =
                 candidateSigningOwners.emplace(*candidate.signingKey, master);

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -388,26 +388,33 @@ ManifestCache::revoked(PublicKey const& pk) const
 ManifestDisposition
 ManifestCache::applyManifest(Manifest m, ManifestRateLimitCapPolicy const cap)
 {
-    return applyManifestImpl(std::move(m), cap, nullptr);
+    return applyManifestImpl(std::move(m), cap, nullptr, nullptr);
 }
 
-ManifestDisposition
+ManifestApplyResult
 ManifestCache::applyManifestWithEviction(
     Manifest m,
     hash_set<PublicKey> const& currentValidationKeys)
 {
-    return applyManifestImpl(
+    bool acceptedUpdate = false;
+    auto const disposition = applyManifestImpl(
         std::move(m),
         ManifestRateLimitCapPolicy::Capped,
-        &currentValidationKeys);
+        &currentValidationKeys,
+        &acceptedUpdate);
+    return {disposition, acceptedUpdate};
 }
 
 ManifestDisposition
 ManifestCache::applyManifestImpl(
     Manifest m,
     ManifestRateLimitCapPolicy const cap,
-    hash_set<PublicKey> const* const currentValidationKeys)
+    hash_set<PublicKey> const* const currentValidationKeys,
+    bool* const acceptedUpdate)
 {
+    if (acceptedUpdate)
+        *acceptedUpdate = false;
+
     bool const uncapped = cap == ManifestRateLimitCapPolicy::Uncapped;
     bool checkSignature = true;
 
@@ -659,8 +666,8 @@ ManifestCache::applyManifestImpl(
     }
 
     bool const revoked = m.revoked();
-    // This is the first manifest we are seeing for a master key. This should
-    // only ever happen once per validator run.
+    // This master key is not currently retained. An untrusted key may reach
+    // this path again after eviction.
     if (iter == map_.end())
     {
         if (auto stream = j_.info())
@@ -702,6 +709,9 @@ ManifestCache::applyManifestImpl(
 
     // Something has changed. Keep track of it.
     seq_++;
+
+    if (acceptedUpdate)
+        *acceptedUpdate = true;
 
     return ManifestDisposition::accepted;
 }

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -543,7 +543,14 @@ ManifestCache::applyManifestImpl(
                 return rejectAtUntrustedCap();
         }
         if (auto d = prewriteCheck(iter, sl); d.has_value())
-            return *d;
+        {
+            // An uncapped application also carries retention policy. Defer a
+            // stale result to the write lock so an existing entry can be
+            // promoted atomically instead of racing eviction.
+            if (!uncapped || *d != ManifestDisposition::stale ||
+                !untrustedKeys_.contains(m.masterKey))
+                return *d;
+        }
     }
 
     std::unique_lock sl{mutex_};
@@ -552,6 +559,14 @@ ManifestCache::applyManifestImpl(
     bool const needsEviction = atUntrustedCap(iter, sl);
     if (needsEviction && !currentValidationKeys)
         return rejectAtUntrustedCap();
+
+    if (uncapped && iter != map_.end() && m.sequence <= iter->second.sequence)
+    {
+        if (untrustedKeys_.erase(m.masterKey) != 0)
+            ++seq_;
+        return ManifestDisposition::stale;
+    }
+
     // Since we released the previously held read lock, it's possible that the
     // collections have been written to. This means we need to run
     // `prewriteCheck` again. This re-does work, but `prewriteCheck` is
@@ -606,9 +621,14 @@ ManifestCache::applyManifestImpl(
 
         PublicKey const victimMaster = [&]() {
             if (!dormant.empty())
+            {
+                if (dormant.size() == 1)
+                    return dormant.front();
                 return dormant[rand_int(dormant.size() - 1)];
+            }
             auto victim = untrustedKeys_.begin();
-            std::advance(victim, rand_int(untrustedKeys_.size() - 1));
+            if (untrustedKeys_.size() > 1)
+                std::advance(victim, rand_int(untrustedKeys_.size() - 1));
             return *victim;
         }();
 

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -524,11 +524,24 @@ ManifestCache::applyManifestImpl(
         return ManifestDisposition::untrustedCapacity;
     };
 
+    auto evictionPermitAvailable = [this](auto const& lock) {
+        XRPL_ASSERT(
+            lock.owns_lock(),
+            "ripple::ManifestCache::applyManifestImpl : eviction budget "
+            "locked");
+        (void)lock;
+        return evictionPermits_ > 0 ||
+            now_() - evictionBudgetUpdated_ >= kEvictionPermitInterval;
+    };
+
     {
         std::shared_lock sl{mutex_};
         auto const iter = map_.find(m.masterKey);
-        if (atUntrustedCap(iter, sl) && !currentValidationKeys)
-            return rejectAtUntrustedCap();
+        if (atUntrustedCap(iter, sl))
+        {
+            if (!currentValidationKeys || !evictionPermitAvailable(sl))
+                return rejectAtUntrustedCap();
+        }
         if (auto d = prewriteCheck(iter, sl); d.has_value())
             return *d;
     }
@@ -556,6 +569,22 @@ ManifestCache::applyManifestImpl(
         XRPL_ASSERT(
             currentValidationKeys && !untrustedKeys_.empty(),
             "ripple::ManifestCache::applyManifestImpl : eviction inputs");
+
+        auto const now = now_();
+        auto const elapsed = now - evictionBudgetUpdated_;
+        auto const refillIntervals = elapsed / kEvictionPermitInterval;
+        if (refillIntervals > 0)
+        {
+            auto const refill = refillIntervals >= kMaxEvictionPermits
+                ? kMaxEvictionPermits
+                : static_cast<std::size_t>(refillIntervals);
+            evictionPermits_ =
+                std::min(kMaxEvictionPermits, evictionPermits_ + refill);
+            evictionBudgetUpdated_ += refillIntervals * kEvictionPermitInterval;
+        }
+        if (evictionPermits_ == 0)
+            return rejectAtUntrustedCap();
+        --evictionPermits_;
 
         std::vector<PublicKey> dormant;
         dormant.reserve(untrustedKeys_.size());

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -375,20 +375,15 @@ ManifestCache::revoked(PublicKey const& pk) const
 ManifestDisposition
 ManifestCache::applyManifest(Manifest m, ManifestRetention const retention)
 {
-    return applyManifestImpl(std::move(m), retention, nullptr, nullptr);
+    return applyManifestImpl(std::move(m), retention, false, nullptr);
 }
 
 ManifestApplyResult
-ManifestCache::applyManifestWithEviction(
-    Manifest m,
-    hash_set<PublicKey> const& currentValidationKeys)
+ManifestCache::applyManifestWithEviction(Manifest m)
 {
     bool acceptedUpdate = false;
     auto const disposition = applyManifestImpl(
-        std::move(m),
-        ManifestRetention::evictable,
-        &currentValidationKeys,
-        &acceptedUpdate);
+        std::move(m), ManifestRetention::evictable, true, &acceptedUpdate);
     return {disposition, acceptedUpdate};
 }
 
@@ -396,7 +391,7 @@ ManifestDisposition
 ManifestCache::applyManifestImpl(
     Manifest m,
     ManifestRetention const retention,
-    hash_set<PublicKey> const* const currentValidationKeys,
+    bool const mayEvict,
     bool* const acceptedUpdate)
 {
     if (acceptedUpdate)
@@ -547,7 +542,7 @@ ManifestCache::applyManifestImpl(
         auto const iter = map_.find(m.masterKey);
         if (atEvictableCap(iter, sl))
         {
-            if (!currentValidationKeys || !evictionPermitAvailable(sl))
+            if (!mayEvict || !evictionPermitAvailable(sl))
                 return rejectAtUntrustedCap();
         }
         if (auto d = prewriteCheck(iter, sl); d.has_value())
@@ -565,7 +560,7 @@ ManifestCache::applyManifestImpl(
     auto const iter = map_.find(m.masterKey);
 
     bool const needsEviction = atEvictableCap(iter, sl);
-    if (needsEviction && !currentValidationKeys)
+    if (needsEviction && !mayEvict)
         return rejectAtUntrustedCap();
 
     if (protectedRetention && iter != map_.end() &&
@@ -591,7 +586,7 @@ ManifestCache::applyManifestImpl(
     if (needsEviction)
     {
         XRPL_ASSERT(
-            currentValidationKeys && !evictableKeys_.empty(),
+            mayEvict && !evictableKeys_.empty(),
             "ripple::ManifestCache::applyManifestImpl : eviction inputs");
 
         auto const now = now_();
@@ -610,36 +605,10 @@ ManifestCache::applyManifestImpl(
             return rejectAtUntrustedCap();
         --evictionPermits_;
 
-        std::vector<PublicKey> dormant;
-        dormant.reserve(evictableKeys_.size());
-        for (auto const& master : evictableKeys_)
-        {
-            auto const victim = map_.find(master);
-            XRPL_ASSERT(
-                victim != map_.end(),
-                "ripple::ManifestCache::applyManifestImpl : untrusted key "
-                "retained");
-            if (victim == map_.end())
-                continue;
-            if (!victim->second.signingKey ||
-                !currentValidationKeys->contains(*victim->second.signingKey))
-            {
-                dormant.push_back(master);
-            }
-        }
-
-        PublicKey const victimMaster = [&]() {
-            if (!dormant.empty())
-            {
-                if (dormant.size() == 1)
-                    return dormant.front();
-                return dormant[rand_int(dormant.size() - 1)];
-            }
-            auto victim = evictableKeys_.begin();
-            if (evictableKeys_.size() > 1)
-                std::advance(victim, rand_int(evictableKeys_.size() - 1));
-            return *victim;
-        }();
+        auto victimKey = evictableKeys_.begin();
+        if (evictableKeys_.size() > 1)
+            std::advance(victimKey, rand_int(evictableKeys_.size() - 1));
+        PublicKey const victimMaster = *victimKey;
 
         auto const victim = map_.find(victimMaster);
         XRPL_ASSERT(

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -360,19 +360,6 @@ ManifestCache::getManifest(PublicKey const& pk) const
     return std::nullopt;
 }
 
-std::shared_ptr<Manifest const>
-ManifestCache::getManifestByMaster(PublicKey const& pk) const
-{
-    std::shared_lock lock{mutex_};
-    if (auto const iter = map_.find(pk); iter != map_.end())
-    {
-        auto const& m = iter->second;
-        return std::make_shared<Manifest const>(
-            m.serialized, m.masterKey, m.signingKey, m.sequence, m.domain);
-    }
-    return {};
-}
-
 bool
 ManifestCache::revoked(PublicKey const& pk) const
 {
@@ -386,9 +373,9 @@ ManifestCache::revoked(PublicKey const& pk) const
 }
 
 ManifestDisposition
-ManifestCache::applyManifest(Manifest m, ManifestRateLimitCapPolicy const cap)
+ManifestCache::applyManifest(Manifest m, ManifestRetention const retention)
 {
-    return applyManifestImpl(std::move(m), cap, nullptr, nullptr);
+    return applyManifestImpl(std::move(m), retention, nullptr, nullptr);
 }
 
 ManifestApplyResult
@@ -399,7 +386,7 @@ ManifestCache::applyManifestWithEviction(
     bool acceptedUpdate = false;
     auto const disposition = applyManifestImpl(
         std::move(m),
-        ManifestRateLimitCapPolicy::Capped,
+        ManifestRetention::evictable,
         &currentValidationKeys,
         &acceptedUpdate);
     return {disposition, acceptedUpdate};
@@ -408,14 +395,14 @@ ManifestCache::applyManifestWithEviction(
 ManifestDisposition
 ManifestCache::applyManifestImpl(
     Manifest m,
-    ManifestRateLimitCapPolicy const cap,
+    ManifestRetention const retention,
     hash_set<PublicKey> const* const currentValidationKeys,
     bool* const acceptedUpdate)
 {
     if (acceptedUpdate)
         *acceptedUpdate = false;
 
-    bool const uncapped = cap == ManifestRateLimitCapPolicy::Uncapped;
+    bool const protectedRetention = retention == ManifestRetention::protected_;
     bool checkSignature = true;
 
     // Check the manifest against the conditions that do not require a
@@ -522,13 +509,14 @@ ManifestCache::applyManifestImpl(
         return std::nullopt;
     };
 
-    auto atUntrustedCap = [this, uncapped](auto const& iter, auto const& lock) {
+    auto atEvictableCap = [this, protectedRetention](
+                              auto const& iter, auto const& lock) {
         XRPL_ASSERT(
             lock.owns_lock(),
-            "ripple::ManifestCache::applyManifest::atUntrustedCap : locked");
+            "ripple::ManifestCache::applyManifest::atEvictableCap : locked");
         (void)lock;
-        return iter == map_.end() && !uncapped &&
-            untrustedKeys_.size() >= kMaxUntrustedCount;
+        return iter == map_.end() && !protectedRetention &&
+            evictableKeys_.size() >= kMaxUntrustedCount;
     };
 
     auto rejectAtUntrustedCap = [this, &m]() {
@@ -557,18 +545,18 @@ ManifestCache::applyManifestImpl(
     {
         std::shared_lock sl{mutex_};
         auto const iter = map_.find(m.masterKey);
-        if (atUntrustedCap(iter, sl))
+        if (atEvictableCap(iter, sl))
         {
             if (!currentValidationKeys || !evictionPermitAvailable(sl))
                 return rejectAtUntrustedCap();
         }
         if (auto d = prewriteCheck(iter, sl); d.has_value())
         {
-            // An uncapped application also carries retention policy. Defer a
+            // A protected application also carries retention policy. Defer a
             // stale result to the write lock so an existing entry can be
             // promoted atomically instead of racing eviction.
-            if (!uncapped || *d != ManifestDisposition::stale ||
-                !untrustedKeys_.contains(m.masterKey))
+            if (!protectedRetention || *d != ManifestDisposition::stale ||
+                !evictableKeys_.contains(m.masterKey))
                 return *d;
         }
     }
@@ -576,13 +564,14 @@ ManifestCache::applyManifestImpl(
     std::unique_lock sl{mutex_};
     auto const iter = map_.find(m.masterKey);
 
-    bool const needsEviction = atUntrustedCap(iter, sl);
+    bool const needsEviction = atEvictableCap(iter, sl);
     if (needsEviction && !currentValidationKeys)
         return rejectAtUntrustedCap();
 
-    if (uncapped && iter != map_.end() && m.sequence <= iter->second.sequence)
+    if (protectedRetention && iter != map_.end() &&
+        m.sequence <= iter->second.sequence)
     {
-        if (untrustedKeys_.erase(m.masterKey) != 0)
+        if (evictableKeys_.erase(m.masterKey) != 0)
             ++seq_;
         return ManifestDisposition::stale;
     }
@@ -602,7 +591,7 @@ ManifestCache::applyManifestImpl(
     if (needsEviction)
     {
         XRPL_ASSERT(
-            currentValidationKeys && !untrustedKeys_.empty(),
+            currentValidationKeys && !evictableKeys_.empty(),
             "ripple::ManifestCache::applyManifestImpl : eviction inputs");
 
         auto const now = now_();
@@ -622,8 +611,8 @@ ManifestCache::applyManifestImpl(
         --evictionPermits_;
 
         std::vector<PublicKey> dormant;
-        dormant.reserve(untrustedKeys_.size());
-        for (auto const& master : untrustedKeys_)
+        dormant.reserve(evictableKeys_.size());
+        for (auto const& master : evictableKeys_)
         {
             auto const victim = map_.find(master);
             XRPL_ASSERT(
@@ -646,9 +635,9 @@ ManifestCache::applyManifestImpl(
                     return dormant.front();
                 return dormant[rand_int(dormant.size() - 1)];
             }
-            auto victim = untrustedKeys_.begin();
-            if (untrustedKeys_.size() > 1)
-                std::advance(victim, rand_int(untrustedKeys_.size() - 1));
+            auto victim = evictableKeys_.begin();
+            if (evictableKeys_.size() > 1)
+                std::advance(victim, rand_int(evictableKeys_.size() - 1));
             return *victim;
         }();
 
@@ -662,7 +651,7 @@ ManifestCache::applyManifestImpl(
         if (victim->second.signingKey)
             signingToMasterKeys_.erase(*victim->second.signingKey);
         map_.erase(victim);
-        untrustedKeys_.erase(victimMaster);
+        evictableKeys_.erase(victimMaster);
     }
 
     bool const revoked = m.revoked();
@@ -677,8 +666,8 @@ ManifestCache::applyManifestImpl(
             signingToMasterKeys_.emplace(*m.signingKey, m.masterKey);
 
         auto masterKey = m.masterKey;
-        if (!uncapped)
-            untrustedKeys_.insert(masterKey);
+        if (!protectedRetention)
+            evictableKeys_.insert(masterKey);
         map_.emplace(std::move(masterKey), std::move(m));
 
         // Increment sequence to invalidate cached manifest messages
@@ -697,8 +686,8 @@ ManifestCache::applyManifestImpl(
             m.sequence,
             iter->second.sequence);
 
-    if (uncapped)
-        untrustedKeys_.erase(m.masterKey);
+    if (protectedRetention)
+        evictableKeys_.erase(m.masterKey);
 
     signingToMasterKeys_.erase(*iter->second.signingKey);
 
@@ -717,15 +706,87 @@ ManifestCache::applyManifestImpl(
 }
 
 void
-ManifestCache::promoteToTrusted(PublicKey const& pk)
+ManifestCache::setRetention(
+    PublicKey const& pk,
+    ManifestRetention const retention)
 {
     std::unique_lock sl{mutex_};
-    if (untrustedKeys_.erase(pk) != 0)
+    auto const iter = map_.find(pk);
+    if (iter == map_.end())
+        return;
+
+    if (retention == ManifestRetention::protected_)
     {
-        // Trust classification affects which manifests are selected for the
-        // cached peer snapshot, even though the retained manifest is unchanged.
-        ++seq_;
+        if (evictableKeys_.erase(pk) != 0)
+        {
+            // Retention affects peer-snapshot priority even though the
+            // retained manifest is unchanged.
+            ++seq_;
+        }
+        return;
     }
+
+    if (evictableKeys_.contains(pk))
+        return;
+
+    if (configuredKeys_.contains(pk))
+        return;
+
+    if (evictableKeys_.size() < kMaxUntrustedCount)
+    {
+        evictableKeys_.insert(pk);
+    }
+    else
+    {
+        if (iter->second.signingKey)
+            signingToMasterKeys_.erase(*iter->second.signingKey);
+        map_.erase(iter);
+    }
+
+    // Retention changes peer-snapshot priority; removal also changes manifest
+    // resolution.
+    ++seq_;
+}
+
+void
+ManifestCache::reconcileRetention(hash_set<PublicKey> const& protectedMasters)
+{
+    std::unique_lock sl{mutex_};
+    bool changed = false;
+
+    for (auto iter = map_.begin(); iter != map_.end();)
+    {
+        auto const master = iter->first;
+        if (configuredKeys_.contains(master) ||
+            protectedMasters.contains(master))
+        {
+            changed = evictableKeys_.erase(master) != 0 || changed;
+            ++iter;
+            continue;
+        }
+
+        if (evictableKeys_.contains(master))
+        {
+            ++iter;
+            continue;
+        }
+
+        if (evictableKeys_.size() < kMaxUntrustedCount)
+        {
+            evictableKeys_.insert(master);
+            changed = true;
+            ++iter;
+            continue;
+        }
+
+        if (iter->second.signingKey)
+            signingToMasterKeys_.erase(*iter->second.signingKey);
+        iter = map_.erase(iter);
+        changed = true;
+    }
+
+    if (changed)
+        ++seq_;
 }
 
 void
@@ -758,13 +819,16 @@ ManifestCache::load(
             JLOG(j_.warn()) << "Configured manifest revokes public key";
         }
 
-        if (applyManifest(
-                std::move(*mo), ManifestRateLimitCapPolicy::Uncapped) ==
+        auto const masterKey = mo->masterKey;
+        if (applyManifest(std::move(*mo), ManifestRetention::protected_) ==
             ManifestDisposition::invalid)
         {
             JLOG(j_.error()) << "Manifest in config was rejected";
             return false;
         }
+
+        std::unique_lock lock{mutex_};
+        configuredKeys_.insert(masterKey);
     }
 
     if (!configRevocation.empty())
@@ -783,14 +847,22 @@ ManifestCache::load(
 
         auto mo = deserializeManifest(base64_decode(revocationStr));
 
-        if (!mo || !mo->revoked() ||
-            applyManifest(
-                std::move(*mo), ManifestRateLimitCapPolicy::Uncapped) ==
-                ManifestDisposition::invalid)
+        if (!mo || !mo->revoked())
         {
             JLOG(j_.error()) << "Invalid validator key revocation in config";
             return false;
         }
+
+        auto const masterKey = mo->masterKey;
+        if (applyManifest(std::move(*mo), ManifestRetention::protected_) ==
+            ManifestDisposition::invalid)
+        {
+            JLOG(j_.error()) << "Invalid validator key revocation in config";
+            return false;
+        }
+
+        std::unique_lock lock{mutex_};
+        configuredKeys_.insert(masterKey);
     }
 
     return true;

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -677,7 +677,12 @@ void
 ManifestCache::promoteToTrusted(PublicKey const& pk)
 {
     std::unique_lock sl{mutex_};
-    untrustedKeys_.erase(pk);
+    if (untrustedKeys_.erase(pk) != 0)
+    {
+        // Trust classification affects which manifests are selected for the
+        // cached peer snapshot, even though the retained manifest is unchanged.
+        ++seq_;
+    }
 }
 
 void

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1077,6 +1077,7 @@ ValidatorList::updatePublisherList(
     PublicKey const& pubKey,
     PublisherList const& current,
     std::vector<PublicKey> const& oldList,
+    bool const applyCandidates,
     ValidatorList::lock_guard const&)
 {
     // Update keyListings_ for added and removed keys
@@ -1142,31 +1143,41 @@ ValidatorList::updatePublisherList(
         }
     }
 
-    // Candidate manifests are authenticated by the trusted publisher, so keep
-    // their key bindings outside the untrusted eviction population. Candidate
-    // master keys deliberately do not enter keyListings_: this is a monitoring
-    // tier, not a second source of consensus weight.
-    for (auto const& candidateManifest : current.candidateManifests)
+    if (!applyCandidates)
+        return;
+
+    // Candidates are monitoring hints, not trusted validators. Their
+    // manifests use the bounded untrusted cache and may not alter the binding
+    // of any key which currently contributes to keyListings_.
+    for (auto const& [candidateKey, candidateManifest] : current.candidates)
     {
         auto m = deserializeManifest(base64_decode(candidateManifest));
 
-        if (!m ||
-            !std::binary_search(
-                current.candidates.begin(),
-                current.candidates.end(),
-                m->masterKey))
+        if (!m || m->masterKey != candidateKey || !m->verify())
         {
-            JLOG(j_.warn()) << "List for " << strHex(pubKey)
-                            << " contained unmatched candidate manifest";
+            JLOG(j_.warn())
+                << "List for " << strHex(pubKey)
+                << " contained invalid or mismatched candidate manifest";
+            continue;
+        }
+
+        if (keyListings_.contains(m->masterKey) ||
+            (m->signingKey && keyListings_.contains(*m->signingKey)))
+        {
+            JLOG(j_.warn())
+                << "List for " << strHex(pubKey)
+                << " contained candidate manifest intersecting a listed key";
             continue;
         }
 
         if (auto const r = validatorManifests_.applyManifest(
-                std::move(*m), ManifestRateLimitCapPolicy::Uncapped);
-            r == ManifestDisposition::invalid)
+                std::move(*m), ManifestRateLimitCapPolicy::Capped);
+            r != ManifestDisposition::accepted &&
+            r != ManifestDisposition::stale &&
+            r != ManifestDisposition::untrustedCapacity)
         {
             JLOG(j_.warn()) << "List for " << strHex(pubKey)
-                            << " contained invalid candidate manifest";
+                            << " contained conflicting candidate manifest";
         }
     }
 }
@@ -1286,9 +1297,8 @@ ValidatorList::applyList(
 
         std::vector<PublicKey>& publisherList = publisher.list;
         std::vector<std::string>& manifests = publisher.manifests;
-        std::vector<PublicKey>& candidates = publisher.candidates;
-        std::vector<std::string>& candidateManifests =
-            publisher.candidateManifests;
+        std::vector<std::pair<PublicKey, std::string>>& candidates =
+            publisher.candidates;
 
         // Copy the old validator list
         oldList = std::move(publisherList);
@@ -1325,15 +1335,18 @@ ValidatorList::applyList(
         std::sort(publisherList.begin(), publisherList.end());
 
         candidates.clear();
-        candidateManifests.clear();
         if (newCandidates)
         {
             candidates.reserve(newCandidates->size());
+            hash_set<PublicKey> candidateKeys;
+            candidateKeys.reserve(newCandidates->size());
             for (auto const& val : *newCandidates)
             {
                 if (val.isObject() &&
                     val.isMember(jss::validation_public_key) &&
-                    val[jss::validation_public_key].isString())
+                    val[jss::validation_public_key].isString() &&
+                    val.isMember(jss::manifest) &&
+                    val[jss::manifest].isString())
                 {
                     std::optional<Blob> const ret =
                         strUnHex(val[jss::validation_public_key].asString());
@@ -1346,17 +1359,21 @@ ValidatorList::applyList(
                     }
                     else
                     {
-                        candidates.emplace_back(
-                            Slice{ret->data(), ret->size()});
+                        PublicKey const key{Slice{ret->data(), ret->size()}};
+                        if (candidateKeys.insert(key).second)
+                        {
+                            candidates.emplace_back(
+                                key, val[jss::manifest].asString());
+                        }
+                        else
+                        {
+                            JLOG(j_.warn())
+                                << "Duplicate candidate identity: "
+                                << val[jss::validation_public_key].asString();
+                        }
                     }
-
-                    if (val.isMember(jss::manifest) &&
-                        val[jss::manifest].isString())
-                        candidateManifests.push_back(
-                            val[jss::manifest].asString());
                 }
             }
-            std::sort(candidates.begin(), candidates.end());
         }
     }
     // If this publisher has ever sent a more updated version than the one
@@ -1374,7 +1391,12 @@ ValidatorList::applyList(
 
     if (accepted)
     {
-        updatePublisherList(pubKey, pubCollection.current, oldList, lock);
+        updatePublisherList(
+            pubKey,
+            pubCollection.current,
+            oldList,
+            result == ListDisposition::accepted,
+            lock);
     }
 
     return applyResult;
@@ -2058,7 +2080,12 @@ ValidatorList::updateTrusted(
                 if (current.validUntil <= closeTime)
                     current.list.clear();
 
-                updatePublisherList(pubKey, current, oldList, lock);
+                updatePublisherList(
+                    pubKey,
+                    current,
+                    oldList,
+                    current.validUntil > closeTime,
+                    lock);
 
                 // Only broadcast the current, which will consequently only
                 // send to peers that don't understand v2, or which are

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -2251,13 +2251,20 @@ ValidatorList::updateTrusted(
                     "ripple::ValidatorList::updateTrusted : sequence match");
 
                 bool const expired = current.validUntil <= closeTime;
-                collection.status = expired ? PublisherStatus::expired
-                                            : PublisherStatus::available;
-                auto const currentMasters = expired ? std::vector<PublicKey>{}
-                                                    : validatorMasters(current);
+                collection.status = PublisherStatus::available;
+                if (expired)
+                {
+                    // Preserve the raw list for publisher history, but do not
+                    // retain parsed identities that were never counted in
+                    // keyListings_. A later refresh must not subtract them.
+                    current.validators.clear();
+                    current.candidates.clear();
+                }
+                auto const currentMasters = validatorMasters(current);
 
                 updatePublisherList(pubKey, currentMasters, oldList, lock);
-                ingestPublisherManifests(pubKey, current, lock);
+                if (!expired)
+                    ingestPublisherManifests(pubKey, current, lock);
                 publisherCandidatesDirty = true;
 
                 // Only broadcast the current, which will consequently only

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -226,8 +226,8 @@ ValidatorList::load(
             keyListings_.insert({*localPubKey_, listThreshold_});
         if (inserted)
         {
-            ++listingSequence_;
-            validatorManifests_.promoteToTrusted(*localPubKey_);
+            validatorManifests_.setRetention(
+                *localPubKey_, ManifestRetention::protected_);
             JLOG(j_.debug()) << "Added own master key "
                              << toBase58(TokenType::NodePublic, *localPubKey_);
         }
@@ -267,8 +267,7 @@ ValidatorList::load(
             JLOG(j_.warn()) << "Duplicate node identity: " << match[1];
             continue;
         }
-        ++listingSequence_;
-        validatorManifests_.promoteToTrusted(*id);
+        validatorManifests_.setRetention(*id, ManifestRetention::protected_);
         localPublisherList.validators.push_back(PublisherValidator{*id, {}});
         ++count;
     }
@@ -280,6 +279,12 @@ ValidatorList::load(
         localPublisherList.validUntil = TimeKeeper::time_point::max();
 
     JLOG(j_.debug()) << "Loaded " << count << " entries";
+
+    // Wallet rows are loaded before local and publisher configuration is
+    // known. Reconcile that provisional startup retention now that the current
+    // local source set is complete. Available publisher lists, if any, are
+    // folded in by the same path.
+    rebuildPublisherCandidates(lock);
 
     return true;
 }
@@ -1098,10 +1103,9 @@ ValidatorList::updatePublisherList(
             (iNew != publisherList.end() && *iNew < *iOld))
         {
             // Increment list count for added keys
-            auto& count = keyListings_[*iNew];
-            if (count++ == 0)
-                ++listingSequence_;
-            validatorManifests_.promoteToTrusted(*iNew);
+            ++keyListings_[*iNew];
+            validatorManifests_.setRetention(
+                *iNew, ManifestRetention::protected_);
             ++iNew;
         }
         else if (
@@ -1110,10 +1114,7 @@ ValidatorList::updatePublisherList(
         {
             // Decrement list count for removed keys
             if (keyListings_[*iOld] <= 1)
-            {
                 keyListings_.erase(*iOld);
-                ++listingSequence_;
-            }
             else
                 --keyListings_[*iOld];
             ++iOld;
@@ -1156,7 +1157,7 @@ ValidatorList::ingestPublisherManifests(
             supplied.sequence,
             supplied.domain};
         if (auto const r = validatorManifests_.applyManifest(
-                std::move(m), ManifestRateLimitCapPolicy::Uncapped);
+                std::move(m), ManifestRetention::protected_);
             r == ManifestDisposition::invalid)
         {
             JLOG(j_.warn()) << "List for " << strHex(pubKey)
@@ -1165,49 +1166,12 @@ ValidatorList::ingestPublisherManifests(
     }
 }
 
-bool
+void
 ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
 {
-    hash_map<PublicKey, CandidateRecord> byMaster;
+    hash_set<PublicKey> candidateMasters;
     hash_set<PublicKey> contributingPublishers;
     std::size_t supplied = 0;
-
-    auto mergeManifest = [](CandidateRecord& record,
-                            std::shared_ptr<Manifest const> const& manifest,
-                            PublicKey const* publisher) {
-        auto const sequence = manifest->sequence;
-        auto& variants = record.highestSequenceVariants;
-        if (!variants.empty() && variants.front().manifest->sequence > sequence)
-            return;
-        if (!variants.empty() && variants.front().manifest->sequence < sequence)
-            variants.clear();
-
-        auto const existing = std::find_if(
-            variants.begin(),
-            variants.end(),
-            [&](CandidateVariant const& variant) {
-                return variant.manifest->serialized == manifest->serialized;
-            });
-        if (existing != variants.end())
-        {
-            if (publisher)
-                existing->publishers.insert(*publisher);
-            return;
-        }
-
-        CandidateVariant variant{manifest, {}};
-        if (publisher)
-            variant.publishers.insert(*publisher);
-        variants.push_back(std::move(variant));
-        std::sort(
-            variants.begin(),
-            variants.end(),
-            [](CandidateVariant const& lhs, CandidateVariant const& rhs) {
-                return lhs.manifest->serialized < rhs.manifest->serialized;
-            });
-        if (variants.size() > 2)
-            variants.pop_back();
-    };
 
     for (auto const& [pubKey, collection] : publisherLists_)
     {
@@ -1218,26 +1182,14 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
         {
             ++supplied;
             contributingPublishers.insert(pubKey);
-            auto [it, inserted] =
-                byMaster.try_emplace(candidate.master, candidate.master);
-            (void)inserted;
-            auto& record = it->second;
-            record.identityPublishers.insert(pubKey);
-
-            if (!candidate.manifest)
-                continue;
-
-            mergeManifest(record, candidate.manifest, &pubKey);
+            candidateMasters.insert(candidate.master);
         }
     }
 
     std::vector<PublicKey> retained;
-    retained.reserve(byMaster.size());
-    for (auto const& [master, _] : byMaster)
-    {
-        (void)_;
+    retained.reserve(candidateMasters.size());
+    for (auto const& master : candidateMasters)
         retained.push_back(master);
-    }
     std::sort(retained.begin(), retained.end());
 
     auto const distinct = retained.size();
@@ -1246,7 +1198,7 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
         for (auto it = retained.begin() + maxPublisherCandidates;
              it != retained.end();
              ++it)
-            byMaster.erase(*it);
+            candidateMasters.erase(*it);
         retained.erase(
             retained.begin() + maxPublisherCandidates, retained.end());
 
@@ -1258,114 +1210,52 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
             << ", publishers=" << contributingPublishers.size();
     }
 
-    bool overridesChanged = false;
-    for (auto it = candidateManifestOverrides_.begin();
-         it != candidateManifestOverrides_.end();)
+    // List tiers choose retention and relay policy only. ManifestCache remains
+    // the sole high-water and signer-to-master namespace. Reconcile the whole
+    // current source set so removed validators do not stay protected merely
+    // because an older publisher generation once named them.
+    hash_set<PublicKey> protectedMasters;
+    protectedMasters.reserve(keyListings_.size() + candidateMasters.size());
+    for (auto const& [master, _] : keyListings_)
     {
-        auto const record = byMaster.find(it->first);
-        if (record == byMaster.end() || keyListings_.contains(it->first))
-        {
-            it = candidateManifestOverrides_.erase(it);
-            overridesChanged = true;
-            continue;
-        }
-
-        auto const& variants = record->second.highestSequenceVariants;
-        bool const publisherIsNewer = !variants.empty() &&
-            variants.front().manifest->sequence > it->second->sequence;
-        bool const publisherHasSameManifest = std::any_of(
-            variants.begin(),
-            variants.end(),
-            [&](CandidateVariant const& variant) {
-                return variant.manifest->serialized == it->second->serialized;
-            });
-        if (publisherIsNewer || publisherHasSameManifest)
-        {
-            it = candidateManifestOverrides_.erase(it);
-            overridesChanged = true;
-            continue;
-        }
-
-        mergeManifest(record->second, it->second, nullptr);
-        ++it;
+        (void)_;
+        protectedMasters.insert(master);
     }
+    for (auto const& master : candidateMasters)
+        protectedMasters.insert(master);
+    validatorManifests_.reconcileRetention(protectedMasters);
 
-    hash_map<PublicKey, hash_set<PublicKey>> signingOwners;
-    hash_set<PublicKey> conflicts;
-    for (auto const& [master, record] : byMaster)
+    // Apply candidate manifests only after enforcing the global candidate
+    // bound. They use ManifestCache's ordinary verification, collision and
+    // sequence rules. Protected retention grants no consensus weight.
+    for (auto const& [pubKey, collection] : publisherLists_)
     {
-        if (record.highestSequenceVariants.size() > 1)
-            conflicts.insert(master);
-
-        for (auto const& variant : record.highestSequenceVariants)
+        if (collection.status != PublisherStatus::available)
+            continue;
+        for (auto const& candidate : collection.current.candidates)
         {
-            if (variant.manifest->signingKey)
-                signingOwners[*variant.manifest->signingKey].insert(master);
-        }
-    }
+            if (!candidate.manifest ||
+                !candidateMasters.contains(candidate.master))
+                continue;
 
-    for (auto const& [signing, owners] : signingOwners)
-    {
-        if (owners.size() > 1)
-            conflicts.insert(owners.begin(), owners.end());
-
-        if (auto const identity = byMaster.find(signing);
-            identity != byMaster.end())
-        {
-            for (auto const& owner : owners)
+            auto const& supplied = *candidate.manifest;
+            Manifest manifest{
+                supplied.serialized,
+                supplied.masterKey,
+                supplied.signingKey,
+                supplied.sequence,
+                supplied.domain};
+            if (auto const result = validatorManifests_.applyManifest(
+                    std::move(manifest), ManifestRetention::protected_);
+                result == ManifestDisposition::invalid)
             {
-                if (owner != identity->first)
-                {
-                    conflicts.insert(owner);
-                    conflicts.insert(identity->first);
-                }
+                JLOG(j_.warn()) << "List for " << strHex(pubKey)
+                                << " contained invalid candidate manifest";
             }
         }
     }
 
-    auto recordsEqual = [](CandidateRecord const& lhs,
-                           CandidateRecord const& rhs) {
-        if (lhs.master != rhs.master ||
-            lhs.identityPublishers != rhs.identityPublishers ||
-            lhs.highestSequenceVariants.size() !=
-                rhs.highestSequenceVariants.size())
-            return false;
-        for (std::size_t i = 0; i < lhs.highestSequenceVariants.size(); ++i)
-        {
-            auto const& l = lhs.highestSequenceVariants[i];
-            auto const& r = rhs.highestSequenceVariants[i];
-            if (l.manifest->serialized != r.manifest->serialized ||
-                l.publishers != r.publishers)
-                return false;
-        }
-        return true;
-    };
-
-    bool unchanged = !overridesChanged &&
-        byMaster.size() == publisherCandidates_.byMaster.size() &&
-        signingOwners == publisherCandidates_.signingOwners &&
-        conflicts == publisherCandidates_.conflictedMasters;
-    if (unchanged)
-    {
-        for (auto const& [master, record] : byMaster)
-        {
-            auto const old = publisherCandidates_.byMaster.find(master);
-            if (old == publisherCandidates_.byMaster.end() ||
-                !recordsEqual(record, old->second))
-            {
-                unchanged = false;
-                break;
-            }
-        }
-    }
-    if (unchanged)
-        return false;
-
-    publisherCandidates_.byMaster = std::move(byMaster);
-    publisherCandidates_.signingOwners = std::move(signingOwners);
-    publisherCandidates_.conflictedMasters = std::move(conflicts);
-    ++publisherCandidates_.revision;
-    return true;
+    publisherCandidateMasters_ = std::move(candidateMasters);
 }
 
 ValidatorList::PublisherListStats
@@ -1753,7 +1643,7 @@ ValidatorList::verify(
     auto const revoked = m->revoked();
 
     auto const result = publisherManifests_.applyManifest(
-        std::move(*m), ManifestRateLimitCapPolicy::Uncapped);
+        std::move(*m), ManifestRetention::protected_);
 
     if (revoked && result == ManifestDisposition::accepted)
     {
@@ -1840,49 +1730,7 @@ ValidatorList::manifestPolicy(PublicKey const& master) const
     std::shared_lock readLock{mutex_};
     return {
         keyListings_.contains(master),
-        publisherCandidates_.byMaster.contains(master)};
-}
-
-std::optional<ManifestDisposition>
-ValidatorList::applyCandidateManifest(Manifest m)
-{
-    if (!m.verify())
-        return ManifestDisposition::invalid;
-
-    std::lock_guard lock{mutex_};
-    auto const candidate = publisherCandidates_.byMaster.find(m.masterKey);
-    if (candidate == publisherCandidates_.byMaster.end() ||
-        keyListings_.contains(m.masterKey))
-        return std::nullopt;
-
-    auto const ordinary = validatorManifests_.getManifestByMaster(m.masterKey);
-    if (ordinary && m.sequence <= ordinary->sequence)
-        return ManifestDisposition::stale;
-
-    auto const& variants = candidate->second.highestSequenceVariants;
-    if (!variants.empty() && m.sequence <= variants.front().manifest->sequence)
-        return ManifestDisposition::stale;
-
-    auto manifest = std::make_shared<Manifest const>(
-        m.serialized, m.masterKey, m.signingKey, m.sequence, m.domain);
-    candidateManifestOverrides_.insert_or_assign(
-        m.masterKey, std::move(manifest));
-    rebuildPublisherCandidates(lock);
-    return ManifestDisposition::accepted;
-}
-
-std::vector<std::shared_ptr<Manifest const>>
-ValidatorList::candidateManifestOverrides() const
-{
-    std::shared_lock lock{mutex_};
-    std::vector<std::shared_ptr<Manifest const>> result;
-    result.reserve(candidateManifestOverrides_.size());
-    for (auto const& [_, manifest] : candidateManifestOverrides_)
-    {
-        (void)_;
-        result.push_back(manifest);
-    }
-    return result;
+        publisherCandidateMasters_.contains(master)};
 }
 
 bool
@@ -1910,387 +1758,6 @@ ValidatorList::getListedKey(PublicKey const& identity) const
     if (keyListings_.find(pubKey) != keyListings_.end())
         return pubKey;
     return std::nullopt;
-}
-
-ValidatorIdentity
-ValidatorList::composeMonitoringIdentity(
-    PublicKey const& master,
-    std::shared_ptr<Manifest const> const& ordinary,
-    std::optional<CandidateRecord> const& candidate,
-    bool const directListed,
-    bool const candidateConflict,
-    std::vector<PublicKey> conflictingMasters)
-{
-    ValidatorIdentity result{master};
-    result.presentInOrdinaryState = static_cast<bool>(ordinary) || directListed;
-    if (candidate)
-        result.candidateIdentityPublishers = candidate->identityPublishers;
-
-    auto select = [&](std::shared_ptr<Manifest const> const& manifest) {
-        result.master = master;
-        result.manifest = manifest;
-        if (manifest->revoked())
-        {
-            result.status = ValidatorIdentityStatus::revoked;
-            result.signing.reset();
-        }
-        else
-        {
-            result.status = ValidatorIdentityStatus::resolved;
-            result.signing = manifest->signingKey;
-        }
-    };
-
-    if (!candidate || candidate->highestSequenceVariants.empty())
-    {
-        if (ordinary)
-            select(ordinary);
-        else if (candidate && candidateConflict)
-        {
-            result.status = ValidatorIdentityStatus::conflict;
-            result.master = master;
-            result.conflictingMasters = std::move(conflictingMasters);
-            if (result.conflictingMasters.empty())
-                result.conflictingMasters.push_back(master);
-        }
-        else if (candidate || directListed)
-        {
-            result.status = ValidatorIdentityStatus::resolved;
-            result.master = master;
-            result.signing = master;
-        }
-        return result;
-    }
-
-    auto const& variants = candidate->highestSequenceVariants;
-    auto const candidateSequence = variants.front().manifest->sequence;
-    if (ordinary && ordinary->sequence > candidateSequence)
-    {
-        select(ordinary);
-        return result;
-    }
-
-    for (auto const& variant : variants)
-        result.candidateManifestPublishers.insert(
-            variant.publishers.begin(), variant.publishers.end());
-
-    if (variants.size() > 1 || candidateConflict)
-    {
-        result.status = ValidatorIdentityStatus::conflict;
-        result.master = master;
-        result.conflictingMasters = std::move(conflictingMasters);
-        if (result.conflictingMasters.empty())
-            result.conflictingMasters.push_back(master);
-        return result;
-    }
-
-    auto const& published = variants.front().manifest;
-    if (ordinary && ordinary->sequence == candidateSequence)
-    {
-        if (ordinary->serialized != published->serialized)
-        {
-            result.status = ValidatorIdentityStatus::conflict;
-            result.master = master;
-            result.conflictingMasters.push_back(master);
-            return result;
-        }
-        select(ordinary);
-        return result;
-    }
-
-    select(published);
-    return result;
-}
-
-std::uint64_t
-ValidatorList::publisherCandidateRevision() const
-{
-    std::shared_lock lock{mutex_};
-    return publisherCandidates_.revision;
-}
-
-ValidatorIdentity
-ValidatorList::lookupMonitoringIdentity(PublicKey const& master) const
-{
-    for (int attempt = 0; attempt < 3; ++attempt)
-    {
-        auto const ordinaryRevision = validatorManifests_.sequence();
-        std::uint64_t candidateRevision;
-        std::uint64_t listingRevision;
-        std::optional<CandidateRecord> candidate;
-        bool directListed = false;
-        bool candidateConflict = false;
-        std::vector<PublicKey> conflictingMasters;
-        {
-            std::shared_lock lock{mutex_};
-            candidateRevision = publisherCandidates_.revision;
-            listingRevision = listingSequence_.load();
-            directListed = keyListings_.contains(master);
-            if (auto const it = publisherCandidates_.byMaster.find(master);
-                it != publisherCandidates_.byMaster.end())
-                candidate = it->second;
-            candidateConflict =
-                publisherCandidates_.conflictedMasters.contains(master);
-            if (candidateConflict && candidate)
-            {
-                conflictingMasters.push_back(master);
-                for (auto const& variant : candidate->highestSequenceVariants)
-                {
-                    if (!variant.manifest->signingKey)
-                        continue;
-                    if (publisherCandidates_.byMaster.contains(
-                            *variant.manifest->signingKey))
-                        conflictingMasters.push_back(
-                            *variant.manifest->signingKey);
-                    if (auto const owners =
-                            publisherCandidates_.signingOwners.find(
-                                *variant.manifest->signingKey);
-                        owners != publisherCandidates_.signingOwners.end())
-                        conflictingMasters.insert(
-                            conflictingMasters.end(),
-                            owners->second.begin(),
-                            owners->second.end());
-                }
-                if (auto const owners =
-                        publisherCandidates_.signingOwners.find(master);
-                    owners != publisherCandidates_.signingOwners.end())
-                    conflictingMasters.insert(
-                        conflictingMasters.end(),
-                        owners->second.begin(),
-                        owners->second.end());
-                std::sort(conflictingMasters.begin(), conflictingMasters.end());
-                conflictingMasters.erase(
-                    std::unique(
-                        conflictingMasters.begin(), conflictingMasters.end()),
-                    conflictingMasters.end());
-            }
-        }
-
-        auto ordinary = validatorManifests_.getManifestByMaster(master);
-        if (ordinaryRevision != validatorManifests_.sequence() ||
-            candidateRevision != publisherCandidateRevision() ||
-            listingRevision != listingSequence_.load())
-            continue;
-
-        auto result = composeMonitoringIdentity(
-            master,
-            ordinary,
-            candidate,
-            directListed,
-            candidateConflict,
-            std::move(conflictingMasters));
-        if (result.status == ValidatorIdentityStatus::resolved &&
-            result.signing)
-        {
-            auto signer = resolveMonitoringSigner(*result.signing);
-            if (signer.status == ValidatorIdentityStatus::conflict)
-            {
-                result.status = ValidatorIdentityStatus::conflict;
-                result.conflictingMasters =
-                    std::move(signer.conflictingMasters);
-                result.signing.reset();
-            }
-        }
-        else if (result.status == ValidatorIdentityStatus::revoked)
-        {
-            auto namespaceResult = resolveMonitoringSigner(master);
-            if (namespaceResult.status == ValidatorIdentityStatus::conflict)
-            {
-                result.status = ValidatorIdentityStatus::conflict;
-                result.conflictingMasters =
-                    std::move(namespaceResult.conflictingMasters);
-            }
-        }
-        return result;
-    }
-
-    ValidatorIdentity result{master};
-    result.status = ValidatorIdentityStatus::unstable;
-    return result;
-}
-
-ValidatorIdentity
-ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
-{
-    for (int attempt = 0; attempt < 3; ++attempt)
-    {
-        auto const ordinaryRevision = validatorManifests_.sequence();
-        auto const ordinaryMaster =
-            validatorManifests_.getMasterKey(signingKey);
-
-        std::uint64_t candidateRevision;
-        std::uint64_t listingRevision;
-        hash_set<PublicKey> possibleMasters;
-        hash_map<PublicKey, CandidateRecord> candidates;
-        hash_set<PublicKey> directListedMasters;
-        hash_set<PublicKey> candidateNamespaceKeys;
-        hash_set<PublicKey> directlyListedNamespaces;
-        hash_set<PublicKey> candidateConflicts;
-        bool directListed = false;
-        {
-            std::shared_lock lock{mutex_};
-            candidateRevision = publisherCandidates_.revision;
-            listingRevision = listingSequence_.load();
-            directListed = keyListings_.contains(signingKey);
-            if (auto const owners =
-                    publisherCandidates_.signingOwners.find(signingKey);
-                owners != publisherCandidates_.signingOwners.end())
-                possibleMasters.insert(
-                    owners->second.begin(), owners->second.end());
-            if (publisherCandidates_.byMaster.contains(signingKey))
-                possibleMasters.insert(signingKey);
-            if (ordinaryMaster != signingKey || directListed)
-                possibleMasters.insert(ordinaryMaster);
-
-            for (auto const& master : possibleMasters)
-            {
-                if (keyListings_.contains(master))
-                    directListedMasters.insert(master);
-                if (auto const it = publisherCandidates_.byMaster.find(master);
-                    it != publisherCandidates_.byMaster.end())
-                {
-                    candidates.emplace(master, it->second);
-                    candidateNamespaceKeys.insert(master);
-                    for (auto const& variant :
-                         it->second.highestSequenceVariants)
-                        if (variant.manifest->signingKey)
-                            candidateNamespaceKeys.insert(
-                                *variant.manifest->signingKey);
-                }
-                if (publisherCandidates_.conflictedMasters.contains(master))
-                    candidateConflicts.insert(master);
-            }
-            for (auto const& key : candidateNamespaceKeys)
-                if (keyListings_.contains(key))
-                    directlyListedNamespaces.insert(key);
-        }
-
-        hash_map<PublicKey, std::shared_ptr<Manifest const>> ordinary;
-        for (auto const& master : possibleMasters)
-        {
-            if (auto manifest = validatorManifests_.getManifestByMaster(master))
-                ordinary.emplace(master, std::move(manifest));
-        }
-
-        hash_map<PublicKey, hash_set<PublicKey>> ordinaryNamespaceOwners;
-        for (auto const& key : candidateNamespaceKeys)
-        {
-            auto const owner = validatorManifests_.getMasterKey(key);
-            if (owner != key)
-                ordinaryNamespaceOwners[key].insert(owner);
-            if (validatorManifests_.getManifestByMaster(key) ||
-                directlyListedNamespaces.contains(key))
-                ordinaryNamespaceOwners[key].insert(key);
-        }
-
-        if (ordinaryRevision != validatorManifests_.sequence() ||
-            candidateRevision != publisherCandidateRevision() ||
-            listingRevision != listingSequence_.load())
-            continue;
-
-        std::vector<ValidatorIdentity> resolved;
-        hash_set<PublicKey> conflicts;
-        for (auto const& master : possibleMasters)
-        {
-            std::shared_ptr<Manifest const> ordinaryManifest;
-            if (auto const it = ordinary.find(master); it != ordinary.end())
-                ordinaryManifest = it->second;
-            std::optional<CandidateRecord> candidate;
-            if (auto const it = candidates.find(master); it != candidates.end())
-                candidate = it->second;
-
-            auto identity = composeMonitoringIdentity(
-                master,
-                ordinaryManifest,
-                candidate,
-                directListedMasters.contains(master),
-                candidateConflicts.contains(master));
-
-            bool candidateEffective = false;
-            if (candidate)
-            {
-                auto const& variants = candidate->highestSequenceVariants;
-                candidateEffective = variants.empty() ? !ordinaryManifest
-                                                      : !ordinaryManifest ||
-                        variants.front().manifest->sequence >=
-                            ordinaryManifest->sequence;
-            }
-
-            hash_set<PublicKey> crossLayerOwners;
-            auto addNamespaceOwners = [&](PublicKey const& key) {
-                if (auto const owners = ordinaryNamespaceOwners.find(key);
-                    owners != ordinaryNamespaceOwners.end())
-                    crossLayerOwners.insert(
-                        owners->second.begin(), owners->second.end());
-            };
-            if (candidateEffective)
-            {
-                addNamespaceOwners(master);
-                if (identity.signing)
-                    addNamespaceOwners(*identity.signing);
-                crossLayerOwners.erase(master);
-            }
-            if (!crossLayerOwners.empty())
-            {
-                conflicts.insert(master);
-                conflicts.insert(
-                    crossLayerOwners.begin(), crossLayerOwners.end());
-                continue;
-            }
-
-            if (identity.status == ValidatorIdentityStatus::resolved &&
-                identity.signing && *identity.signing == signingKey)
-                resolved.push_back(std::move(identity));
-            else if (identity.status == ValidatorIdentityStatus::conflict)
-            {
-                bool relevant = master == signingKey;
-                if (ordinaryManifest && ordinaryManifest->signingKey)
-                    relevant =
-                        relevant || *ordinaryManifest->signingKey == signingKey;
-                if (candidate)
-                {
-                    for (auto const& variant :
-                         candidate->highestSequenceVariants)
-                        relevant = relevant ||
-                            (variant.manifest->signingKey &&
-                             *variant.manifest->signingKey == signingKey);
-                }
-                if (relevant)
-                {
-                    conflicts.insert(master);
-                    conflicts.insert(
-                        identity.conflictingMasters.begin(),
-                        identity.conflictingMasters.end());
-                }
-            }
-        }
-
-        if (resolved.size() == 1 && conflicts.empty())
-        {
-            resolved.front().requested = signingKey;
-            return std::move(resolved.front());
-        }
-        if (resolved.size() > 1 || !conflicts.empty())
-        {
-            ValidatorIdentity result{signingKey};
-            result.status = ValidatorIdentityStatus::conflict;
-            for (auto const& identity : resolved)
-                if (identity.master)
-                    conflicts.insert(*identity.master);
-            result.conflictingMasters.assign(
-                conflicts.begin(), conflicts.end());
-            std::sort(
-                result.conflictingMasters.begin(),
-                result.conflictingMasters.end());
-            return result;
-        }
-
-        return ValidatorIdentity{signingKey};
-    }
-
-    ValidatorIdentity result{signingKey};
-    result.status = ValidatorIdentityStatus::unstable;
-    return result;
 }
 
 std::optional<PublicKey>
@@ -2352,10 +1819,7 @@ ValidatorList::removePublisherList(
             continue;
 
         if (iVal->second <= 1)
-        {
             keyListings_.erase(iVal);
-            ++listingSequence_;
-        }
         else
             --iVal->second;
     }

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1934,6 +1934,7 @@ ValidatorList::lookupMonitoringIdentity(PublicKey const& master) const
     {
         auto const ordinaryRevision = validatorManifests_.sequence();
         std::uint64_t candidateRevision;
+        std::uint64_t listingRevision;
         std::optional<CandidateRecord> candidate;
         bool directListed = false;
         bool candidateConflict = false;
@@ -1941,6 +1942,7 @@ ValidatorList::lookupMonitoringIdentity(PublicKey const& master) const
         {
             std::shared_lock lock{mutex_};
             candidateRevision = publisherCandidates_.revision;
+            listingRevision = listingSequence_.load();
             directListed = keyListings_.contains(master);
             if (auto const it = publisherCandidates_.byMaster.find(master);
                 it != publisherCandidates_.byMaster.end())
@@ -1979,7 +1981,8 @@ ValidatorList::lookupMonitoringIdentity(PublicKey const& master) const
 
         auto ordinary = validatorManifests_.getManifestByMaster(master);
         if (ordinaryRevision != validatorManifests_.sequence() ||
-            candidateRevision != publisherCandidateRevision())
+            candidateRevision != publisherCandidateRevision() ||
+            listingRevision != listingSequence_.load())
             continue;
 
         auto result = composeMonitoringIdentity(
@@ -2019,6 +2022,7 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
             validatorManifests_.getMasterKey(signingKey);
 
         std::uint64_t candidateRevision;
+        std::uint64_t listingRevision;
         hash_set<PublicKey> possibleMasters;
         hash_map<PublicKey, CandidateRecord> candidates;
         hash_set<PublicKey> directListedMasters;
@@ -2027,6 +2031,7 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
         {
             std::shared_lock lock{mutex_};
             candidateRevision = publisherCandidates_.revision;
+            listingRevision = listingSequence_.load();
             directListed = keyListings_.contains(signingKey);
             if (auto const owners =
                     publisherCandidates_.signingOwners.find(signingKey);
@@ -2058,7 +2063,8 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
         }
 
         if (ordinaryRevision != validatorManifests_.sequence() ||
-            candidateRevision != publisherCandidateRevision())
+            candidateRevision != publisherCandidateRevision() ||
+            listingRevision != listingSequence_.load())
             continue;
 
         std::vector<ValidatorIdentity> resolved;

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1087,6 +1087,7 @@ ValidatorList::updatePublisherList(
         {
             // Increment list count for added keys
             ++keyListings_[*iNew];
+            validatorManifests_.promoteToTrusted(*iNew);
             ++iNew;
         }
         else if (
@@ -1123,7 +1124,8 @@ ValidatorList::updatePublisherList(
             continue;
         }
 
-        if (auto const r = validatorManifests_.applyManifest(std::move(*m));
+        if (auto const r = validatorManifests_.applyManifest(
+                std::move(*m), ManifestRateLimitCapPolicy::Uncapped);
             r == ManifestDisposition::invalid)
         {
             JLOG(j_.warn()) << "List for " << strHex(pubKey)
@@ -1143,10 +1145,16 @@ ValidatorList::applyList(
     std::optional<uint256> const& hash,
     ValidatorList::lock_guard const& lock)
 {
+    auto const& manifest = localManifest ? *localManifest : globalManifest;
+    if (manifest.size() > kMaxManifestBase64)
+    {
+        JLOG(j_.warn()) << "UNL manifest exceeds maximum size";
+        return PublisherListStats{ListDisposition::invalid};
+    }
+
     using namespace std::string_literals;
 
     Json::Value list;
-    auto const& manifest = localManifest ? *localManifest : globalManifest;
     auto [result, pubKeyOpt] = verify(lock, list, manifest, blob, signature);
 
     if (!pubKeyOpt)
@@ -1366,7 +1374,8 @@ ValidatorList::verify(
     PublicKey masterPubKey = m->masterKey;
     auto const revoked = m->revoked();
 
-    auto const result = publisherManifests_.applyManifest(std::move(*m));
+    auto const result = publisherManifests_.applyManifest(
+        std::move(*m), ManifestRateLimitCapPolicy::Uncapped);
 
     if (revoked && result == ManifestDisposition::accepted)
     {

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -2090,6 +2090,9 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
             else if (identity.status == ValidatorIdentityStatus::conflict)
             {
                 bool relevant = master == signingKey;
+                if (ordinaryManifest && ordinaryManifest->signingKey)
+                    relevant =
+                        relevant || *ordinaryManifest->signingKey == signingKey;
                 if (candidate)
                 {
                     for (auto const& variant :

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -215,8 +215,7 @@ ValidatorList::load(
     JLOG(j_.debug()) << "Loaded " << count << " keys";
 
     if (localSigningKey)
-        localPubKey_ =
-            validatorManifests_.getAuthoritativeMasterKey(*localSigningKey);
+        localPubKey_ = validatorManifests_.getMasterKey(*localSigningKey);
 
     // Treat local validator key as though it was listed in the config
     if (localPubKey_)
@@ -270,7 +269,7 @@ ValidatorList::load(
         }
         ++listingSequence_;
         validatorManifests_.promoteToTrusted(*id);
-        localPublisherList.list.emplace_back(*id);
+        localPublisherList.validators.push_back(PublisherValidator{*id, {}});
         ++count;
     }
 
@@ -1073,16 +1072,24 @@ ValidatorList::applyLists(
     return result;
 }
 
+std::vector<PublicKey>
+ValidatorList::validatorMasters(PublisherList const& list)
+{
+    std::vector<PublicKey> result;
+    result.reserve(list.validators.size());
+    for (auto const& entry : list.validators)
+        result.push_back(entry.master);
+    return result;
+}
+
 void
 ValidatorList::updatePublisherList(
     PublicKey const& pubKey,
-    PublisherList const& current,
+    std::vector<PublicKey> const& publisherList,
     std::vector<PublicKey> const& oldList,
     ValidatorList::lock_guard const&)
 {
     // Update keyListings_ for added and removed keys
-    std::vector<PublicKey> const& publisherList = current.list;
-    std::vector<std::string> const& manifests = current.manifests;
     auto iNew = publisherList.begin();
     auto iOld = oldList.begin();
     while (iNew != publisherList.end() || iOld != oldList.end())
@@ -1122,20 +1129,34 @@ ValidatorList::updatePublisherList(
     {
         JLOG(j_.warn()) << "No validator keys included in valid list";
     }
+}
 
-    for (auto const& valManifest : manifests)
+void
+ValidatorList::ingestPublisherManifests(
+    PublicKey const& pubKey,
+    PublisherList const& current,
+    ValidatorList::lock_guard const&)
+{
+    for (auto const& entry : current.validators)
     {
-        auto m = deserializeManifest(base64_decode(valManifest));
-
-        if (!m || !keyListings_.count(m->masterKey))
+        if (!entry.manifest)
+            continue;
+        if (entry.manifest->masterKey != entry.master)
         {
             JLOG(j_.warn()) << "List for " << strHex(pubKey)
-                            << " contained untrusted validator manifest";
+                            << " contained mismatched validator manifest";
             continue;
         }
 
+        auto const& supplied = *entry.manifest;
+        Manifest m{
+            supplied.serialized,
+            supplied.masterKey,
+            supplied.signingKey,
+            supplied.sequence,
+            supplied.domain};
         if (auto const r = validatorManifests_.applyManifest(
-                std::move(*m), ManifestRateLimitCapPolicy::Uncapped);
+                std::move(m), ManifestRateLimitCapPolicy::Uncapped);
             r == ManifestDisposition::invalid)
         {
             JLOG(j_.warn()) << "List for " << strHex(pubKey)
@@ -1144,39 +1165,174 @@ ValidatorList::updatePublisherList(
     }
 }
 
-void
+bool
 ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
 {
-    std::vector<Manifest> candidates;
+    hash_map<PublicKey, CandidateRecord> byMaster;
+    hash_set<PublicKey> contributingPublishers;
+    std::size_t supplied = 0;
+
     for (auto const& [pubKey, collection] : publisherLists_)
     {
         if (collection.status != PublisherStatus::available)
             continue;
 
-        for (auto const& [candidateKey, candidateManifest] :
-             collection.current.candidates)
+        for (auto const& candidate : collection.current.candidates)
         {
-            auto m = deserializeManifest(base64_decode(candidateManifest));
-            if (!m || m->masterKey != candidateKey || !m->verify())
-            {
-                JLOG(j_.warn())
-                    << "List for " << strHex(pubKey)
-                    << " contained invalid or mismatched candidate manifest";
+            ++supplied;
+            contributingPublishers.insert(pubKey);
+            auto [it, inserted] =
+                byMaster.try_emplace(candidate.master, candidate.master);
+            (void)inserted;
+            auto& record = it->second;
+            record.identityPublishers.insert(pubKey);
+
+            if (!candidate.manifest)
                 continue;
+
+            auto const sequence = candidate.manifest->sequence;
+            auto& variants = record.highestSequenceVariants;
+            if (!variants.empty() &&
+                variants.front().manifest->sequence > sequence)
+                continue;
+            if (!variants.empty() &&
+                variants.front().manifest->sequence < sequence)
+            {
+                variants.clear();
             }
-            candidates.push_back(std::move(*m));
+
+            auto const existing = std::find_if(
+                variants.begin(),
+                variants.end(),
+                [&](CandidateVariant const& v) {
+                    return v.manifest->serialized ==
+                        candidate.manifest->serialized;
+                });
+            if (existing != variants.end())
+            {
+                existing->publishers.insert(pubKey);
+            }
+            else if (variants.size() < 2)
+            {
+                variants.push_back(
+                    CandidateVariant{candidate.manifest, {pubKey}});
+            }
         }
     }
 
-    hash_set<PublicKey> listedMasters;
-    listedMasters.reserve(keyListings_.size());
-    for (auto const& [master, _] : keyListings_)
+    std::vector<PublicKey> retained;
+    retained.reserve(byMaster.size());
+    for (auto const& [master, _] : byMaster)
     {
         (void)_;
-        listedMasters.insert(master);
+        retained.push_back(master);
     }
-    validatorManifests_.replacePublisherCandidates(
-        std::move(candidates), listedMasters);
+    std::sort(retained.begin(), retained.end());
+
+    auto const distinct = retained.size();
+    if (retained.size() > maxPublisherCandidates)
+    {
+        for (auto it = retained.begin() + maxPublisherCandidates;
+             it != retained.end();
+             ++it)
+            byMaster.erase(*it);
+        retained.erase(
+            retained.begin() + maxPublisherCandidates, retained.end());
+
+        JLOG(j_.warn())
+            << "Publisher candidate tier exceeded global capacity: supplied="
+            << supplied << ", distinct=" << distinct
+            << ", retained=" << retained.size()
+            << ", dropped=" << (distinct - retained.size())
+            << ", publishers=" << contributingPublishers.size();
+    }
+
+    for (auto& [_, record] : byMaster)
+    {
+        (void)_;
+        std::sort(
+            record.highestSequenceVariants.begin(),
+            record.highestSequenceVariants.end(),
+            [](CandidateVariant const& lhs, CandidateVariant const& rhs) {
+                return lhs.manifest->serialized < rhs.manifest->serialized;
+            });
+    }
+
+    hash_map<PublicKey, hash_set<PublicKey>> signingOwners;
+    hash_set<PublicKey> conflicts;
+    for (auto const& [master, record] : byMaster)
+    {
+        if (record.highestSequenceVariants.size() > 1)
+            conflicts.insert(master);
+
+        for (auto const& variant : record.highestSequenceVariants)
+        {
+            if (variant.manifest->signingKey)
+                signingOwners[*variant.manifest->signingKey].insert(master);
+        }
+    }
+
+    for (auto const& [signing, owners] : signingOwners)
+    {
+        if (owners.size() > 1)
+            conflicts.insert(owners.begin(), owners.end());
+
+        if (auto const identity = byMaster.find(signing);
+            identity != byMaster.end())
+        {
+            for (auto const& owner : owners)
+            {
+                if (owner != identity->first)
+                {
+                    conflicts.insert(owner);
+                    conflicts.insert(identity->first);
+                }
+            }
+        }
+    }
+
+    auto recordsEqual = [](CandidateRecord const& lhs,
+                           CandidateRecord const& rhs) {
+        if (lhs.master != rhs.master ||
+            lhs.identityPublishers != rhs.identityPublishers ||
+            lhs.highestSequenceVariants.size() !=
+                rhs.highestSequenceVariants.size())
+            return false;
+        for (std::size_t i = 0; i < lhs.highestSequenceVariants.size(); ++i)
+        {
+            auto const& l = lhs.highestSequenceVariants[i];
+            auto const& r = rhs.highestSequenceVariants[i];
+            if (l.manifest->serialized != r.manifest->serialized ||
+                l.publishers != r.publishers)
+                return false;
+        }
+        return true;
+    };
+
+    bool unchanged = byMaster.size() == publisherCandidates_.byMaster.size() &&
+        signingOwners == publisherCandidates_.signingOwners &&
+        conflicts == publisherCandidates_.conflictedMasters;
+    if (unchanged)
+    {
+        for (auto const& [master, record] : byMaster)
+        {
+            auto const old = publisherCandidates_.byMaster.find(master);
+            if (old == publisherCandidates_.byMaster.end() ||
+                !recordsEqual(record, old->second))
+            {
+                unchanged = false;
+                break;
+            }
+        }
+    }
+    if (unchanged)
+        return false;
+
+    publisherCandidates_.byMaster = std::move(byMaster);
+    publisherCandidates_.signingOwners = std::move(signingOwners);
+    publisherCandidates_.conflictedMasters = std::move(conflicts);
+    ++publisherCandidates_.revision;
+    return true;
 }
 
 ValidatorList::PublisherListStats
@@ -1266,7 +1422,7 @@ ValidatorList::applyList(
         // some of that work here.
         auto& publisher = pubCollection.current;
         // Copy the old validator list
-        oldList = std::move(pubCollection.current.list);
+        oldList = validatorMasters(pubCollection.current);
         // Move the publisher info from "remaining" to "current"
         publisher = std::move(pubCollection.remaining[sequence]);
         // Remove the entry in "remaining"
@@ -1292,13 +1448,11 @@ ValidatorList::applyList(
         if (hash)
             publisher.hash = *hash;
 
-        std::vector<PublicKey>& publisherList = publisher.list;
-        std::vector<std::string>& manifests = publisher.manifests;
-        std::vector<std::pair<PublicKey, std::string>>& candidates =
-            publisher.candidates;
+        std::vector<PublisherValidator>& publisherList = publisher.validators;
+        std::vector<PublisherCandidate>& candidates = publisher.candidates;
 
         // Copy the old validator list
-        oldList = std::move(publisherList);
+        oldList = validatorMasters(publisher);
         // Build the new validator list from "newList"
         publisherList.clear();
         publisherList.reserve(newList.size());
@@ -1318,64 +1472,148 @@ ValidatorList::applyList(
                 }
                 else
                 {
-                    publisherList.push_back(
-                        PublicKey(Slice{ret->data(), ret->size()}));
-                }
+                    PublicKey key{Slice{ret->data(), ret->size()}};
+                    std::shared_ptr<Manifest const> validatorManifest;
+                    if (val.isMember(jss::manifest))
+                    {
+                        if (!val[jss::manifest].isString() ||
+                            val[jss::manifest].asString().size() >
+                                kMaxManifestBase64)
+                        {
+                            JLOG(j_.warn())
+                                << "List for " << strHex(pubKey)
+                                << " contained malformed validator manifest";
+                        }
+                        else
+                        {
+                            auto m = deserializeManifest(
+                                base64_decode(val[jss::manifest].asString()));
+                            if (!m || m->masterKey != key)
+                            {
+                                JLOG(j_.warn())
+                                    << "List for " << strHex(pubKey)
+                                    << " contained invalid or mismatched "
+                                       "validator manifest";
+                            }
+                            else
+                            {
+                                validatorManifest =
+                                    std::make_shared<Manifest const>(
+                                        std::move(*m));
+                            }
+                        }
+                    }
 
-                if (val.isMember(jss::manifest) &&
-                    val[jss::manifest].isString())
-                    manifests.push_back(val[jss::manifest].asString());
+                    publisherList.push_back(
+                        PublisherValidator{key, std::move(validatorManifest)});
+                }
             }
         }
 
         // Standardize the list order by sorting
-        std::sort(publisherList.begin(), publisherList.end());
+        std::sort(
+            publisherList.begin(),
+            publisherList.end(),
+            [](PublisherValidator const& lhs, PublisherValidator const& rhs) {
+                return lhs.master < rhs.master;
+            });
 
         candidates.clear();
         if (newCandidates)
         {
-            candidates.reserve(newCandidates->size());
-            hash_set<PublicKey> candidateKeys;
-            candidateKeys.reserve(newCandidates->size());
-            for (auto const& val : *newCandidates)
+            bool candidatePlaneValid =
+                newCandidates->size() <= maxPublisherCandidates;
+            if (!candidatePlaneValid)
             {
-                if (candidates.size() >= ManifestCache::maxPublisherCandidates)
-                {
-                    JLOG(j_.warn()) << "Publisher candidate limit reached for "
-                                    << strHex(pubKey);
-                    break;
-                }
-                if (val.isObject() &&
-                    val.isMember(jss::validation_public_key) &&
-                    val[jss::validation_public_key].isString() &&
-                    val.isMember(jss::manifest) &&
-                    val[jss::manifest].isString())
-                {
-                    std::optional<Blob> const ret =
-                        strUnHex(val[jss::validation_public_key].asString());
+                JLOG(j_.error())
+                    << "List for " << strHex(pubKey) << " supplied "
+                    << newCandidates->size() << " candidates; maximum is "
+                    << maxPublisherCandidates
+                    << ". Ignoring candidate tier only.";
+            }
+            else
+            {
+                std::vector<PublisherCandidate> parsed;
+                parsed.reserve(newCandidates->size());
+                hash_set<PublicKey> candidateKeys;
+                candidateKeys.reserve(newCandidates->size());
+                hash_set<PublicKey> validatorKeys;
+                validatorKeys.reserve(publisherList.size());
+                for (auto const& entry : publisherList)
+                    validatorKeys.insert(entry.master);
 
+                for (auto const& val : *newCandidates)
+                {
+                    if (!val.isObject() ||
+                        !val.isMember(jss::validation_public_key) ||
+                        !val[jss::validation_public_key].isString())
+                    {
+                        candidatePlaneValid = false;
+                        break;
+                    }
+
+                    auto const ret =
+                        strUnHex(val[jss::validation_public_key].asString());
                     if (!ret || !publicKeyType(makeSlice(*ret)))
                     {
-                        JLOG(j_.error())
-                            << "Invalid candidate identity: "
-                            << val[jss::validation_public_key].asString();
+                        candidatePlaneValid = false;
+                        break;
                     }
-                    else
+
+                    PublicKey key{Slice{ret->data(), ret->size()}};
+                    if (!candidateKeys.insert(key).second ||
+                        validatorKeys.contains(key))
                     {
-                        PublicKey const key{Slice{ret->data(), ret->size()}};
-                        if (candidateKeys.insert(key).second)
-                        {
-                            candidates.emplace_back(
-                                key, val[jss::manifest].asString());
-                        }
-                        else
-                        {
-                            JLOG(j_.warn())
-                                << "Duplicate candidate identity: "
-                                << val[jss::validation_public_key].asString();
-                        }
+                        candidatePlaneValid = false;
+                        break;
                     }
+
+                    std::shared_ptr<Manifest const> candidateManifest;
+                    if (val.isMember(jss::manifest))
+                    {
+                        if (!val[jss::manifest].isString() ||
+                            val[jss::manifest].asString().size() >
+                                kMaxManifestBase64)
+                        {
+                            candidatePlaneValid = false;
+                            break;
+                        }
+
+                        auto m = deserializeManifest(
+                            base64_decode(val[jss::manifest].asString()));
+                        if (!m || m->masterKey != key || !m->verify())
+                        {
+                            candidatePlaneValid = false;
+                            break;
+                        }
+                        candidateManifest =
+                            std::make_shared<Manifest const>(std::move(*m));
+                    }
+                    parsed.push_back(
+                        PublisherCandidate{key, std::move(candidateManifest)});
                 }
+
+                if (candidatePlaneValid)
+                    candidates = std::move(parsed);
+            }
+
+            if (!candidatePlaneValid)
+            {
+                candidates.clear();
+                JLOG(j_.error())
+                    << "List for " << strHex(pubKey)
+                    << " contained an invalid candidate tier; legacy "
+                       "validators remain accepted";
+            }
+            else
+            {
+                std::sort(
+                    candidates.begin(),
+                    candidates.end(),
+                    [](PublisherCandidate const& lhs,
+                       PublisherCandidate const& rhs) {
+                        return lhs.master < rhs.master;
+                    });
             }
         }
     }
@@ -1394,11 +1632,11 @@ ValidatorList::applyList(
 
     if (accepted)
     {
-        updatePublisherList(
-            pubKey,
-            pubCollection.current,
-            oldList,
-            lock);
+        auto const currentMasters = result == ListDisposition::accepted
+            ? validatorMasters(pubCollection.current)
+            : std::vector<PublicKey>{};
+        updatePublisherList(pubKey, currentMasters, oldList, lock);
+        ingestPublisherManifests(pubKey, pubCollection.current, lock);
         rebuildPublisherCandidates(lock);
     }
 
@@ -1484,6 +1722,7 @@ ValidatorList::verify(
         removePublisherList(lock, masterPubKey, PublisherStatus::revoked);
         // If the manifest is revoked, no future list is valid either
         publisherLists_[masterPubKey].remaining.clear();
+        rebuildPublisherCandidates(lock);
     }
 
     auto const signingKey = publisherManifests_.getSigningKey(masterPubKey);
@@ -1554,7 +1793,7 @@ ValidatorList::listed(PublicKey const& identity) const
 {
     std::shared_lock read_lock{mutex_};
 
-    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
+    auto const pubKey = validatorManifests_.getMasterKey(identity);
     return keyListings_.find(pubKey) != keyListings_.end();
 }
 
@@ -1563,7 +1802,7 @@ ValidatorList::trusted(
     ValidatorList::shared_lock const&,
     PublicKey const& identity) const
 {
-    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
+    auto const pubKey = validatorManifests_.getMasterKey(identity);
     return trustedMasterKeys_.find(pubKey) != trustedMasterKeys_.end();
 }
 
@@ -1579,10 +1818,310 @@ ValidatorList::getListedKey(PublicKey const& identity) const
 {
     std::shared_lock read_lock{mutex_};
 
-    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
+    auto const pubKey = validatorManifests_.getMasterKey(identity);
     if (keyListings_.find(pubKey) != keyListings_.end())
         return pubKey;
     return std::nullopt;
+}
+
+ValidatorIdentity
+ValidatorList::composeMonitoringIdentity(
+    PublicKey const& master,
+    std::shared_ptr<Manifest const> const& ordinary,
+    std::optional<CandidateRecord> const& candidate,
+    bool const directListed,
+    bool const candidateConflict,
+    std::vector<PublicKey> conflictingMasters)
+{
+    ValidatorIdentity result{master};
+    result.presentInOrdinaryState = static_cast<bool>(ordinary) || directListed;
+    if (candidate)
+        result.candidateIdentityPublishers = candidate->identityPublishers;
+
+    auto select = [&](std::shared_ptr<Manifest const> const& manifest) {
+        result.master = master;
+        result.manifest = manifest;
+        if (manifest->revoked())
+        {
+            result.status = ValidatorIdentityStatus::revoked;
+            result.signing.reset();
+        }
+        else
+        {
+            result.status = ValidatorIdentityStatus::resolved;
+            result.signing = manifest->signingKey;
+        }
+    };
+
+    if (!candidate || candidate->highestSequenceVariants.empty())
+    {
+        if (ordinary)
+            select(ordinary);
+        else if (candidate && candidateConflict)
+        {
+            result.status = ValidatorIdentityStatus::conflict;
+            result.master = master;
+            result.conflictingMasters = std::move(conflictingMasters);
+            if (result.conflictingMasters.empty())
+                result.conflictingMasters.push_back(master);
+        }
+        else if (candidate || directListed)
+        {
+            result.status = ValidatorIdentityStatus::resolved;
+            result.master = master;
+            result.signing = master;
+        }
+        return result;
+    }
+
+    auto const& variants = candidate->highestSequenceVariants;
+    auto const candidateSequence = variants.front().manifest->sequence;
+    if (ordinary && ordinary->sequence > candidateSequence)
+    {
+        select(ordinary);
+        return result;
+    }
+
+    for (auto const& variant : variants)
+        result.candidateManifestPublishers.insert(
+            variant.publishers.begin(), variant.publishers.end());
+
+    if (variants.size() > 1 || candidateConflict)
+    {
+        result.status = ValidatorIdentityStatus::conflict;
+        result.master = master;
+        result.conflictingMasters = std::move(conflictingMasters);
+        if (result.conflictingMasters.empty())
+            result.conflictingMasters.push_back(master);
+        return result;
+    }
+
+    auto const& published = variants.front().manifest;
+    if (ordinary && ordinary->sequence == candidateSequence)
+    {
+        if (ordinary->serialized != published->serialized)
+        {
+            result.status = ValidatorIdentityStatus::conflict;
+            result.master = master;
+            result.conflictingMasters.push_back(master);
+            return result;
+        }
+        select(ordinary);
+        return result;
+    }
+
+    select(published);
+    return result;
+}
+
+std::uint64_t
+ValidatorList::publisherCandidateRevision() const
+{
+    std::shared_lock lock{mutex_};
+    return publisherCandidates_.revision;
+}
+
+ValidatorIdentity
+ValidatorList::lookupMonitoringIdentity(PublicKey const& master) const
+{
+    for (int attempt = 0; attempt < 3; ++attempt)
+    {
+        auto const ordinaryRevision = validatorManifests_.sequence();
+        std::uint64_t candidateRevision;
+        std::optional<CandidateRecord> candidate;
+        bool directListed = false;
+        bool candidateConflict = false;
+        std::vector<PublicKey> conflictingMasters;
+        {
+            std::shared_lock lock{mutex_};
+            candidateRevision = publisherCandidates_.revision;
+            directListed = keyListings_.contains(master);
+            if (auto const it = publisherCandidates_.byMaster.find(master);
+                it != publisherCandidates_.byMaster.end())
+                candidate = it->second;
+            candidateConflict =
+                publisherCandidates_.conflictedMasters.contains(master);
+            if (candidateConflict && candidate)
+            {
+                for (auto const& variant : candidate->highestSequenceVariants)
+                {
+                    if (!variant.manifest->signingKey)
+                        continue;
+                    if (auto const owners =
+                            publisherCandidates_.signingOwners.find(
+                                *variant.manifest->signingKey);
+                        owners != publisherCandidates_.signingOwners.end())
+                        conflictingMasters.insert(
+                            conflictingMasters.end(),
+                            owners->second.begin(),
+                            owners->second.end());
+                }
+                if (auto const owners =
+                        publisherCandidates_.signingOwners.find(master);
+                    owners != publisherCandidates_.signingOwners.end())
+                    conflictingMasters.insert(
+                        conflictingMasters.end(),
+                        owners->second.begin(),
+                        owners->second.end());
+                std::sort(conflictingMasters.begin(), conflictingMasters.end());
+                conflictingMasters.erase(
+                    std::unique(
+                        conflictingMasters.begin(), conflictingMasters.end()),
+                    conflictingMasters.end());
+            }
+        }
+
+        auto ordinary = validatorManifests_.getManifestByMaster(master);
+        if (ordinaryRevision != validatorManifests_.sequence() ||
+            candidateRevision != publisherCandidateRevision())
+            continue;
+
+        auto result = composeMonitoringIdentity(
+            master,
+            ordinary,
+            candidate,
+            directListed,
+            candidateConflict,
+            std::move(conflictingMasters));
+        if (result.status == ValidatorIdentityStatus::resolved &&
+            result.signing)
+        {
+            auto signer = resolveMonitoringSigner(*result.signing);
+            if (signer.status == ValidatorIdentityStatus::conflict)
+            {
+                result.status = ValidatorIdentityStatus::conflict;
+                result.conflictingMasters =
+                    std::move(signer.conflictingMasters);
+                result.signing.reset();
+            }
+        }
+        return result;
+    }
+
+    ValidatorIdentity result{master};
+    result.status = ValidatorIdentityStatus::unstable;
+    return result;
+}
+
+ValidatorIdentity
+ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
+{
+    for (int attempt = 0; attempt < 3; ++attempt)
+    {
+        auto const ordinaryRevision = validatorManifests_.sequence();
+        auto const ordinaryMaster =
+            validatorManifests_.getMasterKey(signingKey);
+
+        std::uint64_t candidateRevision;
+        hash_set<PublicKey> possibleMasters;
+        hash_map<PublicKey, CandidateRecord> candidates;
+        hash_set<PublicKey> directListedMasters;
+        hash_set<PublicKey> candidateConflicts;
+        bool directListed = false;
+        {
+            std::shared_lock lock{mutex_};
+            candidateRevision = publisherCandidates_.revision;
+            directListed = keyListings_.contains(signingKey);
+            if (auto const owners =
+                    publisherCandidates_.signingOwners.find(signingKey);
+                owners != publisherCandidates_.signingOwners.end())
+                possibleMasters.insert(
+                    owners->second.begin(), owners->second.end());
+            if (publisherCandidates_.byMaster.contains(signingKey))
+                possibleMasters.insert(signingKey);
+            if (ordinaryMaster != signingKey || directListed)
+                possibleMasters.insert(ordinaryMaster);
+
+            for (auto const& master : possibleMasters)
+            {
+                if (keyListings_.contains(master))
+                    directListedMasters.insert(master);
+                if (auto const it = publisherCandidates_.byMaster.find(master);
+                    it != publisherCandidates_.byMaster.end())
+                    candidates.emplace(master, it->second);
+                if (publisherCandidates_.conflictedMasters.contains(master))
+                    candidateConflicts.insert(master);
+            }
+        }
+
+        hash_map<PublicKey, std::shared_ptr<Manifest const>> ordinary;
+        for (auto const& master : possibleMasters)
+        {
+            if (auto manifest = validatorManifests_.getManifestByMaster(master))
+                ordinary.emplace(master, std::move(manifest));
+        }
+
+        if (ordinaryRevision != validatorManifests_.sequence() ||
+            candidateRevision != publisherCandidateRevision())
+            continue;
+
+        std::vector<ValidatorIdentity> resolved;
+        hash_set<PublicKey> conflicts;
+        for (auto const& master : possibleMasters)
+        {
+            std::shared_ptr<Manifest const> ordinaryManifest;
+            if (auto const it = ordinary.find(master); it != ordinary.end())
+                ordinaryManifest = it->second;
+            std::optional<CandidateRecord> candidate;
+            if (auto const it = candidates.find(master); it != candidates.end())
+                candidate = it->second;
+
+            auto identity = composeMonitoringIdentity(
+                master,
+                ordinaryManifest,
+                candidate,
+                directListedMasters.contains(master),
+                candidateConflicts.contains(master));
+            if (identity.status == ValidatorIdentityStatus::resolved &&
+                identity.signing && *identity.signing == signingKey)
+                resolved.push_back(std::move(identity));
+            else if (identity.status == ValidatorIdentityStatus::conflict)
+            {
+                bool relevant = master == signingKey;
+                if (candidate)
+                {
+                    for (auto const& variant :
+                         candidate->highestSequenceVariants)
+                        relevant = relevant ||
+                            (variant.manifest->signingKey &&
+                             *variant.manifest->signingKey == signingKey);
+                }
+                if (relevant)
+                {
+                    conflicts.insert(master);
+                    conflicts.insert(
+                        identity.conflictingMasters.begin(),
+                        identity.conflictingMasters.end());
+                }
+            }
+        }
+
+        if (resolved.size() == 1 && conflicts.empty())
+        {
+            resolved.front().requested = signingKey;
+            return std::move(resolved.front());
+        }
+        if (resolved.size() > 1 || !conflicts.empty())
+        {
+            ValidatorIdentity result{signingKey};
+            result.status = ValidatorIdentityStatus::conflict;
+            for (auto const& identity : resolved)
+                if (identity.master)
+                    conflicts.insert(*identity.master);
+            result.conflictingMasters.assign(
+                conflicts.begin(), conflicts.end());
+            std::sort(
+                result.conflictingMasters.begin(),
+                result.conflictingMasters.end());
+            return result;
+        }
+
+        return ValidatorIdentity{signingKey};
+    }
+
+    ValidatorIdentity result{signingKey};
+    result.status = ValidatorIdentityStatus::unstable;
+    return result;
 }
 
 std::optional<PublicKey>
@@ -1590,7 +2129,7 @@ ValidatorList::getTrustedKey(
     ValidatorList::shared_lock const&,
     PublicKey const& identity) const
 {
-    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
+    auto const pubKey = validatorManifests_.getMasterKey(identity);
     if (trustedMasterKeys_.find(pubKey) != trustedMasterKeys_.end())
         return pubKey;
     return std::nullopt;
@@ -1636,8 +2175,9 @@ ValidatorList::removePublisherList(
     JLOG(j_.debug()) << "Removing validator list for publisher "
                      << strHex(publisherKey);
 
-    for (auto const& val : iList->second.current.list)
+    for (auto const& entry : iList->second.current.validators)
     {
+        auto const& val = entry.master;
         auto const& iVal = keyListings_.find(val);
         if (iVal == keyListings_.end())
             continue;
@@ -1651,9 +2191,8 @@ ValidatorList::removePublisherList(
             --iVal->second;
     }
 
-    iList->second.current.list.clear();
+    iList->second.current.validators.clear();
     iList->second.status = reason;
-    rebuildPublisherCandidates(lock);
 
     return true;
 }
@@ -1661,7 +2200,7 @@ ValidatorList::removePublisherList(
 std::size_t
 ValidatorList::count(ValidatorList::shared_lock const&) const
 {
-    return publisherLists_.size() + (localPublisherList.list.size() > 0);
+    return publisherLists_.size() + (localPublisherList.validators.size() > 0);
 }
 
 std::size_t
@@ -1704,7 +2243,7 @@ ValidatorList::expires(ValidatorList::shared_lock const&) const
         }
     }
 
-    if (localPublisherList.list.size() > 0)
+    if (localPublisherList.validators.size() > 0)
     {
         PublisherList collection = localPublisherList;
         // Unfetched
@@ -1771,8 +2310,8 @@ ValidatorList::getJson() const
     Json::Value& jLocalStaticKeys =
         (res[jss::local_static_keys] = Json::arrayValue);
 
-    for (auto const& key : localPublisherList.list)
-        jLocalStaticKeys.append(toBase58(TokenType::NodePublic, key));
+    for (auto const& entry : localPublisherList.validators)
+        jLocalStaticKeys.append(toBase58(TokenType::NodePublic, entry.master));
 
     // Publisher lists
     Json::Value& jPublisherLists =
@@ -1796,9 +2335,9 @@ ValidatorList::getJson() const
             if (publisherList.validFrom != TimeKeeper::time_point{})
                 target[jss::effective] = to_string(publisherList.validFrom);
             Json::Value& keys = (target[jss::list] = Json::arrayValue);
-            for (auto const& key : publisherList.list)
+            for (auto const& entry : publisherList.validators)
             {
-                keys.append(toBase58(TokenType::NodePublic, key));
+                keys.append(toBase58(TokenType::NodePublic, entry.master));
             }
         };
         {
@@ -2037,6 +2576,7 @@ ValidatorList::updateTrusted(
 
     // Rotate pending and remove expired published lists
     bool good = true;
+    bool publisherCandidatesDirty = false;
     // localPublisherList is not processed here. This is because the
     // Validators specified in the local config file do not expire nor do
     // they have a "remaining" section of PublisherList.
@@ -2071,24 +2611,21 @@ ValidatorList::updateTrusted(
                     candidate.validFrom <= closeTime,
                     "ripple::ValidatorList::updateTrusted : maximum time");
 
-                auto const oldList = current.list;
+                auto const oldList = validatorMasters(current);
                 current = std::move(candidate);
-                if (collection.status != PublisherStatus::available)
-                    collection.status = PublisherStatus::available;
                 XRPL_ASSERT(
                     current.sequence == sequence,
                     "ripple::ValidatorList::updateTrusted : sequence match");
-                // If the list is expired, remove the validators so they don't
-                // get processed in. The expiration check below will do the rest
-                // of the work
-                if (current.validUntil <= closeTime)
-                    current.list.clear();
 
-                updatePublisherList(
-                    pubKey,
-                    current,
-                    oldList,
-                    lock);
+                bool const expired = current.validUntil <= closeTime;
+                collection.status = expired ? PublisherStatus::expired
+                                            : PublisherStatus::available;
+                auto const currentMasters = expired ? std::vector<PublicKey>{}
+                                                    : validatorMasters(current);
+
+                updatePublisherList(pubKey, currentMasters, oldList, lock);
+                ingestPublisherManifests(pubKey, current, lock);
+                publisherCandidatesDirty = true;
 
                 // Only broadcast the current, which will consequently only
                 // send to peers that don't understand v2, or which are
@@ -2115,12 +2652,14 @@ ValidatorList::updateTrusted(
             collection.current.validUntil <= closeTime)
         {
             removePublisherList(lock, pubKey, PublisherStatus::expired);
+            publisherCandidatesDirty = true;
             ops.setUNLBlocked();
         }
         if (collection.status != PublisherStatus::available)
             good = false;
     }
-    rebuildPublisherCandidates(lock);
+    if (publisherCandidatesDirty)
+        rebuildPublisherCandidates(lock);
     if (good)
         ops.clearUNLBlocked();
 
@@ -2132,7 +2671,7 @@ ValidatorList::updateTrusted(
         auto const kit = keyListings_.find(*it);
         if (kit == keyListings_.end() ||     //
             kit->second < listThreshold_ ||  //
-            validatorManifests_.authoritativeRevoked(*it))
+            validatorManifests_.revoked(*it))
         {
             trustChanges.removed.insert(calcNodeID(*it));
             it = trustedMasterKeys_.erase(it);
@@ -2149,7 +2688,7 @@ ValidatorList::updateTrusted(
     for (auto const& val : keyListings_)
     {
         if (val.second >= listThreshold_ &&
-            !validatorManifests_.authoritativeRevoked(val.first) &&
+            !validatorManifests_.revoked(val.first) &&
             trustedMasterKeys_.emplace(val.first).second)
             trustChanges.added.insert(calcNodeID(val.first));
     }
@@ -2165,7 +2704,7 @@ ValidatorList::updateTrusted(
         for (auto const& k : trustedMasterKeys_)
         {
             std::optional<PublicKey> const signingKey =
-                validatorManifests_.getAuthoritativeSigningKey(k);
+                validatorManifests_.getSigningKey(k);
             XRPL_ASSERT(
                 signingKey,
                 "ripple::ValidatorList::updateTrusted : found signing key");
@@ -2212,7 +2751,7 @@ ValidatorList::updateTrusted(
                         << unlSize << ")";
     }
 
-    if ((publisherLists_.size() || localPublisherList.list.size()) &&
+    if ((publisherLists_.size() || localPublisherList.validators.size()) &&
         unlSize == 0)
     {
         // No validators. Lock down.

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1638,9 +1638,7 @@ ValidatorList::applyList(
 
     if (accepted)
     {
-        auto const currentMasters = result == ListDisposition::accepted
-            ? validatorMasters(pubCollection.current)
-            : std::vector<PublicKey>{};
+        auto const currentMasters = validatorMasters(pubCollection.current);
         updatePublisherList(pubKey, currentMasters, oldList, lock);
         ingestPublisherManifests(pubKey, pubCollection.current, lock);
         rebuildPublisherCandidates(lock);

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1172,6 +1172,43 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
     hash_set<PublicKey> contributingPublishers;
     std::size_t supplied = 0;
 
+    auto mergeManifest = [](CandidateRecord& record,
+                            std::shared_ptr<Manifest const> const& manifest,
+                            PublicKey const* publisher) {
+        auto const sequence = manifest->sequence;
+        auto& variants = record.highestSequenceVariants;
+        if (!variants.empty() && variants.front().manifest->sequence > sequence)
+            return;
+        if (!variants.empty() && variants.front().manifest->sequence < sequence)
+            variants.clear();
+
+        auto const existing = std::find_if(
+            variants.begin(),
+            variants.end(),
+            [&](CandidateVariant const& variant) {
+                return variant.manifest->serialized == manifest->serialized;
+            });
+        if (existing != variants.end())
+        {
+            if (publisher)
+                existing->publishers.insert(*publisher);
+            return;
+        }
+
+        CandidateVariant variant{manifest, {}};
+        if (publisher)
+            variant.publishers.insert(*publisher);
+        variants.push_back(std::move(variant));
+        std::sort(
+            variants.begin(),
+            variants.end(),
+            [](CandidateVariant const& lhs, CandidateVariant const& rhs) {
+                return lhs.manifest->serialized < rhs.manifest->serialized;
+            });
+        if (variants.size() > 2)
+            variants.pop_back();
+    };
+
     for (auto const& [pubKey, collection] : publisherLists_)
     {
         if (collection.status != PublisherStatus::available)
@@ -1190,43 +1227,7 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
             if (!candidate.manifest)
                 continue;
 
-            auto const sequence = candidate.manifest->sequence;
-            auto& variants = record.highestSequenceVariants;
-            if (!variants.empty() &&
-                variants.front().manifest->sequence > sequence)
-                continue;
-            if (!variants.empty() &&
-                variants.front().manifest->sequence < sequence)
-            {
-                variants.clear();
-            }
-
-            auto const existing = std::find_if(
-                variants.begin(),
-                variants.end(),
-                [&](CandidateVariant const& v) {
-                    return v.manifest->serialized ==
-                        candidate.manifest->serialized;
-                });
-            if (existing != variants.end())
-            {
-                existing->publishers.insert(pubKey);
-            }
-            else
-            {
-                variants.push_back(
-                    CandidateVariant{candidate.manifest, {pubKey}});
-                std::sort(
-                    variants.begin(),
-                    variants.end(),
-                    [](CandidateVariant const& lhs,
-                       CandidateVariant const& rhs) {
-                        return lhs.manifest->serialized <
-                            rhs.manifest->serialized;
-                    });
-                if (variants.size() > 2)
-                    variants.pop_back();
-            }
+            mergeManifest(record, candidate.manifest, &pubKey);
         }
     }
 
@@ -1255,6 +1256,38 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
             << ", retained=" << retained.size()
             << ", dropped=" << (distinct - retained.size())
             << ", publishers=" << contributingPublishers.size();
+    }
+
+    bool overridesChanged = false;
+    for (auto it = candidateManifestOverrides_.begin();
+         it != candidateManifestOverrides_.end();)
+    {
+        auto const record = byMaster.find(it->first);
+        if (record == byMaster.end() || keyListings_.contains(it->first))
+        {
+            it = candidateManifestOverrides_.erase(it);
+            overridesChanged = true;
+            continue;
+        }
+
+        auto const& variants = record->second.highestSequenceVariants;
+        bool const publisherIsNewer = !variants.empty() &&
+            variants.front().manifest->sequence > it->second->sequence;
+        bool const publisherHasSameManifest = std::any_of(
+            variants.begin(),
+            variants.end(),
+            [&](CandidateVariant const& variant) {
+                return variant.manifest->serialized == it->second->serialized;
+            });
+        if (publisherIsNewer || publisherHasSameManifest)
+        {
+            it = candidateManifestOverrides_.erase(it);
+            overridesChanged = true;
+            continue;
+        }
+
+        mergeManifest(record->second, it->second, nullptr);
+        ++it;
     }
 
     hash_map<PublicKey, hash_set<PublicKey>> signingOwners;
@@ -1308,7 +1341,8 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
         return true;
     };
 
-    bool unchanged = byMaster.size() == publisherCandidates_.byMaster.size() &&
+    bool unchanged = !overridesChanged &&
+        byMaster.size() == publisherCandidates_.byMaster.size() &&
         signingOwners == publisherCandidates_.signingOwners &&
         conflicts == publisherCandidates_.conflictedMasters;
     if (unchanged)
@@ -1798,6 +1832,57 @@ ValidatorList::listed(PublicKey const& identity) const
 
     auto const pubKey = validatorManifests_.getMasterKey(identity);
     return keyListings_.find(pubKey) != keyListings_.end();
+}
+
+ValidatorManifestPolicy
+ValidatorList::manifestPolicy(PublicKey const& master) const
+{
+    std::shared_lock readLock{mutex_};
+    return {
+        keyListings_.contains(master),
+        publisherCandidates_.byMaster.contains(master)};
+}
+
+std::optional<ManifestDisposition>
+ValidatorList::applyCandidateManifest(Manifest m)
+{
+    if (!m.verify())
+        return ManifestDisposition::invalid;
+
+    std::lock_guard lock{mutex_};
+    auto const candidate = publisherCandidates_.byMaster.find(m.masterKey);
+    if (candidate == publisherCandidates_.byMaster.end() ||
+        keyListings_.contains(m.masterKey))
+        return std::nullopt;
+
+    auto const ordinary = validatorManifests_.getManifestByMaster(m.masterKey);
+    if (ordinary && m.sequence <= ordinary->sequence)
+        return ManifestDisposition::stale;
+
+    auto const& variants = candidate->second.highestSequenceVariants;
+    if (!variants.empty() && m.sequence <= variants.front().manifest->sequence)
+        return ManifestDisposition::stale;
+
+    auto manifest = std::make_shared<Manifest const>(
+        m.serialized, m.masterKey, m.signingKey, m.sequence, m.domain);
+    candidateManifestOverrides_.insert_or_assign(
+        m.masterKey, std::move(manifest));
+    rebuildPublisherCandidates(lock);
+    return ManifestDisposition::accepted;
+}
+
+std::vector<std::shared_ptr<Manifest const>>
+ValidatorList::candidateManifestOverrides() const
+{
+    std::shared_lock lock{mutex_};
+    std::vector<std::shared_ptr<Manifest const>> result;
+    result.reserve(candidateManifestOverrides_.size());
+    for (auto const& [_, manifest] : candidateManifestOverrides_)
+    {
+        (void)_;
+        result.push_back(manifest);
+    }
+    return result;
 }
 
 bool

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1521,9 +1521,16 @@ ValidatorList::applyList(
         candidates.clear();
         if (newCandidates)
         {
-            bool candidatePlaneValid =
+            bool candidatePlaneValid = newCandidates->isArray() &&
                 newCandidates->size() <= maxPublisherCandidates;
-            if (!candidatePlaneValid)
+            if (!newCandidates->isArray())
+            {
+                JLOG(j_.error())
+                    << "List for " << strHex(pubKey)
+                    << " supplied a non-array candidate tier. Ignoring "
+                       "candidate tier only.";
+            }
+            else if (!candidatePlaneValid)
             {
                 JLOG(j_.error())
                     << "List for " << strHex(pubKey) << " supplied "
@@ -1742,8 +1749,7 @@ ValidatorList::verify(
     if (list.isMember(jss::sequence) && list[jss::sequence].isInt() &&
         list.isMember(jss::expiration) && list[jss::expiration].isInt() &&
         (!list.isMember(jss::effective) || list[jss::effective].isInt()) &&
-        list.isMember(jss::validators) && list[jss::validators].isArray() &&
-        (!list.isMember(jss::candidates) || list[jss::candidates].isArray()))
+        list.isMember(jss::validators) && list[jss::validators].isArray())
     {
         auto const sequence = list[jss::sequence].asUInt();
         auto const validFrom = TimeKeeper::time_point{TimeKeeper::duration{

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -226,6 +226,8 @@ ValidatorList::load(
             keyListings_.insert({*localPubKey_, listThreshold_});
         if (inserted)
         {
+            ++listingSequence_;
+            validatorManifests_.promoteToTrusted(*localPubKey_);
             JLOG(j_.debug()) << "Added own master key "
                              << toBase58(TokenType::NodePublic, *localPubKey_);
         }
@@ -265,6 +267,8 @@ ValidatorList::load(
             JLOG(j_.warn()) << "Duplicate node identity: " << match[1];
             continue;
         }
+        ++listingSequence_;
+        validatorManifests_.promoteToTrusted(*id);
         localPublisherList.list.emplace_back(*id);
         ++count;
     }
@@ -1086,7 +1090,9 @@ ValidatorList::updatePublisherList(
             (iNew != publisherList.end() && *iNew < *iOld))
         {
             // Increment list count for added keys
-            ++keyListings_[*iNew];
+            auto& count = keyListings_[*iNew];
+            if (count++ == 0)
+                ++listingSequence_;
             validatorManifests_.promoteToTrusted(*iNew);
             ++iNew;
         }
@@ -1096,7 +1102,10 @@ ValidatorList::updatePublisherList(
         {
             // Decrement list count for removed keys
             if (keyListings_[*iOld] <= 1)
+            {
                 keyListings_.erase(*iOld);
+                ++listingSequence_;
+            }
             else
                 --keyListings_[*iOld];
             ++iOld;
@@ -1540,7 +1549,10 @@ ValidatorList::removePublisherList(
             continue;
 
         if (iVal->second <= 1)
+        {
             keyListings_.erase(iVal);
+            ++listingSequence_;
+        }
         else
             --iVal->second;
     }

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -215,7 +215,8 @@ ValidatorList::load(
     JLOG(j_.debug()) << "Loaded " << count << " keys";
 
     if (localSigningKey)
-        localPubKey_ = validatorManifests_.getMasterKey(*localSigningKey);
+        localPubKey_ =
+            validatorManifests_.getAuthoritativeMasterKey(*localSigningKey);
 
     // Treat local validator key as though it was listed in the config
     if (localPubKey_)
@@ -1077,7 +1078,6 @@ ValidatorList::updatePublisherList(
     PublicKey const& pubKey,
     PublisherList const& current,
     std::vector<PublicKey> const& oldList,
-    bool const applyCandidates,
     ValidatorList::lock_guard const&)
 {
     // Update keyListings_ for added and removed keys
@@ -1142,44 +1142,41 @@ ValidatorList::updatePublisherList(
                             << " contained invalid validator manifest";
         }
     }
+}
 
-    if (!applyCandidates)
-        return;
-
-    // Candidates are monitoring hints, not trusted validators. Their
-    // manifests use the bounded untrusted cache and may not alter the binding
-    // of any key which currently contributes to keyListings_.
-    for (auto const& [candidateKey, candidateManifest] : current.candidates)
+void
+ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
+{
+    std::vector<Manifest> candidates;
+    for (auto const& [pubKey, collection] : publisherLists_)
     {
-        auto m = deserializeManifest(base64_decode(candidateManifest));
-
-        if (!m || m->masterKey != candidateKey || !m->verify())
-        {
-            JLOG(j_.warn())
-                << "List for " << strHex(pubKey)
-                << " contained invalid or mismatched candidate manifest";
+        if (collection.status != PublisherStatus::available)
             continue;
-        }
 
-        if (keyListings_.contains(m->masterKey) ||
-            (m->signingKey && keyListings_.contains(*m->signingKey)))
+        for (auto const& [candidateKey, candidateManifest] :
+             collection.current.candidates)
         {
-            JLOG(j_.warn())
-                << "List for " << strHex(pubKey)
-                << " contained candidate manifest intersecting a listed key";
-            continue;
-        }
-
-        if (auto const r = validatorManifests_.applyManifest(
-                std::move(*m), ManifestRateLimitCapPolicy::Capped);
-            r != ManifestDisposition::accepted &&
-            r != ManifestDisposition::stale &&
-            r != ManifestDisposition::untrustedCapacity)
-        {
-            JLOG(j_.warn()) << "List for " << strHex(pubKey)
-                            << " contained conflicting candidate manifest";
+            auto m = deserializeManifest(base64_decode(candidateManifest));
+            if (!m || m->masterKey != candidateKey || !m->verify())
+            {
+                JLOG(j_.warn())
+                    << "List for " << strHex(pubKey)
+                    << " contained invalid or mismatched candidate manifest";
+                continue;
+            }
+            candidates.push_back(std::move(*m));
         }
     }
+
+    hash_set<PublicKey> listedMasters;
+    listedMasters.reserve(keyListings_.size());
+    for (auto const& [master, _] : keyListings_)
+    {
+        (void)_;
+        listedMasters.insert(master);
+    }
+    validatorManifests_.replacePublisherCandidates(
+        std::move(candidates), listedMasters);
 }
 
 ValidatorList::PublisherListStats
@@ -1342,6 +1339,12 @@ ValidatorList::applyList(
             candidateKeys.reserve(newCandidates->size());
             for (auto const& val : *newCandidates)
             {
+                if (candidates.size() >= ManifestCache::maxPublisherCandidates)
+                {
+                    JLOG(j_.warn()) << "Publisher candidate limit reached for "
+                                    << strHex(pubKey);
+                    break;
+                }
                 if (val.isObject() &&
                     val.isMember(jss::validation_public_key) &&
                     val[jss::validation_public_key].isString() &&
@@ -1395,8 +1398,8 @@ ValidatorList::applyList(
             pubKey,
             pubCollection.current,
             oldList,
-            result == ListDisposition::accepted,
             lock);
+        rebuildPublisherCandidates(lock);
     }
 
     return applyResult;
@@ -1551,7 +1554,7 @@ ValidatorList::listed(PublicKey const& identity) const
 {
     std::shared_lock read_lock{mutex_};
 
-    auto const pubKey = validatorManifests_.getMasterKey(identity);
+    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
     return keyListings_.find(pubKey) != keyListings_.end();
 }
 
@@ -1560,7 +1563,7 @@ ValidatorList::trusted(
     ValidatorList::shared_lock const&,
     PublicKey const& identity) const
 {
-    auto const pubKey = validatorManifests_.getMasterKey(identity);
+    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
     return trustedMasterKeys_.find(pubKey) != trustedMasterKeys_.end();
 }
 
@@ -1576,7 +1579,7 @@ ValidatorList::getListedKey(PublicKey const& identity) const
 {
     std::shared_lock read_lock{mutex_};
 
-    auto const pubKey = validatorManifests_.getMasterKey(identity);
+    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
     if (keyListings_.find(pubKey) != keyListings_.end())
         return pubKey;
     return std::nullopt;
@@ -1587,7 +1590,7 @@ ValidatorList::getTrustedKey(
     ValidatorList::shared_lock const&,
     PublicKey const& identity) const
 {
-    auto const pubKey = validatorManifests_.getMasterKey(identity);
+    auto const pubKey = validatorManifests_.getAuthoritativeMasterKey(identity);
     if (trustedMasterKeys_.find(pubKey) != trustedMasterKeys_.end())
         return pubKey;
     return std::nullopt;
@@ -1618,7 +1621,7 @@ ValidatorList::localPublicKey() const
 
 bool
 ValidatorList::removePublisherList(
-    ValidatorList::lock_guard const&,
+    ValidatorList::lock_guard const& lock,
     PublicKey const& publisherKey,
     PublisherStatus reason)
 {
@@ -1650,6 +1653,7 @@ ValidatorList::removePublisherList(
 
     iList->second.current.list.clear();
     iList->second.status = reason;
+    rebuildPublisherCandidates(lock);
 
     return true;
 }
@@ -2084,7 +2088,6 @@ ValidatorList::updateTrusted(
                     pubKey,
                     current,
                     oldList,
-                    current.validUntil > closeTime,
                     lock);
 
                 // Only broadcast the current, which will consequently only
@@ -2117,6 +2120,7 @@ ValidatorList::updateTrusted(
         if (collection.status != PublisherStatus::available)
             good = false;
     }
+    rebuildPublisherCandidates(lock);
     if (good)
         ops.clearUNLBlocked();
 
@@ -2128,7 +2132,7 @@ ValidatorList::updateTrusted(
         auto const kit = keyListings_.find(*it);
         if (kit == keyListings_.end() ||     //
             kit->second < listThreshold_ ||  //
-            validatorManifests_.revoked(*it))
+            validatorManifests_.authoritativeRevoked(*it))
         {
             trustChanges.removed.insert(calcNodeID(*it));
             it = trustedMasterKeys_.erase(it);
@@ -2145,7 +2149,7 @@ ValidatorList::updateTrusted(
     for (auto const& val : keyListings_)
     {
         if (val.second >= listThreshold_ &&
-            !validatorManifests_.revoked(val.first) &&
+            !validatorManifests_.authoritativeRevoked(val.first) &&
             trustedMasterKeys_.emplace(val.first).second)
             trustChanges.added.insert(calcNodeID(val.first));
     }
@@ -2161,7 +2165,7 @@ ValidatorList::updateTrusted(
         for (auto const& k : trustedMasterKeys_)
         {
             std::optional<PublicKey> const signingKey =
-                validatorManifests_.getSigningKey(k);
+                validatorManifests_.getAuthoritativeSigningKey(k);
             XRPL_ASSERT(
                 signingKey,
                 "ripple::ValidatorList::updateTrusted : found signing key");

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1212,10 +1212,20 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
             {
                 existing->publishers.insert(pubKey);
             }
-            else if (variants.size() < 2)
+            else
             {
                 variants.push_back(
                     CandidateVariant{candidate.manifest, {pubKey}});
+                std::sort(
+                    variants.begin(),
+                    variants.end(),
+                    [](CandidateVariant const& lhs,
+                       CandidateVariant const& rhs) {
+                        return lhs.manifest->serialized <
+                            rhs.manifest->serialized;
+                    });
+                if (variants.size() > 2)
+                    variants.pop_back();
             }
         }
     }
@@ -1245,17 +1255,6 @@ ValidatorList::rebuildPublisherCandidates(ValidatorList::lock_guard const&)
             << ", retained=" << retained.size()
             << ", dropped=" << (distinct - retained.size())
             << ", publishers=" << contributingPublishers.size();
-    }
-
-    for (auto& [_, record] : byMaster)
-    {
-        (void)_;
-        std::sort(
-            record.highestSequenceVariants.begin(),
-            record.highestSequenceVariants.end(),
-            [](CandidateVariant const& lhs, CandidateVariant const& rhs) {
-                return lhs.manifest->serialized < rhs.manifest->serialized;
-            });
     }
 
     hash_map<PublicKey, hash_set<PublicKey>> signingOwners;
@@ -1951,10 +1950,15 @@ ValidatorList::lookupMonitoringIdentity(PublicKey const& master) const
                 publisherCandidates_.conflictedMasters.contains(master);
             if (candidateConflict && candidate)
             {
+                conflictingMasters.push_back(master);
                 for (auto const& variant : candidate->highestSequenceVariants)
                 {
                     if (!variant.manifest->signingKey)
                         continue;
+                    if (publisherCandidates_.byMaster.contains(
+                            *variant.manifest->signingKey))
+                        conflictingMasters.push_back(
+                            *variant.manifest->signingKey);
                     if (auto const owners =
                             publisherCandidates_.signingOwners.find(
                                 *variant.manifest->signingKey);
@@ -2004,6 +2008,16 @@ ValidatorList::lookupMonitoringIdentity(PublicKey const& master) const
                 result.signing.reset();
             }
         }
+        else if (result.status == ValidatorIdentityStatus::revoked)
+        {
+            auto namespaceResult = resolveMonitoringSigner(master);
+            if (namespaceResult.status == ValidatorIdentityStatus::conflict)
+            {
+                result.status = ValidatorIdentityStatus::conflict;
+                result.conflictingMasters =
+                    std::move(namespaceResult.conflictingMasters);
+            }
+        }
         return result;
     }
 
@@ -2026,6 +2040,8 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
         hash_set<PublicKey> possibleMasters;
         hash_map<PublicKey, CandidateRecord> candidates;
         hash_set<PublicKey> directListedMasters;
+        hash_set<PublicKey> candidateNamespaceKeys;
+        hash_set<PublicKey> directlyListedNamespaces;
         hash_set<PublicKey> candidateConflicts;
         bool directListed = false;
         {
@@ -2049,10 +2065,21 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
                     directListedMasters.insert(master);
                 if (auto const it = publisherCandidates_.byMaster.find(master);
                     it != publisherCandidates_.byMaster.end())
+                {
                     candidates.emplace(master, it->second);
+                    candidateNamespaceKeys.insert(master);
+                    for (auto const& variant :
+                         it->second.highestSequenceVariants)
+                        if (variant.manifest->signingKey)
+                            candidateNamespaceKeys.insert(
+                                *variant.manifest->signingKey);
+                }
                 if (publisherCandidates_.conflictedMasters.contains(master))
                     candidateConflicts.insert(master);
             }
+            for (auto const& key : candidateNamespaceKeys)
+                if (keyListings_.contains(key))
+                    directlyListedNamespaces.insert(key);
         }
 
         hash_map<PublicKey, std::shared_ptr<Manifest const>> ordinary;
@@ -2060,6 +2087,17 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
         {
             if (auto manifest = validatorManifests_.getManifestByMaster(master))
                 ordinary.emplace(master, std::move(manifest));
+        }
+
+        hash_map<PublicKey, hash_set<PublicKey>> ordinaryNamespaceOwners;
+        for (auto const& key : candidateNamespaceKeys)
+        {
+            auto const owner = validatorManifests_.getMasterKey(key);
+            if (owner != key)
+                ordinaryNamespaceOwners[key].insert(owner);
+            if (validatorManifests_.getManifestByMaster(key) ||
+                directlyListedNamespaces.contains(key))
+                ordinaryNamespaceOwners[key].insert(key);
         }
 
         if (ordinaryRevision != validatorManifests_.sequence() ||
@@ -2084,6 +2122,39 @@ ValidatorList::resolveMonitoringSigner(PublicKey const& signingKey) const
                 candidate,
                 directListedMasters.contains(master),
                 candidateConflicts.contains(master));
+
+            bool candidateEffective = false;
+            if (candidate)
+            {
+                auto const& variants = candidate->highestSequenceVariants;
+                candidateEffective = variants.empty() ? !ordinaryManifest
+                                                      : !ordinaryManifest ||
+                        variants.front().manifest->sequence >=
+                            ordinaryManifest->sequence;
+            }
+
+            hash_set<PublicKey> crossLayerOwners;
+            auto addNamespaceOwners = [&](PublicKey const& key) {
+                if (auto const owners = ordinaryNamespaceOwners.find(key);
+                    owners != ordinaryNamespaceOwners.end())
+                    crossLayerOwners.insert(
+                        owners->second.begin(), owners->second.end());
+            };
+            if (candidateEffective)
+            {
+                addNamespaceOwners(master);
+                if (identity.signing)
+                    addNamespaceOwners(*identity.signing);
+                crossLayerOwners.erase(master);
+            }
+            if (!crossLayerOwners.empty())
+            {
+                conflicts.insert(master);
+                conflicts.insert(
+                    crossLayerOwners.begin(), crossLayerOwners.end());
+                continue;
+            }
+
             if (identity.status == ValidatorIdentityStatus::resolved &&
                 identity.signing && *identity.signing == signingKey)
                 resolved.push_back(std::move(identity));

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1141,6 +1141,34 @@ ValidatorList::updatePublisherList(
                             << " contained invalid validator manifest";
         }
     }
+
+    // Candidate manifests are authenticated by the trusted publisher, so keep
+    // their key bindings outside the untrusted eviction population. Candidate
+    // master keys deliberately do not enter keyListings_: this is a monitoring
+    // tier, not a second source of consensus weight.
+    for (auto const& candidateManifest : current.candidateManifests)
+    {
+        auto m = deserializeManifest(base64_decode(candidateManifest));
+
+        if (!m ||
+            !std::binary_search(
+                current.candidates.begin(),
+                current.candidates.end(),
+                m->masterKey))
+        {
+            JLOG(j_.warn()) << "List for " << strHex(pubKey)
+                            << " contained unmatched candidate manifest";
+            continue;
+        }
+
+        if (auto const r = validatorManifests_.applyManifest(
+                std::move(*m), ManifestRateLimitCapPolicy::Uncapped);
+            r == ManifestDisposition::invalid)
+        {
+            JLOG(j_.warn()) << "List for " << strHex(pubKey)
+                            << " contained invalid candidate manifest";
+        }
+    }
 }
 
 ValidatorList::PublisherListStats
@@ -1218,6 +1246,8 @@ ValidatorList::applyList(
         pubCollection.maxSequence = sequence;
 
     Json::Value const& newList = list[jss::validators];
+    Json::Value const* const newCandidates =
+        list.isMember(jss::candidates) ? &list[jss::candidates] : nullptr;
     std::vector<PublicKey> oldList;
     if (accepted && pubCollection.remaining.count(sequence) != 0)
     {
@@ -1256,6 +1286,9 @@ ValidatorList::applyList(
 
         std::vector<PublicKey>& publisherList = publisher.list;
         std::vector<std::string>& manifests = publisher.manifests;
+        std::vector<PublicKey>& candidates = publisher.candidates;
+        std::vector<std::string>& candidateManifests =
+            publisher.candidateManifests;
 
         // Copy the old validator list
         oldList = std::move(publisherList);
@@ -1290,6 +1323,41 @@ ValidatorList::applyList(
 
         // Standardize the list order by sorting
         std::sort(publisherList.begin(), publisherList.end());
+
+        candidates.clear();
+        candidateManifests.clear();
+        if (newCandidates)
+        {
+            candidates.reserve(newCandidates->size());
+            for (auto const& val : *newCandidates)
+            {
+                if (val.isObject() &&
+                    val.isMember(jss::validation_public_key) &&
+                    val[jss::validation_public_key].isString())
+                {
+                    std::optional<Blob> const ret =
+                        strUnHex(val[jss::validation_public_key].asString());
+
+                    if (!ret || !publicKeyType(makeSlice(*ret)))
+                    {
+                        JLOG(j_.error())
+                            << "Invalid candidate identity: "
+                            << val[jss::validation_public_key].asString();
+                    }
+                    else
+                    {
+                        candidates.emplace_back(
+                            Slice{ret->data(), ret->size()});
+                    }
+
+                    if (val.isMember(jss::manifest) &&
+                        val[jss::manifest].isString())
+                        candidateManifests.push_back(
+                            val[jss::manifest].asString());
+                }
+            }
+            std::sort(candidates.begin(), candidates.end());
+        }
     }
     // If this publisher has ever sent a more updated version than the one
     // in this file, keep it. This scenario is unlikely, but legal.
@@ -1410,7 +1478,8 @@ ValidatorList::verify(
     if (list.isMember(jss::sequence) && list[jss::sequence].isInt() &&
         list.isMember(jss::expiration) && list[jss::expiration].isInt() &&
         (!list.isMember(jss::effective) || list[jss::effective].isInt()) &&
-        list.isMember(jss::validators) && list[jss::validators].isArray())
+        list.isMember(jss::validators) && list[jss::validators].isArray() &&
+        (!list.isMember(jss::candidates) || list[jss::candidates].isArray()))
     {
         auto const sequence = list[jss::sequence].asUInt();
         auto const validFrom = TimeKeeper::time_point{TimeKeeper::duration{

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -977,6 +977,10 @@ ValidatorList::applyListsAndBroadcast(
             networkOPs.clearUNLBlocked();
         }
     }
+    else if (disposition == ListDisposition::expired)
+    {
+        networkOPs.setUNLBlocked();
+    }
     bool broadcast = disposition <= ListDisposition::known_sequence;
 
     // this function is only called for PublicKeys which are not specified
@@ -1320,14 +1324,14 @@ ValidatorList::applyList(
     // Update publisher's list
     auto& pubCollection = publisherLists_[pubKey];
     auto const sequence = list[jss::sequence].asUInt();
-    auto const accepted =
+    auto const currentGeneration =
         (result == ListDisposition::accepted ||
          result == ListDisposition::expired);
+    bool const available = result == ListDisposition::accepted;
 
-    if (accepted)
-        pubCollection.status = result == ListDisposition::accepted
-            ? PublisherStatus::available
-            : PublisherStatus::expired;
+    if (currentGeneration)
+        pubCollection.status =
+            available ? PublisherStatus::available : PublisherStatus::expired;
     pubCollection.rawManifest = globalManifest;
     if (!pubCollection.maxSequence || sequence > *pubCollection.maxSequence)
         pubCollection.maxSequence = sequence;
@@ -1336,7 +1340,7 @@ ValidatorList::applyList(
     Json::Value const* const newCandidates =
         list.isMember(jss::candidates) ? &list[jss::candidates] : nullptr;
     std::vector<PublicKey> oldList;
-    if (accepted && pubCollection.remaining.count(sequence) != 0)
+    if (currentGeneration && pubCollection.remaining.count(sequence) != 0)
     {
         // We've seen this list before and stored it in "remaining". The
         // normal expected process is that the processed list would have
@@ -1357,8 +1361,8 @@ ValidatorList::applyList(
     }
     else
     {
-        auto& publisher = accepted ? pubCollection.current
-                                   : pubCollection.remaining[sequence];
+        auto& publisher = currentGeneration ? pubCollection.current
+                                            : pubCollection.remaining[sequence];
         publisher.sequence = sequence;
         publisher.validFrom = TimeKeeper::time_point{TimeKeeper::duration{
             list.isMember(jss::effective) ? list[jss::effective].asUInt() : 0}};
@@ -1560,11 +1564,19 @@ ValidatorList::applyList(
     PublisherListStats const applyResult{
         result, pubKey, pubCollection.status, *pubCollection.maxSequence};
 
-    if (accepted)
+    if (currentGeneration)
     {
+        // An expired generation is retained as newer publisher evidence, but
+        // contributes no effective membership or manifest protection.
+        if (!available)
+        {
+            pubCollection.current.validators.clear();
+            pubCollection.current.candidates.clear();
+        }
         auto const currentMasters = validatorMasters(pubCollection.current);
         updatePublisherList(pubKey, currentMasters, oldList, lock);
-        ingestPublisherManifests(pubKey, pubCollection.current, lock);
+        if (available)
+            ingestPublisherManifests(pubKey, pubCollection.current, lock);
         rebuildPublisherCandidates(lock);
     }
 
@@ -1825,6 +1837,7 @@ ValidatorList::removePublisherList(
     }
 
     iList->second.current.validators.clear();
+    iList->second.current.candidates.clear();
     iList->second.status = reason;
 
     return true;

--- a/src/xrpld/app/rdb/detail/Wallet.cpp
+++ b/src/xrpld/app/rdb/detail/Wallet.cpp
@@ -67,8 +67,7 @@ getManifests(
                 continue;
             }
 
-            mCache.applyManifest(
-                std::move(*mo), ManifestRateLimitCapPolicy::Uncapped);
+            mCache.applyManifest(std::move(*mo), ManifestRetention::protected_);
         }
         else
         {
@@ -105,7 +104,10 @@ saveManifests(
     std::size_t skipped = 0;
     for (auto const& v : map)
     {
-        if (!isTrusted(v.second.masterKey))
+        // Preserve the existing wallet contract: terminal revocations are
+        // saved, while non-revocation manifests are saved only for validators
+        // selected by the caller. Retention remains an in-memory policy.
+        if (!v.second.revoked() && !isTrusted(v.second.masterKey))
         {
             ++skipped;
             continue;

--- a/src/xrpld/app/rdb/detail/Wallet.cpp
+++ b/src/xrpld/app/rdb/detail/Wallet.cpp
@@ -20,6 +20,8 @@
 #include <xrpld/app/rdb/Wallet.h>
 #include <boost/format.hpp>
 
+#include <cstddef>
+
 namespace ripple {
 
 std::unique_ptr<DatabaseCon>
@@ -65,7 +67,8 @@ getManifests(
                 continue;
             }
 
-            mCache.applyManifest(std::move(*mo));
+            mCache.applyManifest(
+                std::move(*mo), ManifestRateLimitCapPolicy::Uncapped);
         }
         else
         {
@@ -99,19 +102,24 @@ saveManifests(
 {
     soci::transaction tr(session);
     session << "DELETE FROM " << dbTable;
+    std::size_t skipped = 0;
     for (auto const& v : map)
     {
-        // Save all revocation manifests,
-        // but only save trusted non-revocation manifests.
-        if (!v.second.revoked() && !isTrusted(v.second.masterKey))
+        if (!isTrusted(v.second.masterKey))
         {
-            JLOG(j.info()) << "Untrusted manifest in cache not saved to db";
+            ++skipped;
             continue;
         }
 
         saveManifest(session, dbTable, v.second.serialized);
     }
     tr.commit();
+
+    if (skipped != 0)
+    {
+        JLOG(j.info()) << skipped
+                       << " untrusted manifest(s) in cache not saved to db";
+    }
 }
 
 void

--- a/src/xrpld/consensus/Validations.h
+++ b/src/xrpld/consensus/Validations.h
@@ -1027,27 +1027,6 @@ public:
         return ret;
     }
 
-    /** Get the signing keys associated with current validations.
-
-        Includes trusted and untrusted validators. Calling this method also
-        removes validations that have aged out under the normal validation
-        freshness rules.
-    */
-    auto
-    getCurrentNodeKeys() -> hash_set<NodeKey>
-    {
-        hash_set<NodeKey> ret;
-        std::lock_guard lock{mutex_};
-        current(
-            lock,
-            [&](std::size_t numValidations) { ret.reserve(numValidations); },
-            [&](NodeID const&, Validation const& validation) {
-                ret.insert(validation.key());
-            });
-
-        return ret;
-    }
-
     /** Count the number of trusted full validations for the given ledger
 
         @param ledgerID The identifier of ledger of interest

--- a/src/xrpld/consensus/Validations.h
+++ b/src/xrpld/consensus/Validations.h
@@ -1027,6 +1027,27 @@ public:
         return ret;
     }
 
+    /** Get the signing keys associated with current validations.
+
+        Includes trusted and untrusted validators. Calling this method also
+        removes validations that have aged out under the normal validation
+        freshness rules.
+    */
+    auto
+    getCurrentNodeKeys() -> hash_set<NodeKey>
+    {
+        hash_set<NodeKey> ret;
+        std::lock_guard lock{mutex_};
+        current(
+            lock,
+            [&](std::size_t numValidations) { ret.reserve(numValidations); },
+            [&](NodeID const&, Validation const& validation) {
+                ret.insert(validation.key());
+            });
+
+        return ret;
+    }
+
     /** Count the number of trusted full validations for the given ledger
 
         @param ledgerID The identifier of ledger of interest

--- a/src/xrpld/overlay/Message.h
+++ b/src/xrpld/overlay/Message.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_OVERLAY_MESSAGE_H_INCLUDED
 #define RIPPLE_OVERLAY_MESSAGE_H_INCLUDED
 
+#include <xrpld/app/misc/Manifest.h>
 #include <xrpld/overlay/Compression.h>
 #include <xrpl/basics/ByteUtilities.h>
 #include <xrpl/protocol/PublicKey.h>
@@ -36,6 +37,10 @@
 namespace ripple {
 
 constexpr std::size_t maximiumMessageSize = megabytes(64);
+
+constexpr std::size_t manifestFramingBytes = 8;
+constexpr std::size_t maximumManifestsMessageSize =
+    kMaxManifestsPerMessage * (kMaxManifestBytes + manifestFramingBytes);
 
 // VFALCO NOTE If we forward declare Message and write out shared_ptr
 //             instead of using the in-class type alias, we can remove the

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <xrpld/app/consensus/RCLValidations.h>
 #include <xrpld/app/ledger/LedgerMaster.h>
 #include <xrpld/app/misc/HashRouter.h>
 #include <xrpld/app/misc/NetworkOPs.h>
@@ -639,8 +640,11 @@ OverlayImpl::onManifests(
     auto const total = static_cast<std::size_t>(m->list_size());
     std::size_t untrusted = 0;
     bool skippedUntrusted = false;
+    auto const currentValidationKeys =
+        app_.getValidations().getCurrentNodeKeys();
 
     protocol::TMManifests relay;
+    std::optional<std::set<HashRouter::PeerShortID>> relaySkip;
 
     for (std::size_t i = 0; i < total; ++i)
     {
@@ -649,6 +653,7 @@ OverlayImpl::onManifests(
         if (auto mo = deserializeManifest(s))
         {
             auto const serialized = mo->serialized;
+            auto const manifestHash = mo->hash();
 
             bool const isTrusted = app_.validators().listed(mo->masterKey);
             if (!isTrusted)
@@ -661,14 +666,11 @@ OverlayImpl::onManifests(
                 ++untrusted;
             }
 
-            bool const isKnown = app_.validatorManifests()
-                                     .getSequence(mo->masterKey)
-                                     .has_value();
-
-            auto const result = app_.validatorManifests().applyManifest(
-                std::move(*mo),
-                isTrusted ? ManifestRateLimitCapPolicy::Uncapped
-                          : ManifestRateLimitCapPolicy::Capped);
+            auto const result = isTrusted
+                ? app_.validatorManifests().applyManifest(
+                      std::move(*mo), ManifestRateLimitCapPolicy::Uncapped)
+                : app_.validatorManifests().applyManifestWithEviction(
+                      std::move(*mo), currentValidationKeys);
 
             if (result == ManifestDisposition::accepted)
             {
@@ -683,15 +685,32 @@ OverlayImpl::onManifests(
 
                 app_.getOPs().pubManifest(*mo);
 
-                if (isTrusted || isKnown)
+                // Acceptance is relative to the retention cache. Eviction can
+                // make the same manifest acceptable again, so relay novelty
+                // must be tracked independently. Record the source before
+                // asking HashRouter whether this node should relay it.
+                auto& hashRouter = app_.getHashRouter();
+                hashRouter.addSuppressionPeer(manifestHash, from->id());
+                if (auto toSkip = hashRouter.shouldRelay(manifestHash))
                 {
                     relay.add_list()->set_stobject(s);
 
-                    if (isTrusted)
+                    if (!relaySkip)
                     {
-                        auto db = app_.getWalletDB().checkoutDb();
-                        addValidatorManifest(*db, serialized);
+                        relaySkip = std::move(*toSkip);
                     }
+                    else
+                    {
+                        std::erase_if(*relaySkip, [&toSkip](auto const peer) {
+                            return !toSkip->contains(peer);
+                        });
+                    }
+                }
+
+                if (isTrusted)
+                {
+                    auto db = app_.getWalletDB().checkoutDb();
+                    addValidatorManifest(*db, serialized);
                 }
             }
         }
@@ -714,8 +733,16 @@ OverlayImpl::onManifests(
     }
 
     if (!relay.list().empty())
-        for_each([m2 = std::make_shared<Message>(relay, protocol::mtMANIFESTS)](
-                     std::shared_ptr<PeerImp>&& p) { p->send(m2); });
+    {
+        XRPL_ASSERT(
+            relaySkip,
+            "ripple::OverlayImpl::onManifests : relay suppression state");
+        for_each([m2 = std::make_shared<Message>(relay, protocol::mtMANIFESTS),
+                  &relaySkip](std::shared_ptr<PeerImp>&& p) {
+            if (!relaySkip->contains(p->id()))
+                p->send(m2);
+        });
+    }
 }
 
 void

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -638,6 +638,16 @@ OverlayImpl::onManifests(
     auto const& journal = from->pjournal();
 
     auto const total = static_cast<std::size_t>(m->list_size());
+    if (total > kMaxManifestEntriesPerMessage)
+    {
+        from->charge(
+            Resource::feeMalformedRequest, "too many manifest entries");
+        JLOG(journal.warn())
+            << "Manifests: message had " << total << " entries; maximum is "
+            << kMaxManifestEntriesPerMessage;
+        return;
+    }
+
     std::size_t untrusted = 0;
     bool skippedUntrusted = false;
     auto const currentValidationKeys =
@@ -653,9 +663,10 @@ OverlayImpl::onManifests(
         if (auto mo = deserializeManifest(s))
         {
             auto const serialized = mo->serialized;
+            auto const masterKey = mo->masterKey;
             auto const manifestHash = mo->hash();
 
-            bool const isTrusted = app_.validators().listed(mo->masterKey);
+            bool isTrusted = app_.validators().listed(masterKey);
             if (!isTrusted)
             {
                 if (untrusted >= kMaxManifestsPerMessage)
@@ -666,11 +677,39 @@ OverlayImpl::onManifests(
                 ++untrusted;
             }
 
-            auto const result = isTrusted
+            auto result = isTrusted
                 ? app_.validatorManifests().applyManifest(
                       std::move(*mo), ManifestRateLimitCapPolicy::Uncapped)
                 : app_.validatorManifests().applyManifestWithEviction(
                       std::move(*mo), currentValidationKeys);
+
+            if (!isTrusted &&
+                (result == ManifestDisposition::accepted ||
+                 result == ManifestDisposition::untrustedCapacity) &&
+                app_.validators().listed(masterKey))
+            {
+                // Listing may have raced capped admission. An uncapped stale
+                // application promotes the retained entry under the cache
+                // write lock; if eviction already won, it inserts this saved,
+                // previously validated manifest instead.
+                mo = deserializeManifest(serialized);
+                XRPL_ASSERT(
+                    mo,
+                    "ripple::OverlayImpl::onManifests : manifest "
+                    "deserialization succeeded for trusted reconciliation");
+                auto const trustedResult =
+                    app_.validatorManifests().applyManifest(
+                        std::move(*mo), ManifestRateLimitCapPolicy::Uncapped);
+
+                if (result == ManifestDisposition::untrustedCapacity)
+                    result = trustedResult;
+                else if (
+                    trustedResult != ManifestDisposition::accepted &&
+                    trustedResult != ManifestDisposition::stale)
+                    result = trustedResult;
+
+                isTrusted = true;
+            }
 
             if (result == ManifestDisposition::accepted)
             {
@@ -1246,8 +1285,9 @@ OverlayImpl::getManifestsMessage()
 {
     std::lock_guard g(manifestLock_);
 
-    if (auto seq = app_.validatorManifests().sequence();
-        seq != manifestListSeq_)
+    auto const seq = app_.validatorManifests().sequence();
+    auto const listingSeq = app_.validators().listingSequence();
+    if (seq != manifestListSeq_ || listingSeq != manifestListingSeq_)
     {
         struct CachedManifest
         {
@@ -1284,6 +1324,10 @@ OverlayImpl::getManifestsMessage()
             std::min(kMaxManifestsPerMessage, untrusted.size())));
 
         auto addIfFits = [&tm, &hashRouter](CachedManifest const& entry) {
+            if (static_cast<std::size_t>(tm.list_size()) >=
+                kMaxManifestEntriesPerMessage)
+                return;
+
             tm.add_list()->set_stobject(
                 entry.serialized.data(), entry.serialized.size());
             if (Message::messageSize(tm) > maximumManifestsMessageSize)
@@ -1313,6 +1357,7 @@ OverlayImpl::getManifestsMessage()
                 std::make_shared<Message>(tm, protocol::mtMANIFESTS);
 
         manifestListSeq_ = seq;
+        manifestListingSeq_ = listingSeq;
     }
 
     return manifestMessage_;

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -677,44 +677,10 @@ OverlayImpl::onManifests(
 
             bool acceptedUpdate = false;
             ManifestDisposition result;
-            if (policy.consensusListed)
+            if (policy.relayEligible())
             {
                 result = app_.validatorManifests().applyManifest(
-                    std::move(*mo), ManifestRateLimitCapPolicy::Uncapped);
-            }
-            else if (policy.publisherCandidate)
-            {
-                auto const candidateResult =
-                    app_.validators().applyCandidateManifest(std::move(*mo));
-                if (candidateResult)
-                {
-                    result = *candidateResult;
-                }
-                else
-                {
-                    // Candidate membership changed after classification.
-                    // Reclassify the same bytes under the current policy.
-                    policy = app_.validators().manifestPolicy(masterKey);
-                    mo = deserializeManifest(serialized);
-                    XRPL_ASSERT(
-                        mo,
-                        "ripple::OverlayImpl::onManifests : manifest "
-                        "deserialization succeeded for policy reconciliation");
-                    if (policy.consensusListed)
-                    {
-                        result = app_.validatorManifests().applyManifest(
-                            std::move(*mo),
-                            ManifestRateLimitCapPolicy::Uncapped);
-                    }
-                    else
-                    {
-                        auto const admission =
-                            app_.validatorManifests().applyManifestWithEviction(
-                                std::move(*mo), currentValidationKeys);
-                        acceptedUpdate = admission.acceptedUpdate;
-                        result = admission.disposition;
-                    }
-                }
+                    std::move(*mo), ManifestRetention::protected_);
             }
             else
             {
@@ -725,37 +691,35 @@ OverlayImpl::onManifests(
                 result = admission.disposition;
             }
 
-            if (!policy.consensusListed &&
+            auto const latestPolicy =
+                app_.validators().manifestPolicy(masterKey);
+            if (!policy.relayEligible() && latestPolicy.relayEligible() &&
                 (result == ManifestDisposition::accepted ||
                  result == ManifestDisposition::untrustedCapacity))
             {
-                auto const latestPolicy =
-                    app_.validators().manifestPolicy(masterKey);
-                if (latestPolicy.consensusListed)
-                {
-                    // Listing may have raced non-consensus admission. Replay
-                    // the already verified bytes as ordinary listed state.
-                    mo = deserializeManifest(serialized);
-                    XRPL_ASSERT(
-                        mo,
-                        "ripple::OverlayImpl::onManifests : manifest "
-                        "deserialization succeeded for policy reconciliation");
-
-                    auto const reconciled =
-                        app_.validatorManifests().applyManifest(
-                            std::move(*mo),
-                            ManifestRateLimitCapPolicy::Uncapped);
-
-                    if (result == ManifestDisposition::untrustedCapacity)
-                        result = reconciled;
-                    else if (
-                        reconciled != ManifestDisposition::accepted &&
-                        reconciled != ManifestDisposition::stale)
-                        result = reconciled;
-
-                    policy = latestPolicy;
-                }
+                // Protected membership may race bounded admission. Reapply the
+                // already parsed bytes so the retained high-water is promoted
+                // atomically by ManifestCache.
+                mo = deserializeManifest(serialized);
+                XRPL_ASSERT(
+                    mo,
+                    "ripple::OverlayImpl::onManifests : manifest "
+                    "deserialization succeeded for policy reconciliation");
+                auto const reconciled = app_.validatorManifests().applyManifest(
+                    std::move(*mo), ManifestRetention::protected_);
+                if (result == ManifestDisposition::untrustedCapacity)
+                    result = reconciled;
+                else if (
+                    reconciled != ManifestDisposition::accepted &&
+                    reconciled != ManifestDisposition::stale)
+                    result = reconciled;
             }
+            else if (policy.relayEligible() && !latestPolicy.relayEligible())
+            {
+                app_.validatorManifests().setRetention(
+                    masterKey, ManifestRetention::evictable);
+            }
+            policy = latestPolicy;
 
             if (result == ManifestDisposition::accepted)
             {
@@ -1307,128 +1271,95 @@ OverlayImpl::relay(
     return {};
 }
 
-std::shared_ptr<Message>
-OverlayImpl::getManifestsMessage()
+std::vector<std::shared_ptr<Message>>
+OverlayImpl::getManifestsMessages()
 {
     std::lock_guard g(manifestLock_);
 
     auto const seq = app_.validatorManifests().sequence();
-    auto const listingSeq = app_.validators().listingSequence();
-    auto const candidateSeq = app_.validators().publisherCandidateRevision();
-    if (seq != manifestListSeq_ || listingSeq != manifestListingSeq_ ||
-        candidateSeq != manifestCandidateSeq_)
+    if (seq != manifestListSeq_)
     {
         struct CachedManifest
         {
-            PublicKey masterKey;
             std::string serialized;
-            std::uint32_t sequence;
+            ManifestRetention retention;
         };
 
         std::vector<CachedManifest> cached;
         app_.validatorManifests().for_each_manifest(
             [&cached](std::size_t s) { cached.reserve(s); },
-            [&cached](Manifest const& manifest) {
-                cached.push_back(
-                    {manifest.masterKey,
-                     manifest.serialized,
-                     manifest.sequence});
+            [&cached](Manifest const& manifest, ManifestRetention retention) {
+                cached.push_back({manifest.serialized, retention});
             });
 
-        auto const candidateOverrides =
-            app_.validators().candidateManifestOverrides();
-        std::vector<CachedManifest> candidates;
-        hash_map<PublicKey, std::uint32_t> candidateSequences;
-        candidates.reserve(candidateOverrides.size());
-        for (auto const& manifest : candidateOverrides)
-        {
-            candidateSequences.emplace(manifest->masterKey, manifest->sequence);
-            candidates.push_back(
-                {manifest->masterKey,
-                 manifest->serialized,
-                 manifest->sequence});
-        }
-
-        hash_set<PublicKey> suppressedCandidates;
-        std::vector<CachedManifest const*> trusted;
-        std::vector<CachedManifest const*> untrusted;
+        std::vector<CachedManifest const*> protectedManifests;
+        std::vector<CachedManifest const*> evictableManifests;
         for (auto const& entry : cached)
         {
-            if (app_.validators().listed(entry.masterKey))
-            {
-                trusted.push_back(&entry);
-                suppressedCandidates.insert(entry.masterKey);
-            }
-            else if (auto const candidate =
-                         candidateSequences.find(entry.masterKey);
-                     candidate != candidateSequences.end())
-            {
-                if (candidate->second > entry.sequence)
-                    continue;
-                suppressedCandidates.insert(entry.masterKey);
-                untrusted.push_back(&entry);
-            }
+            if (entry.retention == ManifestRetention::protected_)
+                protectedManifests.push_back(&entry);
             else
-                untrusted.push_back(&entry);
+                evictableManifests.push_back(&entry);
         }
 
-        std::erase_if(candidates, [&](CachedManifest const& candidate) {
-            return suppressedCandidates.contains(candidate.masterKey);
-        });
+        std::shuffle(
+            protectedManifests.begin(),
+            protectedManifests.end(),
+            default_prng());
+        std::shuffle(
+            evictableManifests.begin(),
+            evictableManifests.end(),
+            default_prng());
 
-        std::shuffle(trusted.begin(), trusted.end(), default_prng());
-        std::shuffle(candidates.begin(), candidates.end(), default_prng());
-        std::shuffle(untrusted.begin(), untrusted.end(), default_prng());
-
+        manifestMessages_.clear();
         protocol::TMManifests tm;
-        tm.mutable_list()->Reserve(static_cast<int>(
-            trusted.size() + candidates.size() +
-            std::min(kMaxManifestsPerMessage, untrusted.size())));
-
-        auto addIfFits = [&tm](CachedManifest const& entry) {
-            if (static_cast<std::size_t>(tm.list_size()) >=
-                kMaxManifestEntriesPerMessage)
+        auto flush = [this, &tm]() {
+            if (tm.list_size() == 0)
                 return;
+            manifestMessages_.push_back(
+                std::make_shared<Message>(tm, protocol::mtMANIFESTS));
+            tm.Clear();
+        };
+        auto add = [this, &tm, &flush](CachedManifest const& entry) {
+            if (static_cast<std::size_t>(tm.list_size()) ==
+                kMaxManifestEntriesPerMessage)
+                flush();
 
             tm.add_list()->set_stobject(
                 entry.serialized.data(), entry.serialized.size());
             if (Message::messageSize(tm) > maximumManifestsMessageSize)
             {
                 tm.mutable_list()->RemoveLast();
-                return;
+                flush();
+
+                tm.add_list()->set_stobject(
+                    entry.serialized.data(), entry.serialized.size());
+                if (Message::messageSize(tm) > maximumManifestsMessageSize)
+                {
+                    tm.mutable_list()->RemoveLast();
+                    JLOG(journal_.warn())
+                        << "Manifest exceeds peer snapshot message limit";
+                }
             }
         };
 
-        // Listed validators are authoritative local policy and get first use
-        // of the snapshot byte budget. Unlisted manifests may use the
-        // remainder, but both sides must agree on one maximum frame size.
-        for (auto const* entry : trusted)
-            addIfFits(*entry);
+        // All protected entries are delivered across as many bounded frames as
+        // needed. This covers local, listed, and publisher-candidate sources
+        // without re-deriving provenance in the overlay.
+        // The bounded evictable population remains best-effort and sampled.
+        for (auto const* entry : protectedManifests)
+            add(*entry);
 
-        // Current signed-list candidates have no consensus weight, but their
-        // newer live manifests are a bounded, publisher-authorized transport
-        // class and are included ahead of arbitrary untrusted entries.
-        for (auto const& entry : candidates)
-            addIfFits(entry);
-
-        auto const take = std::min(kMaxManifestsPerMessage, untrusted.size());
+        auto const take =
+            std::min(kMaxManifestsPerMessage, evictableManifests.size());
         for (std::size_t i = 0; i < take; ++i)
-        {
-            addIfFits(*untrusted[i]);
-        }
-
-        manifestMessage_.reset();
-
-        if (tm.list_size() != 0)
-            manifestMessage_ =
-                std::make_shared<Message>(tm, protocol::mtMANIFESTS);
+            add(*evictableManifests[i]);
+        flush();
 
         manifestListSeq_ = seq;
-        manifestListingSeq_ = listingSeq;
-        manifestCandidateSeq_ = candidateSeq;
     }
 
-    return manifestMessage_;
+    return manifestMessages_;
 }
 
 void

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1264,29 +1264,47 @@ OverlayImpl::getManifestsMessage()
                     {manifest.masterKey, manifest.serialized, manifest.hash()});
             });
 
-        std::vector<CachedManifest const*> selected;
+        std::vector<CachedManifest const*> trusted;
         std::vector<CachedManifest const*> untrusted;
         for (auto const& entry : cached)
         {
             if (app_.validators().listed(entry.masterKey))
-                selected.push_back(&entry);
+                trusted.push_back(&entry);
             else
                 untrusted.push_back(&entry);
         }
 
-        auto const take = std::min(kMaxManifestsPerMessage, untrusted.size());
-        selected.insert(
-            selected.end(), untrusted.begin(), untrusted.begin() + take);
-        std::shuffle(selected.begin(), selected.end(), default_prng());
+        std::shuffle(trusted.begin(), trusted.end(), default_prng());
+        std::shuffle(untrusted.begin(), untrusted.end(), default_prng());
 
         protocol::TMManifests tm;
         auto& hashRouter = app_.getHashRouter();
-        tm.mutable_list()->Reserve(static_cast<int>(selected.size()));
-        for (auto const* entry : selected)
-        {
+        tm.mutable_list()->Reserve(
+            static_cast<int>(
+                trusted.size() +
+                std::min(kMaxManifestsPerMessage, untrusted.size())));
+
+        auto addIfFits = [&tm, &hashRouter](CachedManifest const& entry) {
             tm.add_list()->set_stobject(
-                entry->serialized.data(), entry->serialized.size());
-            hashRouter.addSuppression(entry->hash);
+                entry.serialized.data(), entry.serialized.size());
+            if (Message::messageSize(tm) > maximumManifestsMessageSize)
+            {
+                tm.mutable_list()->RemoveLast();
+                return;
+            }
+            hashRouter.addSuppression(entry.hash);
+        };
+
+        // Listed validators are authoritative local policy and get first use
+        // of the snapshot byte budget. Unlisted manifests may use the
+        // remainder, but both sides must agree on one maximum frame size.
+        for (auto const* entry : trusted)
+            addIfFits(*entry);
+
+        auto const take = std::min(kMaxManifestsPerMessage, untrusted.size());
+        for (std::size_t i = 0; i < take; ++i)
+        {
+            addIfFits(*untrusted[i]);
         }
 
         manifestMessage_.reset();

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1279,10 +1279,9 @@ OverlayImpl::getManifestsMessage()
 
         protocol::TMManifests tm;
         auto& hashRouter = app_.getHashRouter();
-        tm.mutable_list()->Reserve(
-            static_cast<int>(
-                trusted.size() +
-                std::min(kMaxManifestsPerMessage, untrusted.size())));
+        tm.mutable_list()->Reserve(static_cast<int>(
+            trusted.size() +
+            std::min(kMaxManifestsPerMessage, untrusted.size())));
 
         auto addIfFits = [&tm, &hashRouter](CachedManifest const& entry) {
             tm.add_list()->set_stobject(

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -654,7 +654,6 @@ OverlayImpl::onManifests(
         app_.getValidations().getCurrentNodeKeys();
 
     protocol::TMManifests relay;
-    std::optional<std::set<HashRouter::PeerShortID>> relaySkip;
 
     for (std::size_t i = 0; i < total; ++i)
     {
@@ -664,7 +663,6 @@ OverlayImpl::onManifests(
         {
             auto const serialized = mo->serialized;
             auto const masterKey = mo->masterKey;
-            auto const manifestHash = mo->hash();
 
             bool isTrusted = app_.validators().listed(masterKey);
             if (!isTrusted)
@@ -677,11 +675,21 @@ OverlayImpl::onManifests(
                 ++untrusted;
             }
 
-            auto result = isTrusted
-                ? app_.validatorManifests().applyManifest(
-                      std::move(*mo), ManifestRateLimitCapPolicy::Uncapped)
-                : app_.validatorManifests().applyManifestWithEviction(
-                      std::move(*mo), currentValidationKeys);
+            bool acceptedUpdate = false;
+            ManifestDisposition result;
+            if (isTrusted)
+            {
+                result = app_.validatorManifests().applyManifest(
+                    std::move(*mo), ManifestRateLimitCapPolicy::Uncapped);
+            }
+            else
+            {
+                auto const admission =
+                    app_.validatorManifests().applyManifestWithEviction(
+                        std::move(*mo), currentValidationKeys);
+                acceptedUpdate = admission.acceptedUpdate;
+                result = admission.disposition;
+            }
 
             if (!isTrusted &&
                 (result == ManifestDisposition::accepted ||
@@ -724,27 +732,13 @@ OverlayImpl::onManifests(
 
                 app_.getOPs().pubManifest(*mo);
 
-                // Acceptance is relative to the retention cache. Eviction can
-                // make the same manifest acceptable again, so relay novelty
-                // must be tracked independently. Record the source before
-                // asking HashRouter whether this node should relay it.
-                auto& hashRouter = app_.getHashRouter();
-                hashRouter.addSuppressionPeer(manifestHash, from->id());
-                if (auto toSkip = hashRouter.shouldRelay(manifestHash))
-                {
+                // Do not live-relay a first-seen unlisted identity. Retained
+                // identities may relay later rotations and revocations, while
+                // listed identities always relay. If eviction later forgets
+                // this identity, a reappearance is first-seen again and stops
+                // locally instead of producing an immediate relay loop.
+                if (isTrusted || acceptedUpdate)
                     relay.add_list()->set_stobject(s);
-
-                    if (!relaySkip)
-                    {
-                        relaySkip = std::move(*toSkip);
-                    }
-                    else
-                    {
-                        std::erase_if(*relaySkip, [&toSkip](auto const peer) {
-                            return !toSkip->contains(peer);
-                        });
-                    }
-                }
 
                 if (isTrusted)
                 {
@@ -772,16 +766,11 @@ OverlayImpl::onManifests(
     }
 
     if (!relay.list().empty())
-    {
-        XRPL_ASSERT(
-            relaySkip,
-            "ripple::OverlayImpl::onManifests : relay suppression state");
         for_each([m2 = std::make_shared<Message>(relay, protocol::mtMANIFESTS),
-                  &relaySkip](std::shared_ptr<PeerImp>&& p) {
-            if (!relaySkip->contains(p->id()))
+                  source = from->id()](std::shared_ptr<PeerImp>&& p) {
+            if (p->id() != source)
                 p->send(m2);
         });
-    }
 }
 
 void
@@ -1293,15 +1282,13 @@ OverlayImpl::getManifestsMessage()
         {
             PublicKey masterKey;
             std::string serialized;
-            uint256 hash;
         };
 
         std::vector<CachedManifest> cached;
         app_.validatorManifests().for_each_manifest(
             [&cached](std::size_t s) { cached.reserve(s); },
             [&cached](Manifest const& manifest) {
-                cached.push_back(
-                    {manifest.masterKey, manifest.serialized, manifest.hash()});
+                cached.push_back({manifest.masterKey, manifest.serialized});
             });
 
         std::vector<CachedManifest const*> trusted;
@@ -1318,12 +1305,11 @@ OverlayImpl::getManifestsMessage()
         std::shuffle(untrusted.begin(), untrusted.end(), default_prng());
 
         protocol::TMManifests tm;
-        auto& hashRouter = app_.getHashRouter();
         tm.mutable_list()->Reserve(static_cast<int>(
             trusted.size() +
             std::min(kMaxManifestsPerMessage, untrusted.size())));
 
-        auto addIfFits = [&tm, &hashRouter](CachedManifest const& entry) {
+        auto addIfFits = [&tm](CachedManifest const& entry) {
             if (static_cast<std::size_t>(tm.list_size()) >=
                 kMaxManifestEntriesPerMessage)
                 return;
@@ -1335,7 +1321,6 @@ OverlayImpl::getManifestsMessage()
                 tm.mutable_list()->RemoveLast();
                 return;
             }
-            hashRouter.addSuppression(entry.hash);
         };
 
         // Listed validators are authoritative local policy and get first use

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -36,6 +36,7 @@
 #include <xrpl/basics/random.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/protocol/STTx.h>
+#include <xrpl/resource/Fees.h>
 #include <xrpl/server/SimpleWriter.h>
 
 #include <xrpld/core/ConfigSections.h>
@@ -633,12 +634,15 @@ OverlayImpl::onManifests(
     std::shared_ptr<protocol::TMManifests> const& m,
     std::shared_ptr<PeerImp> const& from)
 {
-    auto const n = m->list_size();
     auto const& journal = from->pjournal();
+
+    auto const total = static_cast<std::size_t>(m->list_size());
+    std::size_t untrusted = 0;
+    bool skippedUntrusted = false;
 
     protocol::TMManifests relay;
 
-    for (std::size_t i = 0; i < n; ++i)
+    for (std::size_t i = 0; i < total; ++i)
     {
         auto& s = m->list().Get(i).stobject();
 
@@ -646,13 +650,28 @@ OverlayImpl::onManifests(
         {
             auto const serialized = mo->serialized;
 
-            auto const result =
-                app_.validatorManifests().applyManifest(std::move(*mo));
+            bool const isTrusted = app_.validators().listed(mo->masterKey);
+            if (!isTrusted)
+            {
+                if (untrusted >= kMaxManifestsPerMessage)
+                {
+                    skippedUntrusted = true;
+                    continue;
+                }
+                ++untrusted;
+            }
+
+            bool const isKnown = app_.validatorManifests()
+                                     .getSequence(mo->masterKey)
+                                     .has_value();
+
+            auto const result = app_.validatorManifests().applyManifest(
+                std::move(*mo),
+                isTrusted ? ManifestRateLimitCapPolicy::Uncapped
+                          : ManifestRateLimitCapPolicy::Capped);
 
             if (result == ManifestDisposition::accepted)
             {
-                relay.add_list()->set_stobject(s);
-
                 // N.B.: this is important; the applyManifest call above moves
                 //       the loaded Manifest out of the optional so we need to
                 //       reload it here.
@@ -664,10 +683,15 @@ OverlayImpl::onManifests(
 
                 app_.getOPs().pubManifest(*mo);
 
-                if (app_.validators().listed(mo->masterKey))
+                if (isTrusted || isKnown)
                 {
-                    auto db = app_.getWalletDB().checkoutDb();
-                    addValidatorManifest(*db, serialized);
+                    relay.add_list()->set_stobject(s);
+
+                    if (isTrusted)
+                    {
+                        auto db = app_.getWalletDB().checkoutDb();
+                        addValidatorManifest(*db, serialized);
+                    }
                 }
             }
         }
@@ -677,6 +701,16 @@ OverlayImpl::onManifests(
                 << "Malformed manifest #" << i + 1 << ": " << strHex(s);
             continue;
         }
+    }
+
+    if (skippedUntrusted)
+    {
+        from->charge(
+            Resource::feeMalformedRequest, "too many untrusted manifests");
+        JLOG(journal.warn())
+            << "Manifests: message had " << total
+            << " entries; processed all trusted plus the first "
+            << kMaxManifestsPerMessage << " untrusted";
     }
 
     if (!relay.list().empty())
@@ -1188,15 +1222,45 @@ OverlayImpl::getManifestsMessage()
     if (auto seq = app_.validatorManifests().sequence();
         seq != manifestListSeq_)
     {
-        protocol::TMManifests tm;
+        struct CachedManifest
+        {
+            PublicKey masterKey;
+            std::string serialized;
+            uint256 hash;
+        };
 
+        std::vector<CachedManifest> cached;
         app_.validatorManifests().for_each_manifest(
-            [&tm](std::size_t s) { tm.mutable_list()->Reserve(s); },
-            [&tm, &hr = app_.getHashRouter()](Manifest const& manifest) {
-                tm.add_list()->set_stobject(
-                    manifest.serialized.data(), manifest.serialized.size());
-                hr.addSuppression(manifest.hash());
+            [&cached](std::size_t s) { cached.reserve(s); },
+            [&cached](Manifest const& manifest) {
+                cached.push_back(
+                    {manifest.masterKey, manifest.serialized, manifest.hash()});
             });
+
+        std::vector<CachedManifest const*> selected;
+        std::vector<CachedManifest const*> untrusted;
+        for (auto const& entry : cached)
+        {
+            if (app_.validators().listed(entry.masterKey))
+                selected.push_back(&entry);
+            else
+                untrusted.push_back(&entry);
+        }
+
+        auto const take = std::min(kMaxManifestsPerMessage, untrusted.size());
+        selected.insert(
+            selected.end(), untrusted.begin(), untrusted.begin() + take);
+        std::shuffle(selected.begin(), selected.end(), default_prng());
+
+        protocol::TMManifests tm;
+        auto& hashRouter = app_.getHashRouter();
+        tm.mutable_list()->Reserve(static_cast<int>(selected.size()));
+        for (auto const* entry : selected)
+        {
+            tm.add_list()->set_stobject(
+                entry->serialized.data(), entry->serialized.size());
+            hashRouter.addSuppression(entry->hash);
+        }
 
         manifestMessage_.reset();
 

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -650,9 +650,6 @@ OverlayImpl::onManifests(
 
     std::size_t untrusted = 0;
     bool skippedUntrusted = false;
-    auto const currentValidationKeys =
-        app_.getValidations().getCurrentNodeKeys();
-
     protocol::TMManifests relay;
 
     for (std::size_t i = 0; i < total; ++i)
@@ -686,7 +683,7 @@ OverlayImpl::onManifests(
             {
                 auto const admission =
                     app_.validatorManifests().applyManifestWithEviction(
-                        std::move(*mo), currentValidationKeys);
+                        std::move(*mo));
                 acceptedUpdate = admission.acceptedUpdate;
                 result = admission.disposition;
             }
@@ -1279,28 +1276,20 @@ OverlayImpl::getManifestsMessages()
     auto const seq = app_.validatorManifests().sequence();
     if (seq != manifestListSeq_)
     {
-        struct CachedManifest
-        {
-            std::string serialized;
-            ManifestRetention retention;
-        };
-
-        std::vector<CachedManifest> cached;
+        std::vector<std::string> protectedManifests;
+        std::vector<std::string> evictableManifests;
         app_.validatorManifests().for_each_manifest(
-            [&cached](std::size_t s) { cached.reserve(s); },
-            [&cached](Manifest const& manifest, ManifestRetention retention) {
-                cached.push_back({manifest.serialized, retention});
+            [&protectedManifests, &evictableManifests](std::size_t s) {
+                protectedManifests.reserve(s);
+                evictableManifests.reserve(s);
+            },
+            [&protectedManifests, &evictableManifests](
+                Manifest const& manifest, ManifestRetention retention) {
+                auto& entries = retention == ManifestRetention::protected_
+                    ? protectedManifests
+                    : evictableManifests;
+                entries.push_back(manifest.serialized);
             });
-
-        std::vector<CachedManifest const*> protectedManifests;
-        std::vector<CachedManifest const*> evictableManifests;
-        for (auto const& entry : cached)
-        {
-            if (entry.retention == ManifestRetention::protected_)
-                protectedManifests.push_back(&entry);
-            else
-                evictableManifests.push_back(&entry);
-        }
 
         std::shuffle(
             protectedManifests.begin(),
@@ -1320,20 +1309,19 @@ OverlayImpl::getManifestsMessages()
                 std::make_shared<Message>(tm, protocol::mtMANIFESTS));
             tm.Clear();
         };
-        auto add = [this, &tm, &flush](CachedManifest const& entry) {
+        auto add = [this, &tm, &flush](std::string const& serialized) {
             if (static_cast<std::size_t>(tm.list_size()) ==
                 kMaxManifestEntriesPerMessage)
                 flush();
 
-            tm.add_list()->set_stobject(
-                entry.serialized.data(), entry.serialized.size());
+            tm.add_list()->set_stobject(serialized.data(), serialized.size());
             if (Message::messageSize(tm) > maximumManifestsMessageSize)
             {
                 tm.mutable_list()->RemoveLast();
                 flush();
 
                 tm.add_list()->set_stobject(
-                    entry.serialized.data(), entry.serialized.size());
+                    serialized.data(), serialized.size());
                 if (Message::messageSize(tm) > maximumManifestsMessageSize)
                 {
                     tm.mutable_list()->RemoveLast();
@@ -1347,13 +1335,13 @@ OverlayImpl::getManifestsMessages()
         // needed. This covers local, listed, and publisher-candidate sources
         // without re-deriving provenance in the overlay.
         // The bounded evictable population remains best-effort and sampled.
-        for (auto const* entry : protectedManifests)
-            add(*entry);
+        for (auto const& entry : protectedManifests)
+            add(entry);
 
         auto const take =
             std::min(kMaxManifestsPerMessage, evictableManifests.size());
         for (std::size_t i = 0; i < take; ++i)
-            add(*evictableManifests[i]);
+            add(evictableManifests[i]);
         flush();
 
         manifestListSeq_ = seq;

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -683,7 +683,9 @@ OverlayImpl::onManifests(
             {
                 auto const admission =
                     app_.validatorManifests().applyManifestWithEviction(
-                        std::move(*mo));
+                        std::move(*mo), [this] {
+                            return app_.getValidations().getCurrentNodeKeys();
+                        });
                 acceptedUpdate = admission.acceptedUpdate;
                 result = admission.disposition;
             }

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -664,8 +664,8 @@ OverlayImpl::onManifests(
             auto const serialized = mo->serialized;
             auto const masterKey = mo->masterKey;
 
-            bool isTrusted = app_.validators().listed(masterKey);
-            if (!isTrusted)
+            auto policy = app_.validators().manifestPolicy(masterKey);
+            if (!policy.relayEligible())
             {
                 if (untrusted >= kMaxManifestsPerMessage)
                 {
@@ -677,10 +677,44 @@ OverlayImpl::onManifests(
 
             bool acceptedUpdate = false;
             ManifestDisposition result;
-            if (isTrusted)
+            if (policy.consensusListed)
             {
                 result = app_.validatorManifests().applyManifest(
                     std::move(*mo), ManifestRateLimitCapPolicy::Uncapped);
+            }
+            else if (policy.publisherCandidate)
+            {
+                auto const candidateResult =
+                    app_.validators().applyCandidateManifest(std::move(*mo));
+                if (candidateResult)
+                {
+                    result = *candidateResult;
+                }
+                else
+                {
+                    // Candidate membership changed after classification.
+                    // Reclassify the same bytes under the current policy.
+                    policy = app_.validators().manifestPolicy(masterKey);
+                    mo = deserializeManifest(serialized);
+                    XRPL_ASSERT(
+                        mo,
+                        "ripple::OverlayImpl::onManifests : manifest "
+                        "deserialization succeeded for policy reconciliation");
+                    if (policy.consensusListed)
+                    {
+                        result = app_.validatorManifests().applyManifest(
+                            std::move(*mo),
+                            ManifestRateLimitCapPolicy::Uncapped);
+                    }
+                    else
+                    {
+                        auto const admission =
+                            app_.validatorManifests().applyManifestWithEviction(
+                                std::move(*mo), currentValidationKeys);
+                        acceptedUpdate = admission.acceptedUpdate;
+                        result = admission.disposition;
+                    }
+                }
             }
             else
             {
@@ -691,32 +725,36 @@ OverlayImpl::onManifests(
                 result = admission.disposition;
             }
 
-            if (!isTrusted &&
+            if (!policy.consensusListed &&
                 (result == ManifestDisposition::accepted ||
-                 result == ManifestDisposition::untrustedCapacity) &&
-                app_.validators().listed(masterKey))
+                 result == ManifestDisposition::untrustedCapacity))
             {
-                // Listing may have raced capped admission. An uncapped stale
-                // application promotes the retained entry under the cache
-                // write lock; if eviction already won, it inserts this saved,
-                // previously validated manifest instead.
-                mo = deserializeManifest(serialized);
-                XRPL_ASSERT(
-                    mo,
-                    "ripple::OverlayImpl::onManifests : manifest "
-                    "deserialization succeeded for trusted reconciliation");
-                auto const trustedResult =
-                    app_.validatorManifests().applyManifest(
-                        std::move(*mo), ManifestRateLimitCapPolicy::Uncapped);
+                auto const latestPolicy =
+                    app_.validators().manifestPolicy(masterKey);
+                if (latestPolicy.consensusListed)
+                {
+                    // Listing may have raced non-consensus admission. Replay
+                    // the already verified bytes as ordinary listed state.
+                    mo = deserializeManifest(serialized);
+                    XRPL_ASSERT(
+                        mo,
+                        "ripple::OverlayImpl::onManifests : manifest "
+                        "deserialization succeeded for policy reconciliation");
 
-                if (result == ManifestDisposition::untrustedCapacity)
-                    result = trustedResult;
-                else if (
-                    trustedResult != ManifestDisposition::accepted &&
-                    trustedResult != ManifestDisposition::stale)
-                    result = trustedResult;
+                    auto const reconciled =
+                        app_.validatorManifests().applyManifest(
+                            std::move(*mo),
+                            ManifestRateLimitCapPolicy::Uncapped);
 
-                isTrusted = true;
+                    if (result == ManifestDisposition::untrustedCapacity)
+                        result = reconciled;
+                    else if (
+                        reconciled != ManifestDisposition::accepted &&
+                        reconciled != ManifestDisposition::stale)
+                        result = reconciled;
+
+                    policy = latestPolicy;
+                }
             }
 
             if (result == ManifestDisposition::accepted)
@@ -737,10 +775,10 @@ OverlayImpl::onManifests(
                 // listed identities always relay. If eviction later forgets
                 // this identity, a reappearance is first-seen again and stops
                 // locally instead of producing an immediate relay loop.
-                if (isTrusted || acceptedUpdate)
+                if (policy.relayEligible() || acceptedUpdate)
                     relay.add_list()->set_stobject(s);
 
-                if (isTrusted)
+                if (policy.consensusListed)
                 {
                     auto db = app_.getWalletDB().checkoutDb();
                     addValidatorManifest(*db, serialized);
@@ -1276,37 +1314,75 @@ OverlayImpl::getManifestsMessage()
 
     auto const seq = app_.validatorManifests().sequence();
     auto const listingSeq = app_.validators().listingSequence();
-    if (seq != manifestListSeq_ || listingSeq != manifestListingSeq_)
+    auto const candidateSeq = app_.validators().publisherCandidateRevision();
+    if (seq != manifestListSeq_ || listingSeq != manifestListingSeq_ ||
+        candidateSeq != manifestCandidateSeq_)
     {
         struct CachedManifest
         {
             PublicKey masterKey;
             std::string serialized;
+            std::uint32_t sequence;
         };
 
         std::vector<CachedManifest> cached;
         app_.validatorManifests().for_each_manifest(
             [&cached](std::size_t s) { cached.reserve(s); },
             [&cached](Manifest const& manifest) {
-                cached.push_back({manifest.masterKey, manifest.serialized});
+                cached.push_back(
+                    {manifest.masterKey,
+                     manifest.serialized,
+                     manifest.sequence});
             });
 
+        auto const candidateOverrides =
+            app_.validators().candidateManifestOverrides();
+        std::vector<CachedManifest> candidates;
+        hash_map<PublicKey, std::uint32_t> candidateSequences;
+        candidates.reserve(candidateOverrides.size());
+        for (auto const& manifest : candidateOverrides)
+        {
+            candidateSequences.emplace(manifest->masterKey, manifest->sequence);
+            candidates.push_back(
+                {manifest->masterKey,
+                 manifest->serialized,
+                 manifest->sequence});
+        }
+
+        hash_set<PublicKey> suppressedCandidates;
         std::vector<CachedManifest const*> trusted;
         std::vector<CachedManifest const*> untrusted;
         for (auto const& entry : cached)
         {
             if (app_.validators().listed(entry.masterKey))
+            {
                 trusted.push_back(&entry);
+                suppressedCandidates.insert(entry.masterKey);
+            }
+            else if (auto const candidate =
+                         candidateSequences.find(entry.masterKey);
+                     candidate != candidateSequences.end())
+            {
+                if (candidate->second > entry.sequence)
+                    continue;
+                suppressedCandidates.insert(entry.masterKey);
+                untrusted.push_back(&entry);
+            }
             else
                 untrusted.push_back(&entry);
         }
 
+        std::erase_if(candidates, [&](CachedManifest const& candidate) {
+            return suppressedCandidates.contains(candidate.masterKey);
+        });
+
         std::shuffle(trusted.begin(), trusted.end(), default_prng());
+        std::shuffle(candidates.begin(), candidates.end(), default_prng());
         std::shuffle(untrusted.begin(), untrusted.end(), default_prng());
 
         protocol::TMManifests tm;
         tm.mutable_list()->Reserve(static_cast<int>(
-            trusted.size() +
+            trusted.size() + candidates.size() +
             std::min(kMaxManifestsPerMessage, untrusted.size())));
 
         auto addIfFits = [&tm](CachedManifest const& entry) {
@@ -1329,6 +1405,12 @@ OverlayImpl::getManifestsMessage()
         for (auto const* entry : trusted)
             addIfFits(*entry);
 
+        // Current signed-list candidates have no consensus weight, but their
+        // newer live manifests are a bounded, publisher-authorized transport
+        // class and are included ahead of arbitrary untrusted entries.
+        for (auto const& entry : candidates)
+            addIfFits(entry);
+
         auto const take = std::min(kMaxManifestsPerMessage, untrusted.size());
         for (std::size_t i = 0; i < take; ++i)
         {
@@ -1343,6 +1425,7 @@ OverlayImpl::getManifestsMessage()
 
         manifestListSeq_ = seq;
         manifestListingSeq_ = listingSeq;
+        manifestCandidateSeq_ = candidateSeq;
     }
 
     return manifestMessage_;

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -130,6 +130,8 @@ private:
     std::optional<std::uint32_t> manifestListSeq_;
     // Listed-key policy also affects which manifests receive snapshot priority
     std::optional<std::uint64_t> manifestListingSeq_;
+    // Current publisher-candidate overrides are included in peer snapshots.
+    std::optional<std::uint64_t> manifestCandidateSeq_;
     // Protects the message and the sequence list of manifests
     std::mutex manifestLock_;
 

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -128,6 +128,8 @@ private:
     std::shared_ptr<Message> manifestMessage_;
     // Used to track whether we need to update the cached list of manifests
     std::optional<std::uint32_t> manifestListSeq_;
+    // Listed-key policy also affects which manifests receive snapshot priority
+    std::optional<std::uint64_t> manifestListingSeq_;
     // Protects the message and the sequence list of manifests
     std::mutex manifestLock_;
 

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -49,6 +49,7 @@
 #include <mutex>
 #include <optional>
 #include <unordered_map>
+#include <vector>
 
 namespace ripple {
 
@@ -124,15 +125,11 @@ private:
     // Transaction reduce-relay metrics
     metrics::TxMetrics txMetrics_;
 
-    // A message with the list of manifests we send to peers
-    std::shared_ptr<Message> manifestMessage_;
+    // Bounded messages containing the manifest snapshot sent to new peers.
+    std::vector<std::shared_ptr<Message>> manifestMessages_;
     // Used to track whether we need to update the cached list of manifests
     std::optional<std::uint32_t> manifestListSeq_;
-    // Listed-key policy also affects which manifests receive snapshot priority
-    std::optional<std::uint64_t> manifestListingSeq_;
-    // Current publisher-candidate overrides are included in peer snapshots.
-    std::optional<std::uint64_t> manifestCandidateSeq_;
-    // Protects the message and the sequence list of manifests
+    // Protects the messages and the sequence list of manifests
     std::mutex manifestLock_;
 
     //--------------------------------------------------------------------------
@@ -245,8 +242,8 @@ public:
         std::optional<std::reference_wrapper<protocol::TMTransaction>> m,
         std::set<Peer::id_t> const& skip) override;
 
-    std::shared_ptr<Message>
-    getManifestsMessage();
+    std::vector<std::shared_ptr<Message>>
+    getManifestsMessages();
 
     //--------------------------------------------------------------------------
     //

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -1061,6 +1061,10 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
     if (s > 100)
         fee_.update(Resource::feeModerateBurdenPeer, "oversize");
 
+    // TODO(manifest): Charge proportionally to entry/signature-verification
+    // work. Repeated frames of up to 100 manifests currently incur only the
+    // trivial per-message peer charge.
+
     // OverlayImpl bounds untrusted work and charges if the cap is exceeded;
     // trusted manifests are always processed and do not count against it.
     app_.getJobQueue().addJob(

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -24,6 +24,7 @@
 #include <xrpld/app/ledger/TransactionMaster.h>
 #include <xrpld/app/misc/HashRouter.h>
 #include <xrpld/app/misc/LoadFeeTrack.h>
+#include <xrpld/app/misc/Manifest.h>
 #include <xrpld/app/misc/NetworkOPs.h>
 #include <xrpld/app/misc/Transaction.h>
 #include <xrpld/app/misc/ValidatorList.h>
@@ -1060,6 +1061,8 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
     if (s > 100)
         fee_.update(Resource::feeModerateBurdenPeer, "oversize");
 
+    // OverlayImpl bounds untrusted work and charges if the cap is exceeded;
+    // trusted manifests are always processed and do not count against it.
     app_.getJobQueue().addJob(
         jtMANIFEST, "receiveManifests", [this, that = shared_from_this(), m]() {
             overlay_.onManifests(m, that);

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -871,7 +871,7 @@ PeerImp::doProtocolStart()
             });
     }
 
-    if (auto m = overlay_.getManifestsMessage())
+    for (auto const& m : overlay_.getManifestsMessages())
         send(m);
 
     setTimer();

--- a/src/xrpld/overlay/detail/ProtocolMessage.h
+++ b/src/xrpld/overlay/detail/ProtocolMessage.h
@@ -382,6 +382,15 @@ invokeProtocolMessage(
         return result;
     }
 
+    // Drop an oversized TMManifests without penalizing an unpatched peer.
+    if (header->message_type == protocol::mtMANIFESTS &&
+        (header->payload_wire_size > maximumManifestsMessageSize ||
+         header->uncompressed_size > maximumManifestsMessageSize))
+    {
+        result.first = header->total_wire_size;
+        return result;
+    }
+
     bool success;
 
     switch (header->message_type)

--- a/src/xrpld/rpc/handlers/Manifest.cpp
+++ b/src/xrpld/rpc/handlers/Manifest.cpp
@@ -18,12 +18,16 @@
 //==============================================================================
 
 #include <xrpld/app/main/Application.h>
+#include <xrpld/app/misc/ValidatorList.h>
 #include <xrpld/rpc/Context.h>
 #include <xrpl/basics/base64.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/jss.h>
+
+#include <algorithm>
+#include <vector>
 
 namespace ripple {
 Json::Value
@@ -46,29 +50,72 @@ doManifest(RPC::JsonContext& context)
         return ret;
     }
 
-    // first attempt to use params as ephemeral key,
-    // if this lookup succeeds master key will be returned,
-    // else an unseated optional is returned
-    auto const mk = context.app.validatorManifests().getMasterKey(*pk);
+    auto identity = context.app.validators().resolveMonitoringSigner(*pk);
+    if (identity.status == ValidatorIdentityStatus::unknown)
+        identity = context.app.validators().lookupMonitoringIdentity(*pk);
 
-    auto const ek = context.app.validatorManifests().getSigningKey(mk);
-
-    // if ephemeral key not found, we don't have specified manifest
-    if (!ek)
+    auto statusName = [](ValidatorIdentityStatus status) -> char const* {
+        switch (status)
+        {
+            case ValidatorIdentityStatus::resolved:
+                return "resolved";
+            case ValidatorIdentityStatus::revoked:
+                return "revoked";
+            case ValidatorIdentityStatus::conflict:
+                return "conflict";
+            case ValidatorIdentityStatus::unstable:
+                return "unstable";
+            case ValidatorIdentityStatus::unknown:
+                return "unknown";
+        }
+        return "unknown";
+    };
+    ret["monitoring_status"] = statusName(identity.status);
+    if (identity.status == ValidatorIdentityStatus::unknown ||
+        identity.status == ValidatorIdentityStatus::unstable)
         return ret;
 
-    if (auto const manifest = context.app.validatorManifests().getManifest(mk))
-        ret[jss::manifest] = base64_encode(*manifest);
+    if (identity.manifest)
+        ret[jss::manifest] = base64_encode(identity.manifest->serialized);
     Json::Value details;
 
-    details[jss::master_key] = toBase58(TokenType::NodePublic, mk);
-    details[jss::ephemeral_key] = toBase58(TokenType::NodePublic, *ek);
+    if (identity.master)
+        details[jss::master_key] =
+            toBase58(TokenType::NodePublic, *identity.master);
+    if (identity.signing)
+        details[jss::ephemeral_key] =
+            toBase58(TokenType::NodePublic, *identity.signing);
 
-    if (auto const seq = context.app.validatorManifests().getSequence(mk))
-        details[jss::seq] = *seq;
+    if (identity.manifest)
+    {
+        details[jss::seq] = identity.manifest->sequence;
+        if (!identity.manifest->domain.empty())
+            details[jss::domain] = identity.manifest->domain;
+    }
 
-    if (auto const domain = context.app.validatorManifests().getDomain(mk))
-        details[jss::domain] = *domain;
+    details["ordinary_state"] = identity.presentInOrdinaryState;
+
+    auto appendPublishers = [&](char const* field,
+                                hash_set<PublicKey> const& publishers) {
+        if (publishers.empty())
+            return;
+        auto& array = details[field] = Json::arrayValue;
+        std::vector<PublicKey> ordered{publishers.begin(), publishers.end()};
+        std::sort(ordered.begin(), ordered.end());
+        for (auto const& publisher : ordered)
+            array.append(strHex(publisher));
+    };
+    appendPublishers(
+        "candidate_identity_publishers", identity.candidateIdentityPublishers);
+    appendPublishers(
+        "candidate_manifest_publishers", identity.candidateManifestPublishers);
+
+    if (!identity.conflictingMasters.empty())
+    {
+        auto& conflicts = details["conflicting_masters"] = Json::arrayValue;
+        for (auto const& master : identity.conflictingMasters)
+            conflicts.append(toBase58(TokenType::NodePublic, master));
+    }
 
     ret[jss::details] = details;
     return ret;

--- a/src/xrpld/rpc/handlers/Manifest.cpp
+++ b/src/xrpld/rpc/handlers/Manifest.cpp
@@ -18,16 +18,12 @@
 //==============================================================================
 
 #include <xrpld/app/main/Application.h>
-#include <xrpld/app/misc/ValidatorList.h>
 #include <xrpld/rpc/Context.h>
 #include <xrpl/basics/base64.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/jss.h>
-
-#include <algorithm>
-#include <vector>
 
 namespace ripple {
 Json::Value
@@ -50,72 +46,29 @@ doManifest(RPC::JsonContext& context)
         return ret;
     }
 
-    auto identity = context.app.validators().resolveMonitoringSigner(*pk);
-    if (identity.status == ValidatorIdentityStatus::unknown)
-        identity = context.app.validators().lookupMonitoringIdentity(*pk);
+    // first attempt to use params as ephemeral key,
+    // if this lookup succeeds master key will be returned,
+    // else an unseated optional is returned
+    auto const mk = context.app.validatorManifests().getMasterKey(*pk);
 
-    auto statusName = [](ValidatorIdentityStatus status) -> char const* {
-        switch (status)
-        {
-            case ValidatorIdentityStatus::resolved:
-                return "resolved";
-            case ValidatorIdentityStatus::revoked:
-                return "revoked";
-            case ValidatorIdentityStatus::conflict:
-                return "conflict";
-            case ValidatorIdentityStatus::unstable:
-                return "unstable";
-            case ValidatorIdentityStatus::unknown:
-                return "unknown";
-        }
-        return "unknown";
-    };
-    ret["monitoring_status"] = statusName(identity.status);
-    if (identity.status == ValidatorIdentityStatus::unknown ||
-        identity.status == ValidatorIdentityStatus::unstable)
+    auto const ek = context.app.validatorManifests().getSigningKey(mk);
+
+    // if ephemeral key not found, we don't have specified manifest
+    if (!ek)
         return ret;
 
-    if (identity.manifest)
-        ret[jss::manifest] = base64_encode(identity.manifest->serialized);
+    if (auto const manifest = context.app.validatorManifests().getManifest(mk))
+        ret[jss::manifest] = base64_encode(*manifest);
     Json::Value details;
 
-    if (identity.master)
-        details[jss::master_key] =
-            toBase58(TokenType::NodePublic, *identity.master);
-    if (identity.signing)
-        details[jss::ephemeral_key] =
-            toBase58(TokenType::NodePublic, *identity.signing);
+    details[jss::master_key] = toBase58(TokenType::NodePublic, mk);
+    details[jss::ephemeral_key] = toBase58(TokenType::NodePublic, *ek);
 
-    if (identity.manifest)
-    {
-        details[jss::seq] = identity.manifest->sequence;
-        if (!identity.manifest->domain.empty())
-            details[jss::domain] = identity.manifest->domain;
-    }
+    if (auto const seq = context.app.validatorManifests().getSequence(mk))
+        details[jss::seq] = *seq;
 
-    details["ordinary_state"] = identity.presentInOrdinaryState;
-
-    auto appendPublishers = [&](char const* field,
-                                hash_set<PublicKey> const& publishers) {
-        if (publishers.empty())
-            return;
-        auto& array = details[field] = Json::arrayValue;
-        std::vector<PublicKey> ordered{publishers.begin(), publishers.end()};
-        std::sort(ordered.begin(), ordered.end());
-        for (auto const& publisher : ordered)
-            array.append(strHex(publisher));
-    };
-    appendPublishers(
-        "candidate_identity_publishers", identity.candidateIdentityPublishers);
-    appendPublishers(
-        "candidate_manifest_publishers", identity.candidateManifestPublishers);
-
-    if (!identity.conflictingMasters.empty())
-    {
-        auto& conflicts = details["conflicting_masters"] = Json::arrayValue;
-        for (auto const& master : identity.conflictingMasters)
-            conflicts.append(toBase58(TokenType::NodePublic, master));
-    }
+    if (auto const domain = context.app.validatorManifests().getDomain(mk))
+        details[jss::domain] = *domain;
 
     ret[jss::details] = details;
     return ret;


### PR DESCRIPTION
## Summary

- Caps evictable manifest retention at 1,000 identities. Once full, eviction permits allow a burst of 10 replacements and refill roughly once per second; eviction prefers identities without current validations, then falls back to uniform random selection.
- Adds an optional `candidates` tier to signed publisher lists for zero-weight validator monitoring. Candidate membership never contributes listing or trust. Each generation and the deterministically selected current candidate set are capped at 1,000 identities.
- Protects local, tier-1, and selected tier-2 identities from eviction while keeping `ManifestCache` as the sole sequence, revocation, and signing-key-to-master authority. Provenance controls retention and relay independently of consensus eligibility.
- Relays accepted manifests for protected identities and accepted updates for retained evictable identities without using the shared `HashRouter`. First-seen valid evictable identities are retained up to the cap but do not relay.
- Bounds inbound manifests by encoded size, wire and uncompressed frame size, a 1,000-entry frame cap, and a 200-entry processing cap for unprotected manifests.
- Sends protected manifests to new peers in entry- and byte-bounded frames, followed by at most 200 evictable manifests.

## Lifecycle

- Removing an identity from every protected source makes its cached manifest evictable; it is retained if capacity permits and otherwise discarded.
- Embedded manifests in current, available publisher lists establish tier-1/tier-2 baselines; bare entries establish protection only. Newer gossip can advance retained manifests while running.
- Persisted validator manifests load provisionally protected, then startup reconciliation reclassifies DB-only rows as evictable. Shutdown save filtering is unchanged: terminal revocations are saved, while non-revocations are saved only for listed validators.