### PR TITLE
fix: ReportFeeChange data race, no-subscriber queuing, and LoadManager loop

### DIFF
--- a/src/test/app/LoadManager_test.cpp
+++ b/src/test/app/LoadManager_test.cpp
@@ -1,0 +1,150 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2025 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF  USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <xrpl/beast/unit_test.h>
+#include <xrpld/app/misc/LoadFeeTrack.h>
+
+namespace ripple {
+
+/**
+ * Unit tests for LoadFeeTrack fee adjustment mechanics.
+ *
+ * These tests document the expected per-second behaviour of
+ * raiseLocalFee() and lowerLocalFee() as called by LoadManager::run().
+ *
+ * Background: prior to the fix in this PR, the fee adjustment block in
+ * LoadManager::run() was placed *outside* the while loop, meaning
+ * raiseLocalFee()/lowerLocalFee() fired only once on shutdown rather
+ * than every second during normal operation. localTxnLoadFee_ (and thus
+ * load_factor_local in server_info) was therefore never adjusted by
+ * local job queue load during normal operation.
+ */
+class LoadManager_test : public beast::unit_test::suite
+{
+public:
+    // The normal/minimum fee factor (kLftNormalFee in LoadFeeTrack)
+    static constexpr std::uint32_t kNormalFee = 256;
+
+    void
+    testRaiseHysteresis()
+    {
+        testcase("raiseLocalFee requires two consecutive calls");
+
+        LoadFeeTrack track;
+
+        // First call: raiseCount_ goes from 0 to 1, returns false (hysteresis)
+        BEAST_EXPECT(!track.raiseLocalFee());
+        BEAST_EXPECT(track.getLocalFee() == kNormalFee);
+
+        // Second call: raiseCount_ reaches 2, fee is raised
+        BEAST_EXPECT(track.raiseLocalFee());
+        BEAST_EXPECT(track.getLocalFee() > kNormalFee);
+    }
+
+    void
+    testLowerDecaysToBaseline()
+    {
+        testcase("lowerLocalFee decays elevated fee back to baseline");
+
+        LoadFeeTrack track;
+
+        // Raise the fee above baseline (requires two calls due to hysteresis)
+        track.raiseLocalFee();
+        track.raiseLocalFee();
+        auto const elevated = track.getLocalFee();
+        BEAST_EXPECT(elevated > kNormalFee);
+
+        // lowerLocalFee() should decay it each call
+        // Each call reduces by 1/kLftFeeDecFraction (1/4), so a few
+        // iterations should bring it back to kNormalFee
+        bool changed = false;
+        for (int i = 0; i < 100; ++i)
+        {
+            changed |= track.lowerLocalFee();
+            if (track.getLocalFee() == kNormalFee)
+                break;
+        }
+
+        BEAST_EXPECT(changed);
+        BEAST_EXPECT(track.getLocalFee() == kNormalFee);
+    }
+
+    void
+    testLowerAtBaselineIsNoop()
+    {
+        testcase("lowerLocalFee at baseline returns false");
+
+        LoadFeeTrack track;
+
+        // Already at baseline — should return false (no change)
+        BEAST_EXPECT(!track.lowerLocalFee());
+        BEAST_EXPECT(track.getLocalFee() == kNormalFee);
+    }
+
+    void
+    testRaiseResetsOnLower()
+    {
+        testcase("lowerLocalFee resets raiseCount");
+
+        LoadFeeTrack track;
+
+        // One raise call (hysteresis: count=1, no change yet)
+        BEAST_EXPECT(!track.raiseLocalFee());
+
+        // Lower resets raiseCount_ to 0
+        track.lowerLocalFee();
+
+        // Next raise call starts from 0 again — still needs two calls
+        BEAST_EXPECT(!track.raiseLocalFee());
+        BEAST_EXPECT(track.getLocalFee() == kNormalFee);
+    }
+
+    void
+    testIsLoadedLocal()
+    {
+        testcase("isLoadedLocal reflects fee state correctly");
+
+        LoadFeeTrack track;
+
+        // At baseline, not loaded
+        BEAST_EXPECT(!track.isLoadedLocal());
+
+        // After one raise (hysteresis, fee unchanged) — raiseCount_ != 0
+        track.raiseLocalFee();
+        BEAST_EXPECT(track.isLoadedLocal());
+
+        // After lower, raiseCount_ reset and fee back at baseline
+        track.lowerLocalFee();
+        BEAST_EXPECT(!track.isLoadedLocal());
+    }
+
+    void
+    run() override
+    {
+        testRaiseHysteresis();
+        testLowerDecaysToBaseline();
+        testLowerAtBaselineIsNoop();
+        testRaiseResetsOnLower();
+        testIsLoadedLocal();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(LoadManager, app, ripple);
+
+}  // namespace ripple

--- a/src/xrpld/app/main/LoadManager.cpp
+++ b/src/xrpld/app/main/LoadManager.cpp
@@ -170,26 +170,25 @@ LoadManager::run()
                 LogicError("Deadlock detected");
             }
         }
-    }
+        bool change;
 
-    bool change;
+        if (app_.getJobQueue().isOverloaded())
+        {
+            JLOG(journal_.info()) << "Raising local fee (JQ overload): "
+                                  << app_.getJobQueue().getJson(0);
+            change = app_.getFeeTrack().raiseLocalFee();
+        }
+        else
+        {
+            change = app_.getFeeTrack().lowerLocalFee();
+        }
 
