### PR TITLE
Add optional Hooks data to `account_info` response

### DIFF
--- a/Builds/levelization/results/ordering.txt
+++ b/Builds/levelization/results/ordering.txt
@@ -200,6 +200,7 @@ xrpld.rpc > xrpld.core
 xrpld.rpc > xrpld.ledger
 xrpld.rpc > xrpld.nodestore
 xrpld.rpc > xrpld.shamap
+xrpld.rpc > xrpl.hook
 xrpld.rpc > xrpl.json
 xrpld.rpc > xrpl.protocol
 xrpld.rpc > xrpl.resource

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -350,6 +350,7 @@ JSS(hash_mismatches);       // out: catalogue
 JSS(have_header);           // out: InboundLedger
 JSS(have_state);            // out: InboundLedger
 JSS(have_transactions);     // out: InboundLedger
+JSS(hooks);                 // in/out: AccountInfo
 JSS(high);                  // out: BookChanges
 JSS(highest_sequence);      // out: AccountInfo
 JSS(highest_ticket);        // out: AccountInfo

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -24,6 +24,8 @@
 #include <test/jtx/WSClient.h>
 #include <test/rpc/GRPCTestClientBase.h>
 #include <xrpld/rpc/GRPCHandlers.h>
+#include <xrpl/hook/Misc.h>
+#include <xrpl/protocol/InnerObjectFormats.h>
 #include <xrpl/resource/Charge.h>
 #include <xrpl/resource/Fees.h>
 
@@ -119,6 +121,252 @@ public:
             testInvalidIdentParam(Json::Value(Json::objectValue));
             testInvalidIdentParam(Json::Value(Json::arrayValue));
         }
+    }
+
+    void
+    testHooksRequest()
+    {
+        testcase("Hooks request");
+        using namespace jtx;
+        Env env(*this);
+        Account const alice{"alice"};
+        env.fund(XRP(1000), alice);
+
+        auto request = [&](Json::Value const& hooks, unsigned apiVersion) {
+            Json::Value params;
+            params[jss::account] = alice.human();
+            params[jss::hooks] = hooks;
+            if (apiVersion == 1)
+                return env.rpc("json", "account_info", to_string(params));
+
+            params[jss::api_version] = 2;
+            return env.rpc("json", "account_info", to_string(params));
+        };
+
+        for (Json::Value const& invalid :
+             {Json::Value(1),
+              Json::Value(1.1),
+              Json::Value("true"),
+              Json::Value(Json::nullValue),
+              Json::Value(Json::objectValue),
+              Json::Value(Json::arrayValue)})
+        {
+            for (unsigned const apiVersion : {1u, 2u})
+            {
+                auto const info = request(invalid, apiVersion);
+                BEAST_EXPECT(info[jss::result][jss::error] == "invalidParams");
+                BEAST_EXPECT(
+                    info[jss::result][jss::error_message] ==
+                    "Invalid field 'hooks'.");
+            }
+        }
+
+        auto const withoutHooks = env.rpc(
+            "json",
+            "account_info",
+            R"({"account": ")" + alice.human() + R"("})");
+        BEAST_EXPECT(!withoutHooks[jss::result].isMember(jss::hooks));
+
+        auto const explicitlyFalse = env.rpc(
+            "json",
+            "account_info",
+            R"({"account": ")" + alice.human() + R"(","hooks":false})");
+        BEAST_EXPECT(!explicitlyFalse[jss::result].isMember(jss::hooks));
+
+        auto const explicitlyTrue = env.rpc(
+            "json",
+            "account_info",
+            std::string{"{ "} + "\"account\": \"" + alice.human() +
+                "\", \"hooks\": true }");
+        BEAST_EXPECT(explicitlyTrue[jss::result][jss::hooks].isArray());
+        BEAST_EXPECT(explicitlyTrue[jss::result][jss::hooks].size() == 0);
+    }
+
+    void
+    testHooksEffectiveValues()
+    {
+        testcase("Effective hook values");
+
+        auto const* hookTemplate =
+            InnerObjectFormats::getInstance().findSOTemplateBySField(sfHook);
+        if (!BEAST_EXPECTS(hookTemplate != nullptr, "sfHook template"))
+            return;
+        // If this count changes, add or remove tests for the corresponding Hook
+        // fields.
+        BEAST_EXPECT(hookTemplate->size() == 12);
+
+        using namespace jtx;
+        Env env(*this);
+        Account const alice{"alice"};
+        env.fund(XRP(1000), alice);
+
+        uint256 const definitionNamespace{1};
+        uint256 const accountNamespace{2};
+        auto const makeParameter = [](std::string const& name,
+                                      std::string const& value) {
+            Json::Value parameter;
+            parameter[jss::HookParameter][jss::HookParameterName] = name;
+            parameter[jss::HookParameter][jss::HookParameterValue] = value;
+            return parameter;
+        };
+
+        auto create = hso(genesis::AcceptHook);
+        create[jss::Flags] = hsfCOLLECT;
+        create[jss::HookName] = strHex(std::string{"ACCT"});
+        create[jss::HookNamespace] = to_string(definitionNamespace);
+        create[jss::HookParameters] = Json::arrayValue;
+        create[jss::HookParameters].append(makeParameter("AA", "BB"));
+        create[jss::HookParameters].append(makeParameter("CC", "DD"));
+        env(hook(alice, {{create, Json::Value{}}}, 0),
+            fee(XRP(1)),
+            ter(tesSUCCESS));
+        env.close();
+
+        auto const hookSLE = env.le(keylet::hook(alice.id()));
+        BEAST_EXPECT(hookSLE && hookSLE->isFieldPresent(sfHooks));
+        if (!hookSLE || !hookSLE->isFieldPresent(sfHooks))
+            return;
+        auto const& installed = hookSLE->getFieldArray(sfHooks)[0];
+        BEAST_EXPECT(installed.isFieldPresent(sfHookHash));
+        if (!installed.isFieldPresent(sfHookHash))
+            return;
+        auto const hash = installed.getFieldH256(sfHookHash);
+
+        auto const hookDefinition = env.le(keylet::hookDefinition(hash));
+        BEAST_EXPECT(hookDefinition);
+        if (hookDefinition)
+        {
+            BEAST_EXPECT(!hookDefinition->isFieldPresent(sfHookName));
+            BEAST_EXPECT(!hookDefinition->isFieldPresent(sfHookGrants));
+            BEAST_EXPECT(hookDefinition->isFieldPresent(sfHookApiVersion));
+            BEAST_EXPECT(hookDefinition->getFieldU16(sfHookApiVersion) == 0);
+        }
+
+        auto accountInfo = env.rpc(
+            "json",
+            "account_info",
+            R"({"account": ")" + alice.human() + R"(","hooks":true})");
+        auto const& hookJson =
+            accountInfo[jss::result][jss::hooks][0U][sfHook.jsonName];
+        BEAST_EXPECT(hookJson[sfHookHash.jsonName] == to_string(hash));
+        BEAST_EXPECT(!hookJson.isMember(sfCreateCode.jsonName));
+        BEAST_EXPECT(
+            hookJson[sfHookNamespace.jsonName] ==
+            to_string(definitionNamespace));
+        BEAST_EXPECT(
+            hookJson[sfHookName.jsonName].isString() &&
+            hookJson[sfHookName.jsonName] == strHex(std::string{"ACCT"}));
+        BEAST_EXPECT(
+            hookJson[sfHookApiVersion.jsonName].isInt() &&
+            hookJson[sfHookApiVersion.jsonName].asUInt() == 0);
+        BEAST_EXPECT(hookJson[sfHookOn.jsonName] == to_string(uint256{0}));
+        BEAST_EXPECT(!hookJson.isMember(sfHookOnIncoming.jsonName));
+        BEAST_EXPECT(!hookJson.isMember(sfHookOnOutgoing.jsonName));
+        BEAST_EXPECT(
+            hookJson[sfHookCanEmit.jsonName] ==
+            to_string(UINT256_BIT[ttHOOK_SET]));
+        BEAST_EXPECT(hookJson[sfFlags.jsonName] == hsfCOLLECT);
+        BEAST_EXPECT(hookJson[sfHookParameters.jsonName].size() == 2);
+        auto const& hooksJson = accountInfo[jss::result][jss::hooks];
+        BEAST_EXPECT(hooksJson.isArray());
+        BEAST_EXPECT(hooksJson.size() == 2);
+        if (!hooksJson.isArray() || hooksJson.size() < 2)
+            return;
+        BEAST_EXPECT(hooksJson[1U].isObject());
+        BEAST_EXPECT(hooksJson[1U].isMember(sfHook.jsonName));
+        if (!hooksJson[1U].isObject() ||
+            !hooksJson[1U].isMember(sfHook.jsonName))
+            return;
+        auto const& blankHook = hooksJson[1U][sfHook.jsonName];
+        BEAST_EXPECT(blankHook.isObject());
+        BEAST_EXPECT(blankHook.size() == 0);
+
+        Json::Value update;
+        update[jss::HookHash] = to_string(hash);
+        update[jss::Flags] = hsfOVERRIDE;
+        update[jss::HookName] = strHex(std::string{"ACCT"});
+        update[jss::HookGrants] = Json::arrayValue;
+        update[jss::HookGrants][0U][jss::HookGrant][jss::HookHash] =
+            to_string(hash);
+        update[jss::HookNamespace] = to_string(accountNamespace);
+        update[jss::HookOnIncoming] = to_string(uint256{5});
+        update[jss::HookOnOutgoing] = to_string(uint256{6});
+        update[jss::HookCanEmit] = to_string(uint256{4});
+        update[jss::HookParameters] = Json::arrayValue;
+        update[jss::HookParameters].append(makeParameter("AA", ""));
+        update[jss::HookParameters].append(makeParameter("EE", "FF"));
+        env(hook(alice, {{update}}, 0), fee(XRP(1)), ter(tesSUCCESS));
+        env.close();
+
+        accountInfo = env.rpc(
+            "json",
+            "account_info",
+            R"({"account": ")" + alice.human() + R"(","hooks":true})");
+        auto const& overridden =
+            accountInfo[jss::result][jss::hooks][0U][sfHook.jsonName];
+        BEAST_EXPECT(
+            overridden[sfHookNamespace.jsonName] ==
+            to_string(accountNamespace));
+        BEAST_EXPECT(
+            overridden[sfHookName.jsonName].isString() &&
+            overridden[sfHookName.jsonName] == strHex(std::string{"ACCT"}));
+        BEAST_EXPECT(
+            overridden[sfHookApiVersion.jsonName].isInt() &&
+            overridden[sfHookApiVersion.jsonName].asUInt() == 0);
+        BEAST_EXPECT(overridden[sfHookGrants.jsonName].isArray());
+        BEAST_EXPECT(overridden[sfHookGrants.jsonName].size() == 1);
+        if (overridden[sfHookGrants.jsonName].isArray() &&
+            overridden[sfHookGrants.jsonName].size() == 1)
+        {
+            auto const& grant = overridden[sfHookGrants.jsonName][0U];
+            BEAST_EXPECT(grant.isObject());
+            BEAST_EXPECT(grant.size() == 1);
+            BEAST_EXPECT(grant.isMember(sfHookGrant.jsonName));
+            if (grant.isObject() && grant.size() == 1 &&
+                grant.isMember(sfHookGrant.jsonName))
+            {
+                auto const& grantObject = grant[sfHookGrant.jsonName];
+                BEAST_EXPECT(grantObject.isObject());
+                BEAST_EXPECT(grantObject.size() == 1);
+                BEAST_EXPECT(grantObject.isMember(sfHookHash.jsonName));
+                if (grantObject.isObject() && grantObject.size() == 1 &&
+                    grantObject.isMember(sfHookHash.jsonName))
+                    BEAST_EXPECT(
+                        grantObject[sfHookHash.jsonName] == to_string(hash));
+            }
+        }
+        BEAST_EXPECT(overridden[sfFlags.jsonName] == 0);
+        BEAST_EXPECT(!overridden.isMember(sfHookOn.jsonName));
+        BEAST_EXPECT(
+            overridden[sfHookOnIncoming.jsonName] == to_string(uint256{5}));
+        BEAST_EXPECT(
+            overridden[sfHookOnOutgoing.jsonName] == to_string(uint256{6}));
+        BEAST_EXPECT(
+            overridden[sfHookCanEmit.jsonName] == to_string(uint256{4}));
+        BEAST_EXPECT(overridden[sfHookParameters.jsonName].size() == 3);
+        if (overridden[sfHookParameters.jsonName].size() != 3)
+            return;
+        auto expectParameter = [&](std::string const& name,
+                                   std::string const& value) {
+            bool found = false;
+            for (auto const& parameter : overridden[sfHookParameters.jsonName])
+            {
+                if (!parameter.isObject() ||
+                    !parameter.isMember(sfHookParameter.jsonName))
+                    continue;
+                auto const& object = parameter[sfHookParameter.jsonName];
+                if (!object.isObject() ||
+                    object[sfHookParameterName.jsonName] != name)
+                    continue;
+                found = true;
+                BEAST_EXPECT(object[sfHookParameterValue.jsonName] == value);
+                break;
+            }
+            BEAST_EXPECT(found);
+        };
+        expectParameter("AA", "");
+        expectParameter("CC", "DD");
+        expectParameter("EE", "FF");
     }
 
     // Test the "signer_lists" argument in account_info.