-    if (app_.getJobQueue().isOverloaded())
-    {
-        JLOG(journal_.info()) << "Raising local fee (JQ overload): "
-                              << app_.getJobQueue().getJson(0);
-        change = app_.getFeeTrack().raiseLocalFee();
-    }
-    else
-    {
-        change = app_.getFeeTrack().lowerLocalFee();
-    }
-
-    if (change)
-    {
-        // VFALCO TODO replace this with a Listener / observer and
-        // subscribe in NetworkOPs or Application.
-        app_.getOPs().reportFeeChange();
+        if (change)
+        {
+            // VFALCO TODO replace this with a Listener / observer and
+            // subscribe in NetworkOPs or Application.
+            app_.getOPs().reportFeeChange();
+        }
     }
 }
 

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -3010,14 +3010,22 @@ NetworkOPsImp::reportFeeChange()
         app_.getTxQ().getMetrics(*app_.openLedger().current()),
         app_.getFeeTrack()};
 
-    // only schedule the job if something has changed
-    if (f != mLastFeeSummary)
-    {
-        m_job_queue.addJob(
-            jtCLIENT_FEE_CHANGE, "reportFeeChange->pubServer", [this]() {
-                pubServer();
-            });
-    }
+    // Guard mLastFeeSummary under mSubLock to prevent concurrent threads
+    // from simultaneously passing the check and queuing duplicate
+    // jtCLIENT_FEE_CHANGE jobs (data race fix).
+    // Also fixes the no-subscriber case where mLastFeeSummary was
+    // never updated by pubServer(), causing endless job queuing.
+    // Lock is released before addJob to avoid holding mSubLock
+    // across the job queue mutex (per nbougalis review suggestion).
+    if (std::lock_guard sl(mSubLock); f != mLastFeeSummary)
+        mLastFeeSummary = f;
+    else
+        return;
+
+    m_job_queue.addJob(
+        jtCLIENT_FEE_CHANGE, "reportFeeChange->pubServer", [this]() {
+            pubServer();
+        });
 }
 
 void


### PR DESCRIPTION
Fixes #783
Fixes #784

Port of [XRPLF/rippled#8008](https://github.com/XRPLF/rippled/issues/8008) / [XRPLF/rippled#8009](https://github.com/XRPLF/rippled/pull/8009) and [XRPLF/rippled#8038](https://github.com/XRPLF/rippled/issues/8038) / [XRPLF/rippled#8039](https://github.com/XRPLF/rippled/pull/8039).

---

## Release Note (Operators)

Operators upgrading from any version affected by these bugs should expect the following behaviour to return:

- `load_factor_local` appearing in `server_info` during genuine job queue pressure
- `telINSUF_FEE_P` rejections on transactions submitted to a node under high local load
- Path finding, peer drops, and the ledger cleaner shedding load as designed under stress

This is correct behaviour being restored, not a regression.

---

## Changes

### 1. reportFeeChange() data race and no-subscriber endless job queuing

`mLastFeeSummary` was read without holding `mSubLock` in `reportFeeChange()` but written under `mSubLock` in `pubServer()`. On nodes with no WebSocket subscribers, `pubServer()` exits early without updating `mLastFeeSummary`, causing `reportFeeChange()` to queue a new `jtCLIENT_FEE_CHANGE` job on every call - observed at 4–43 jobs/second on production validators.

A dedicated `mFeeSummaryMutex_` now guards `mLastFeeSummary` exclusively in both `reportFeeChange()` and `pubServer()`, eliminating the lock-ordering hazard with `masterMutex` that would have arisen from using `mSubLock` in `reportFeeChange()` (which is called with `masterMutex` held, while `pubServer()` holds `mSubLock` across the entire subscriber fan-out).

`mLastFeeSummary` is also reset in `subServer()` on the empty→non-empty transition, so newly subscribing clients always receive a full `serverStatus` with `base_fee` and `load_factor_*` fields.

### 2. LoadManager::run() fee adjustment block outside while loop

The fee adjustment block was placed outside the `while` loop, causing `raiseLocalFee()` / `lowerLocalFee()` / `reportFeeChange()` to execute only once on shutdown. `load_factor_local` was therefore never adjusted during normal operation, and `isLoadedLocal()` was always `false` for the lifetime of the process - silently disabling all call sites that shed load based on that flag: path finding, the `ledger` RPC, peer drops, and the ledger cleaner.

---

## Evidence

- Production validators: 4–43 `clientFeeChange` jobs/second on stock, zero on patched
- Xahau mainnet: patched nodes raise `load_factor_local` to 28–55x during Evernode hourly events, stock nodes remain at `load_factor:1`
- Fee enforcement confirmed: `telINSUF_FEE_P` on patched vs `tesSUCCESS` on stock for 10-drop transactions during load events

---

## Unit Tests

`LoadManager_test` (6 cases, 24 assertions) covers `LoadFeeTrack` mechanics and a `jtx::Env` integration test:

| Test case | Description |
|---|---|
| raiseLocalFee requires two consecutive calls | Verifies the `raiseCount_ < 2` hysteresis guard |
| lowerLocalFee decays elevated fee back to baseline | Confirms decay to `kNormalFee` (256) |
| lowerLocalFee at baseline returns false | Confirms noop when already at floor |
| lowerLocalFee resets raiseCount | Confirms `raiseCount_` reset on lower |
| isLoadedLocal reflects fee state correctly | Confirms `isLoadedLocal()` tracks fee and count state |
| LoadManager loop raises and decays load_factor_local | `jtx::Env` test: raises fee twice past hysteresis, confirms decay to baseline. Fails on stock, passes with fix. |