@@ -686,6 +934,8 @@ public:
     run() override
     {
         testErrors();
+        testHooksRequest();
+        testHooksEffectiveValues();
         testSignerLists();
         testSignerListsApiVersion2();
         testSignerListsV2();

--- a/src/xrpld/rpc/handlers/AccountInfo.cpp
+++ b/src/xrpld/rpc/handlers/AccountInfo.cpp
@@ -53,7 +53,7 @@ setEffectiveParameters(
         definition && definition->isFieldPresent(sfHookParameters);
     bool const hasEntry = entry.isFieldPresent(sfHookParameters);
     if (!hasDefinition && !hasEntry)
-        return;
+        return;  // LCOV_EXCL_LINE
 
     STArray parameters{sfHookParameters};
 
@@ -112,7 +112,7 @@ effectiveHookOn(
         return definition->getFieldH256(direction);
     if (definition->isFieldPresent(sfHookOn))
         return definition->getFieldH256(sfHookOn);
-    return uint256{0};
+    return uint256{0};  // LCOV_EXCL_LINE
 }
 
 STObject

--- a/src/xrpld/rpc/handlers/AccountInfo.cpp
+++ b/src/xrpld/rpc/handlers/AccountInfo.cpp
@@ -23,15 +23,196 @@
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/GRPCHandlers.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
+#include <xrpl/hook/Misc.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/RPCErr.h>
+#include <xrpl/protocol/STArray.h>
+#include <xrpl/protocol/STObject.h>
+#include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/UintTypes.h>
 #include <xrpl/protocol/jss.h>
+#include <algorithm>
 #include <grpc/status.h>
+#include <map>
+#include <optional>
+#include <vector>
 
 namespace ripple {
+
+namespace {
+
+void
+setEffectiveParameters(
+    STObject& result,
+    STObject const& entry,
+    std::shared_ptr<SLE const> const& definition)
+{
+    bool const hasDefinition =
+        definition && definition->isFieldPresent(sfHookParameters);
+    bool const hasEntry = entry.isFieldPresent(sfHookParameters);
+    if (!hasDefinition && !hasEntry)
+        return;
+
+    STArray parameters{sfHookParameters};
+
+    auto merge = [&parameters](STArray const& source) {
+        for (auto const& parameter : source)
+        {
+            Blob const name = parameter.getFieldVL(sfHookParameterName);
+            Blob const value = parameter.getFieldVL(sfHookParameterValue);
+
+            auto existing = std::find_if(
+                parameters.begin(),
+                parameters.end(),
+                [&name](STObject const& current) {
+                    return current.getFieldVL(sfHookParameterName) == name;
+                });
+
+            if (existing == parameters.end())
+            {
+                STObject merged = STObject::makeInnerObject(sfHookParameter);
+                merged.setFieldVL(sfHookParameterName, name);
+                // gatherHookParameters treats an absent value as an empty
+                // value. Keep it explicit in the effective response.
+                merged.setFieldVL(sfHookParameterValue, value);
+                parameters.push_back(std::move(merged));
+            }
+            else
+            {
+                existing->setFieldVL(sfHookParameterValue, value);
+            }
+        }
+    };
+
+    if (hasDefinition)
+        merge(definition->getFieldArray(sfHookParameters));
+    if (hasEntry)
+        merge(entry.getFieldArray(sfHookParameters));
+
+    result.setFieldArray(sfHookParameters, std::move(parameters));
+}
+
+uint256
+effectiveHookOn(
+    STObject const& entry,
+    std::shared_ptr<SLE const> const& definition,
+    SField const& direction)
+{
+    if (entry.isFieldPresent(direction))
+        return entry.getFieldH256(direction);
+    if (entry.isFieldPresent(sfHookOn))
+        return entry.getFieldH256(sfHookOn);
+
+    if (!definition)
+        return uint256{0};  // LCOV_EXCL_LINE
+
+    if (definition->isFieldPresent(direction))
+        return definition->getFieldH256(direction);
+    if (definition->isFieldPresent(sfHookOn))
+        return definition->getFieldH256(sfHookOn);
+    return uint256{0};
+}
+
+STObject
+effectiveHook(
+    STObject const& entry,
+    std::shared_ptr<SLE const> const& definition)
+{
+    STObject result = STObject::makeInnerObject(sfHook);
+
+    // If there is no definition, return the entry as is
+    if (!definition)
+        return result;  // LCOV_EXCL_LINE
+
+    // A blank sfHooks slot is meaningful: preserve it as an empty Hook
+    // object instead of applying the defaults used for an installed hook.
+    if (!entry.isFieldPresent(sfHookHash))
+        return result;  // LCOV_EXCL_LINE
+
+    // These fields are deliberately selected rather than copying the raw
+    // objects: HookDefinition bookkeeping must not leak from account_info.
+    if (entry.isFieldPresent(sfHookHash))
+        result.setFieldH256(sfHookHash, entry.getFieldH256(sfHookHash));
+    // CreateCode is not included in AccountRoot Hook field
+    // if (definition->isFieldPresent(sfCreateCode))
+    //     result.setFieldVL(sfCreateCode,
+    //     definition->getFieldVL(sfCreateCode));
+    if (entry.isFieldPresent(sfHookGrants))
+        result.setFieldArray(sfHookGrants, entry.getFieldArray(sfHookGrants));
+
+    if (entry.isFieldPresent(sfHookNamespace))
+        result.setFieldH256(
+            sfHookNamespace, entry.getFieldH256(sfHookNamespace));
+    else if (definition->isFieldPresent(sfHookNamespace))
+        result.setFieldH256(
+            sfHookNamespace, definition->getFieldH256(sfHookNamespace));
+
+    if (definition->isFieldPresent(sfHookApiVersion))
+        result.setFieldU16(
+            sfHookApiVersion, definition->getFieldU16(sfHookApiVersion));
+
+    if (entry.isFieldPresent(sfHookCanEmit))
+        result.setFieldH256(sfHookCanEmit, entry.getFieldH256(sfHookCanEmit));
+    else if (definition->isFieldPresent(sfHookCanEmit))
+        result.setFieldH256(
+            sfHookCanEmit, definition->getFieldH256(sfHookCanEmit));
+    else
+        result.setFieldH256(sfHookCanEmit, UINT256_BIT[ttHOOK_SET]);
+
+    if (entry.isFieldPresent(sfHookName))
+        result.setFieldVL(sfHookName, entry.getFieldVL(sfHookName));
+    if (entry.isFieldPresent(sfFlags))
+        result.setFieldU32(sfFlags, entry.getFieldU32(sfFlags));
+    else if (definition->isFieldPresent(sfFlags))
+        result.setFieldU32(sfFlags, definition->getFieldU32(sfFlags));
+
+    auto const incoming = effectiveHookOn(entry, definition, sfHookOnIncoming);
+    auto const outgoing = effectiveHookOn(entry, definition, sfHookOnOutgoing);
+    if (incoming == outgoing)
+        result.setFieldH256(sfHookOn, incoming);
+    else
+    {
+        result.setFieldH256(sfHookOnIncoming, incoming);
+        result.setFieldH256(sfHookOnOutgoing, outgoing);
+    }
+
+    setEffectiveParameters(result, entry, definition);
+    return result;
+}
+
+Json::Value
+accountHooks(ReadView const& ledger, AccountID const& account)
+{
+    Json::Value hooks(Json::arrayValue);
+    auto const hookSLE = ledger.read(keylet::hook(account));
+    if (!hookSLE || !hookSLE->isFieldPresent(sfHooks))
+        return hooks;
+
+    std::map<uint256, std::shared_ptr<SLE const>> definitions;
+    for (auto const& hookElement : hookSLE->getFieldArray(sfHooks))
+    {
+        auto const& entry = hookElement.downcast<STObject const>();
+        std::shared_ptr<SLE const> definition;
+        if (entry.isFieldPresent(sfHookHash))
+        {
+            auto const hash = entry.getFieldH256(sfHookHash);
+            auto [it, inserted] = definitions.emplace(hash, nullptr);
+            if (inserted)
+                it->second = ledger.read(keylet::hookDefinition(hash));
+            definition = it->second;
+        }
+
+        Json::Value wrapped(Json::objectValue);
+        wrapped[sfHook.jsonName] =
+            effectiveHook(entry, definition).getJson(JsonOptions::none);
+        hooks.append(std::move(wrapped));
+    }
+    return hooks;
+}
+
+}  // namespace
 
 // {
 //   account: <ident>,
@@ -51,6 +232,11 @@ Json::Value
 doAccountInfo(RPC::JsonContext& context)
 {
     auto& params = context.params;
+
+    if (params.isMember(jss::hooks) && !params[jss::hooks].isBool())
+        return RPC::invalid_field_error(jss::hooks);
+    bool const includeHooks =
+        params.isMember(jss::hooks) && params[jss::hooks].asBool();
 
     std::string strIdent;
     if (params.isMember(jss::account))
@@ -145,6 +331,9 @@ doAccountInfo(RPC::JsonContext& context)
                 sleAccepted->isFlag(allowTrustLineClawbackFlag.second);
 
         result[jss::account_flags] = std::move(acctFlags);
+
+        if (includeHooks)
+            result[jss::hooks] = accountHooks(*ledger, accountID);
 
         // The document[https://xrpl.org/account_info.html#account_info] states
         // that signer_lists is a bool, however assigning any string value


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

Adds an optional hooks boolean parameter to the account_info RPC method.

When hooks: true is provided, the response includes each Hook slot with its effective runtime values, resolving HookDefinition defaults and account-level overrides.

### Context of Change

- Adds an optional `hooks` boolean request parameter to `account_info`.
- When `hooks` is omitted or `false`, the response remains unchanged.
- When `hooks` is `true`, the response includes a top-level `hooks` array.
- Each item in `hooks` contains a `Hook` object with the effective configuration for that slot.
- Effective values are resolved from the account's Hook entry and its referenced HookDefinition, with account-level values taking precedence over definition defaults.
- Empty Hook slots are returned as empty `Hook` objects.
- HookDefinition bookkeeping fields and create code are not exposed.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [x] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->