### PR TITLE
Experiment: send validator manifests with validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ generated
 
 # Suggested in-tree build directory
 /.build/
+
+# x-testnet runtime state; scenario definitions remain tracked.
+/.testnet/output/
+/.testnet/nodes/
+/testnet/

--- a/.testnet/scenarios/manifest_revocation_live.py
+++ b/.testnet/scenarios/manifest_revocation_live.py
@@ -1,0 +1,96 @@
+"""Revoke one of five validators live and watch the terminal update propagate.
+
+Five validators are used deliberately: revoking one leaves four of five —
+exactly the 80% quorum — so the network keeps closing ledgers and the
+scenario can assert liveness with the revoked member excluded, not merely a
+halt. (On a three-node UNL the same revocation stops the network: small-net
+quorums round up to everyone.)
+
+The revocation is installed by config on the OLD release node deliberately:
+under the new transport slice a config-loaded revocation on an upgraded node
+sits in its durable cache and is never gossiped (there is no connect-time
+dump and no ambient manifest relay), while the old binary still dumps its
+manifest cache on every fresh connection and relays what it accepts. The old
+node is therefore the only in-topology seeder for a config-injected
+revocation — that asymmetry is itself part of the documented durability
+boundary.
+"""
+
+from xahaud_scripts.testnet.scenario import (
+    AssertionError as ScenarioAssertion,
+)
+
+
+async def scenario(ctx, log):
+    nodes = [0, 1, 2, 3, 4, 5]
+    # Validators 0-4 mesh through 0; the old release node 5 hangs off the
+    # mesh and is the revocation's config seeder.
+    expected = ctx.topology_edges(
+        [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (3, 4), (4, 5)]
+    )
+
+    await ctx.apply_topology(expected, nodes=nodes, exact=False)
+
+    # Normal operation first: everyone validates and validator 4's manifest
+    # is durably known, so the revocation supersedes real retained state.
+    await ctx.wait_for_ledgers(2, node_id=0, timeout=180)
+
+    revoked = ctx.mark("revoked")
+    result = await ctx.revoke_validator(4, 5)
+    log(
+        "revoked validator n4 master via the old relay n5: "
+        f"{result['public_key']}"
+    )
+
+    # The restarted old node loads the revocation and seeds it through its
+    # legacy connect-time dump and accept-relay; its peer n4 spreads it into
+    # the mesh through the normal revocation relay lane. The old node's
+    # reconnect interval dominates the latency, so wait on the log fact.
+    deadline = 36
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log("Revoked", since=revoked, nodes=[4])
+            break
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"await-revocation-arrival: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name="await-revocation-arrival")
+
+    # Terminal manifest applied and relayed onward by upgraded nodes: first
+    # at the old seeder's direct peer, then across the mesh.
+    ctx.assert_log(
+        "manifest_revocation accepted_for_relay",
+        since=revoked,
+        nodes=[4],
+    )
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log("Revoked", since=revoked, nodes=[0])
+            break
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"await-mesh-revocation: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name="await-mesh-revocation")
+    ctx.assert_log(
+        "manifest_revocation accepted_for_relay",
+        since=revoked,
+        nodes=[0],
+    )
+
+    # Liveness with the revoked member excluded: four of five is exactly
+    # quorum, so ledgers keep closing.
+    await ctx.wait_for_ledgers(2, node_id=0, timeout=180)
+
+    ctx.assert_not_log("Validation forwarded by peer is invalid", nodes=nodes)
+    ctx.assert_not_log("Validation: Too small", nodes=nodes)
+
+    log(
+        "PASS: a config-injected revocation seeded by the old relay reached"
+        " the mesh, applied terminally on upgraded nodes, relayed onward,"
+        " and the remaining four validators kept the network live at exact"
+        " quorum"
+    )

--- a/.testnet/scenarios/manifest_revocation_live.py
+++ b/.testnet/scenarios/manifest_revocation_live.py
@@ -21,12 +21,27 @@ from xahaud_scripts.testnet.scenario import (
 )
 
 
+async def _await_log(ctx, log, pattern, *, nodes, name, since=None, deadline=36):
+    # Catch the runner's ScenarioAssertion, not the builtin. The scenario
+    # module shadows AssertionError without subclassing it.
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log(pattern, nodes=nodes, **({"since": since} if since else {}))
+            return
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"{name}: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name=name)
+
+
 async def scenario(ctx, log):
     nodes = [0, 1, 2, 3, 4, 5]
-    # Validators 0-4 mesh through 0; the old release node 5 hangs off the
-    # mesh and is the revocation's config seeder.
+    # Validators 0-4 meet at n0. The old release node n5 is a pendant on n4
+    # so it can seed the revocation without joining the UNL mesh.
     expected = ctx.topology_edges(
-        [(0, 1), (0, 2), (0, 3), (0, 4), (1, 2), (3, 4), (4, 5)]
+        [(0, 1), (0, 2), (0, 3), (0, 4), (4, 5)]
     )
 
     await ctx.apply_topology(expected, nodes=nodes, exact=False)
@@ -46,17 +61,15 @@ async def scenario(ctx, log):
     # legacy connect-time dump and accept-relay; its peer n4 spreads it into
     # the mesh through the normal revocation relay lane. The old node's
     # reconnect interval dominates the latency, so wait on the log fact.
-    deadline = 36
-    for attempt in range(deadline):
-        try:
-            ctx.assert_log("Revoked", since=revoked, nodes=[4])
-            break
-        except ScenarioAssertion:
-            if attempt == deadline - 1:
-                raise
-            if attempt % 6 == 5:
-                log(f"await-revocation-arrival: attempt {attempt + 1}/{deadline}")
-            await ctx.sleep(5, name="await-revocation-arrival")
+    await _await_log(
+        ctx,
+        log,
+        "Revoked",
+        nodes=[4],
+        name="await-revocation-arrival",
+        since=revoked,
+        deadline=36,
+    )
 
     # Terminal manifest applied and relayed onward by upgraded nodes: first
     # at the old seeder's direct peer, then across the mesh.
@@ -65,16 +78,15 @@ async def scenario(ctx, log):
         since=revoked,
         nodes=[4],
     )
-    for attempt in range(deadline):
-        try:
-            ctx.assert_log("Revoked", since=revoked, nodes=[0])
-            break
-        except ScenarioAssertion:
-            if attempt == deadline - 1:
-                raise
-            if attempt % 6 == 5:
-                log(f"await-mesh-revocation: attempt {attempt + 1}/{deadline}")
-            await ctx.sleep(5, name="await-mesh-revocation")
+    await _await_log(
+        ctx,
+        log,
+        "Revoked",
+        nodes=[0],
+        name="await-mesh-revocation",
+        since=revoked,
+        deadline=36,
+    )
     ctx.assert_log(
         "manifest_revocation accepted_for_relay",
         since=revoked,

--- a/.testnet/scenarios/manifest_rotation_propagation.py
+++ b/.testnet/scenarios/manifest_rotation_propagation.py
@@ -14,6 +14,20 @@ from xahaud_scripts.testnet.scenario import (
 )
 
 
+async def _await_log(ctx, log, pattern, *, nodes, name, since=None, deadline=36):
+    # Catch the runner's ScenarioAssertion, not the builtin. The scenario
+    # module shadows AssertionError without subclassing it.
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log(pattern, nodes=nodes, **({"since": since} if since else {}))
+            return
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"{name}: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name=name)
+
 
 async def scenario(ctx, log):
     nodes = [0, 1, 2]
@@ -26,20 +40,14 @@ async def scenario(ctx, log):
     # race several ledgers ahead of propagation under fast bootstrap, so
     # wait on the log fact itself.
     await ctx.wait_for_ledgers(2, node_id=0, timeout=120)
-    deadline = 24
-    for attempt in range(deadline):
-        try:
-            ctx.assert_log(
-                "manifest_validation single_manifest_processed .*sequence=1",
-                nodes=[2],
-            )
-            break
-        except ScenarioAssertion:
-            if attempt == deadline - 1:
-                raise
-            if attempt % 6 == 5:
-                log(f"await-baseline-admission: attempt {attempt + 1}/{deadline}")
-            await ctx.sleep(5, name="await-baseline-admission")
+    await _await_log(
+        ctx,
+        log,
+        "manifest_validation single_manifest_processed .*sequence=1",
+        nodes=[2],
+        name="await-baseline-admission",
+        deadline=24,
+    )
 
     rotated = ctx.mark("rotated")
     rotation = await ctx.rotate_validator_manifest(0)
@@ -54,21 +62,16 @@ async def scenario(ctx, log):
     # only the validator advances its ledger, and its own restart closed the
     # node-0 WebSocket ledger feed. The repair re-arm is the last event in
     # the causal chain, so everything else must precede it.
-    deadline = 36  # polls at 5s => 180s budget at ~16s consensus rounds
-    for attempt in range(deadline):
-        try:
-            ctx.assert_log(
-                "manifest_validation repair_sent .*sequence=2",
-                since=rotated,
-                nodes=[2],
-            )
-            break
-        except ScenarioAssertion:
-            if attempt == deadline - 1:
-                raise
-            if attempt % 6 == 5:
-                log(f"await-repair-rearm: attempt {attempt + 1}/{deadline}")
-            await ctx.sleep(5, name="await-repair-rearm")
+    # polls at 5s => 180s budget at ~16s consensus rounds
+    await _await_log(
+        ctx,
+        log,
+        "manifest_validation repair_sent .*sequence=2",
+        nodes=[2],
+        name="await-repair-rearm",
+        since=rotated,
+        deadline=36,
+    )
 
     ctx.assert_log(
         "manifest_validation pair_enqueued .*sequence=2",

--- a/.testnet/scenarios/manifest_rotation_propagation.py
+++ b/.testnet/scenarios/manifest_rotation_propagation.py
@@ -1,0 +1,110 @@
+"""Rotate a validator's manifest mid-run and watch the bump propagate.
+
+"Heals on a sequence bump" is the load-bearing healing claim of the
+manifest-before-validation transport slice. This exercises it live for the
+first time: the validator mints sequence 2 and restarts; its validations then
+carry the new manifest; an old release relay forwards the existing envelopes;
+the upgraded observer supersedes its retained knowledge and admits sequence 2;
+and the observer's repair lane re-arms at the newer sequence when the old
+relay's later validations arrive naked.
+"""
+
+from xahaud_scripts.testnet.scenario import (
+    AssertionError as ScenarioAssertion,
+)
+
+
+
+async def scenario(ctx, log):
+    nodes = [0, 1, 2]
+    expected = ctx.topology_edges([(0, 1), (1, 2)])
+
+    await ctx.apply_topology(expected, nodes=nodes, exact=False)
+
+    # Baseline: sequence 1 propagates through the old relay and is admitted
+    # by the upgraded observer before we rotate anything. The validator can
+    # race several ledgers ahead of propagation under fast bootstrap, so
+    # wait on the log fact itself.
+    await ctx.wait_for_ledgers(2, node_id=0, timeout=120)
+    deadline = 24
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log(
+                "manifest_validation single_manifest_processed .*sequence=1",
+                nodes=[2],
+            )
+            break
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"await-baseline-admission: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name="await-baseline-admission")
+
+    rotated = ctx.mark("rotated")
+    rotation = await ctx.rotate_validator_manifest(0)
+    assert rotation["sequence"] == 2, rotation
+    log(f"rotated validator n0 to manifest sequence {rotation['sequence']}")
+
+    # The restarted validator re-joins and validates under the new signing
+    # key; always-send carries the sequence-2 prerequisite with each
+    # validation, and the old relay's one-shot manifest forward plus later
+    # naked relays exercise both the supersede and the repair re-arm. Wait
+    # on the terminal log fact rather than ledger counts: in this topology
+    # only the validator advances its ledger, and its own restart closed the
+    # node-0 WebSocket ledger feed. The repair re-arm is the last event in
+    # the causal chain, so everything else must precede it.
+    deadline = 36  # polls at 5s => 180s budget at ~16s consensus rounds
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log(
+                "manifest_validation repair_sent .*sequence=2",
+                since=rotated,
+                nodes=[2],
+            )
+            break
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"await-repair-rearm: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name="await-repair-rearm")
+
+    ctx.assert_log(
+        "manifest_validation pair_enqueued .*sequence=2",
+        since=rotated,
+        nodes=[0],
+    )
+    ctx.assert_log(
+        "manifest_validation candidate_staged .*sequence=2",
+        since=rotated,
+        nodes=[2],
+    )
+    ctx.assert_log(
+        "manifest_validation candidate_matched",
+        since=rotated,
+        nodes=[2],
+    )
+    ctx.assert_log(
+        "manifest_validation single_manifest_processed .*sequence=2"
+        " .*disposition=accepted",
+        since=rotated,
+        nodes=[2],
+    )
+    ctx.assert_log_order(
+        [
+            "manifest_validation single_manifest_processed .*sequence=2",
+            "manifest_validation repair_sent .*sequence=2",
+        ],
+        since=rotated,
+        nodes=[2],
+    )
+
+    ctx.assert_not_log("Validation forwarded by peer is invalid", nodes=nodes)
+    ctx.assert_not_log("Validation: Too small", nodes=nodes)
+
+    log(
+        "PASS: mid-run rotation to sequence 2 propagated through an old"
+        " relay; the upgraded observer superseded and admitted the new"
+        " manifest and re-armed its repair lane at the new sequence"
+    )

--- a/.testnet/scenarios/manifest_validation_mixed_binaries.py
+++ b/.testnet/scenarios/manifest_validation_mixed_binaries.py
@@ -49,5 +49,6 @@ async def scenario(ctx, log):
     log(
         "PASS: a release relay accepted the upgraded sender's existing "
         "manifest/validation envelopes; the upgraded observer retained, "
-        "matched, verified, and admitted the relayed prerequisite"
+        "matched, verified, and admitted the relayed prerequisite, then "
+        "repaired the old middle node's later naked validations"
     )

--- a/.testnet/scenarios/manifest_validation_mixed_binaries.py
+++ b/.testnet/scenarios/manifest_validation_mixed_binaries.py
@@ -6,10 +6,12 @@ async def scenario(ctx, log):
     expected = ctx.topology_edges([(0, 1), (1, 2)])
 
     await ctx.apply_topology(expected, nodes=nodes, exact=False)
-    # One close is enough to produce the validator traffic under test. These
+    # The first close produces the validator traffic under test; later closes
+    # produce naked relays from the old middle node (it forwards a manifest
+    # singleton at most once), which must draw the bounded repair. These
     # binaries are different product revisions, so multi-ledger convergence is
     # deliberately not used as the protocol-compatibility oracle.
-    await ctx.wait_for_ledgers(1, node_id=0, timeout=90)
+    await ctx.wait_for_ledgers(3, node_id=0, timeout=180)
 
     # n0 is the sole validator and uses the new ordered prerequisite path
     # toward the old middle node. The old node processes and relays the two
@@ -25,6 +27,18 @@ async def scenario(ctx, log):
             "manifest_validation candidate_staged",
             "manifest_validation candidate_matched",
             "manifest_validation single_manifest_processed",
+        ],
+        nodes=[2],
+    )
+
+    # After durable admission, the old relay's later validations arrive
+    # naked; an authenticated naked validation is an implicit request, so
+    # the upgraded observer repairs its sender once per master/sequence.
+    ctx.assert_log("manifest_validation repair_sent", nodes=[2])
+    ctx.assert_log_order(
+        [
+            "manifest_validation single_manifest_processed",
+            "manifest_validation repair_sent",
         ],
         nodes=[2],
     )

--- a/.testnet/scenarios/manifest_validation_mixed_binaries.py
+++ b/.testnet/scenarios/manifest_validation_mixed_binaries.py
@@ -1,0 +1,39 @@
+"""Exercise manifest/validation traffic across old and new binaries."""
+
+
+async def scenario(ctx, log):
+    nodes = [0, 1, 2]
+    expected = ctx.topology_edges([(0, 1), (1, 2)])
+
+    await ctx.apply_topology(expected, nodes=nodes, exact=False)
+    # One close is enough to produce the validator traffic under test. These
+    # binaries are different product revisions, so multi-ledger convergence is
+    # deliberately not used as the protocol-compatibility oracle.
+    await ctx.wait_for_ledgers(1, node_id=0, timeout=90)
+
+    # n0 is the sole validator and uses the new ordered prerequisite path
+    # toward the old middle node. The old node processes and relays the two
+    # existing envelope types normally. n2 is a new observer and must retain
+    # the relayed candidate across unrelated traffic until its validation.
+    ctx.assert_log("manifest_validation pair_enqueued", nodes=[0])
+    ctx.assert_log("manifest_validation candidate_staged", nodes=[2])
+    ctx.assert_log("manifest_validation candidate_matched", nodes=[2])
+    ctx.assert_log("manifest_validation validation_parsed", nodes=[2])
+    ctx.assert_log("manifest_validation single_manifest_processed", nodes=[2])
+    ctx.assert_log_order(
+        [
+            "manifest_validation candidate_staged",
+            "manifest_validation candidate_matched",
+            "manifest_validation single_manifest_processed",
+        ],
+        nodes=[2],
+    )
+
+    ctx.assert_not_log("Validation forwarded by peer is invalid", nodes=nodes)
+    ctx.assert_not_log("Validation: Too small", nodes=nodes)
+
+    log(
+        "PASS: a release relay accepted the upgraded sender's existing "
+        "manifest/validation envelopes; the upgraded observer retained, "
+        "matched, verified, and admitted the relayed prerequisite"
+    )

--- a/.testnet/scenarios/manifest_validation_order.py
+++ b/.testnet/scenarios/manifest_validation_order.py
@@ -41,8 +41,8 @@ async def scenario(ctx, log):
         ctx.assert_log_order(
             [
                 staged_pattern,
-                matched_pattern,
                 validation_pattern,
+                matched_pattern,
             ],
             nodes=[node],
         )

--- a/.testnet/scenarios/manifest_validation_order.py
+++ b/.testnet/scenarios/manifest_validation_order.py
@@ -1,0 +1,69 @@
+"""Manifest packets precede validations across a real two-hop relay."""
+
+
+async def scenario(ctx, log):
+    nodes = [0, 1, 2]
+    expected = ctx.topology_edges([(0, 1), (1, 2)])
+
+    ctx.mark("before-manifest-validation-connect")
+    # A live TCP peer session is visible from both endpoints, so require the
+    # two links without treating their reverse views as extra connections.
+    await ctx.apply_topology(expected, nodes=nodes, exact=False)
+    await ctx.wait_for_ledgers(3, timeout=90)
+    ctx.mark("after-manifest-validation-ledgers")
+
+    send_pattern = r"manifest_validation send_prerequisite"
+    pair_pattern = r"manifest_validation pair_enqueued .*order=manifest,validation"
+    staged_pattern = r"manifest_validation candidate_staged"
+    matched_pattern = r"manifest_validation candidate_matched"
+    processed_pattern = r"manifest_validation single_manifest_processed"
+    validation_pattern = r"manifest_validation validation_parsed"
+
+    # This is a fresh per-test network, so the complete node logs are the
+    # scenario range. Avoid timestamp filtering: xahaud's custom local-time
+    # prefix is not yet understood by x-testnet's Marker parser.
+    for node in nodes:
+        sent = ctx.assert_log(send_pattern, nodes=[node])
+        paired = ctx.assert_log(pair_pattern, nodes=[node])
+        assert paired.count == sent.count, (
+            f"n{node} logged {sent.count} prerequisite sends but "
+            f"{paired.count} completed pairs"
+        )
+        ctx.assert_log_order([send_pattern, pair_pattern], nodes=[node])
+
+        staged = ctx.assert_log(staged_pattern, nodes=[node])
+        matched = ctx.assert_log(matched_pattern, nodes=[node])
+        assert matched.count <= staged.count, (
+            f"n{node} matched {matched.count} candidates after staging only "
+            f"{staged.count}"
+        )
+        ctx.assert_log(validation_pattern, nodes=[node])
+        ctx.assert_log_order(
+            [
+                staged_pattern,
+                matched_pattern,
+                validation_pattern,
+            ],
+            nodes=[node],
+        )
+
+    # n0 originates the sole listed validator's manifest and already owns it.
+    # The relay and observer must each admit that manifest; other valid pairs
+    # may remain ephemeral, so matched and durably processed counts are not
+    # expected to be equal.
+    for node in [1, 2]:
+        processed = ctx.assert_log(processed_pattern, nodes=[node])
+        matched = ctx.assert_log(matched_pattern, nodes=[node])
+        assert processed.count <= matched.count, (
+            f"n{node} processed {processed.count} manifests after matching "
+            f"only {matched.count} candidates"
+        )
+        ctx.assert_log_order(
+            [staged_pattern, matched_pattern, processed_pattern], nodes=[node]
+        )
+
+    log(
+        "PASS: every live peer enqueued manifest before validation and every "
+        "receiver staged and matched its one candidate, then applied it only "
+        "after the associated validation passed signature verification"
+    )

--- a/.testnet/scenarios/manifest_validation_order.yml
+++ b/.testnet/scenarios/manifest_validation_order.yml
@@ -1,0 +1,22 @@
+defaults:
+  network:
+    node_count: 3
+    validators: 1
+    launcher: tmux
+    fixed_peers: false
+    log_levels:
+      Protocol: debug
+
+tests:
+  - name: manifest_validation_order
+    script: .testnet/scenarios/manifest_validation_order.py
+
+  - name: manifest_validation_mixed_binaries
+    script: .testnet/scenarios/manifest_validation_mixed_binaries.py
+    network:
+      validators: 1
+      node_binaries:
+        1: "@release-3350"
+      log_levels:
+        Protocol: debug
+        Validations: debug

--- a/.testnet/scenarios/manifest_validation_order.yml
+++ b/.testnet/scenarios/manifest_validation_order.yml
@@ -20,3 +20,35 @@ tests:
       log_levels:
         Protocol: debug
         Validations: debug
+
+  - name: manifest_rotation_propagation
+    script: .testnet/scenarios/manifest_rotation_propagation.py
+    network:
+      validators: 1
+      node_binaries:
+        1: "@release-3350"
+      log_levels:
+        Protocol: debug
+        Validations: debug
+
+  - name: manifest_revocation_live
+    script: .testnet/scenarios/manifest_revocation_live.py
+    network:
+      node_count: 6
+      validators: 5
+      node_binaries:
+        5: "@release-3350"
+      log_levels:
+        Protocol: debug
+        Validations: debug
+
+  - name: manifest_wipe_recovery
+    script: .testnet/scenarios/manifest_wipe_recovery.py
+    network:
+      node_count: 4
+      validators: 1
+      node_binaries:
+        1: "@release-3350"
+      log_levels:
+        Protocol: debug
+        Validations: debug

--- a/.testnet/scenarios/manifest_wipe_recovery.py
+++ b/.testnet/scenarios/manifest_wipe_recovery.py
@@ -1,0 +1,97 @@
+"""Wipe a mid-chain node's wallet and watch both generations heal it.
+
+The forever cache's informal replicated history is gone from new nodes, so
+this pins what replaces it. A wiped upgraded node reconnects with empty
+durable state; its old-release upstream re-seeds it through the legacy
+connect-time dump lane, its own validation traffic re-pairs through
+always-send, and it resumes forwarding paired prerequisites downstream. The
+recovery, not a starvation, is the honest live boundary: every reachable
+topology heals, because old peers dump at connect and new peers re-send the
+prerequisite with every validation.
+"""
+
+from xahaud_scripts.testnet.scenario import (
+    AssertionError as ScenarioAssertion,
+)
+
+
+
+async def scenario(ctx, log):
+    nodes = [0, 1, 2, 3]
+    expected = ctx.topology_edges([(0, 1), (1, 2), (2, 3)])
+
+    await ctx.apply_topology(expected, nodes=nodes, exact=False)
+
+    # Baseline: knowledge reaches the end of the chain. The tail observer
+    # receives paired traffic from the upgraded mid-chain node. Admission at
+    # the tail implies the whole upstream chain, so wait on that log fact —
+    # four hops can trail the validator's fast-bootstrap ledger count.
+    await ctx.wait_for_ledgers(2, node_id=0, timeout=120)
+    deadline = 24
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log(
+                "manifest_validation single_manifest_processed .*sequence=1",
+                nodes=[3],
+            )
+            break
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"await-baseline-chain: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name="await-baseline-chain")
+    ctx.assert_log(
+        "manifest_validation single_manifest_processed .*sequence=1",
+        nodes=[2],
+    )
+
+    wiped = ctx.mark("wiped")
+    await ctx.restart_node(2, wipe_wallet_db=True)
+    log("restarted n2 with a wiped wallet database")
+
+    await ctx.wait_for_ledgers(3, node_id=0, timeout=180)
+
+    # Wait on the terminal log fact: resumed paired forwarding downstream is
+    # the last event in the recovery chain, so re-learning and re-admission
+    # must precede it.
+    deadline = 36
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log(
+                "manifest_validation send_prerequisite .*sequence=1",
+                since=wiped,
+                nodes=[2],
+            )
+            break
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"await-resumed-forwarding: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name="await-resumed-forwarding")
+
+    # Recovery: the wiped node re-learned the validator identity from live
+    # traffic (the old upstream's connect-time dump arrives as a singleton
+    # candidate; the next validation proves it) and admitted it durably
+    # again.
+    ctx.assert_log(
+        "manifest_validation candidate_staged .*sequence=1",
+        since=wiped,
+        nodes=[2],
+    )
+    ctx.assert_log(
+        "manifest_validation single_manifest_processed .*sequence=1"
+        " .*disposition=accepted",
+        since=wiped,
+        nodes=[2],
+    )
+
+    ctx.assert_not_log("Validation forwarded by peer is invalid", nodes=nodes)
+    ctx.assert_not_log("Validation: Too small", nodes=nodes)
+
+    log(
+        "PASS: a wallet-wiped mid-chain node re-learned the validator"
+        " identity from live traffic through an old upstream, re-admitted it"
+        " durably, and resumed paired forwarding to the tail observer"
+    )

--- a/.testnet/scenarios/manifest_wipe_recovery.py
+++ b/.testnet/scenarios/manifest_wipe_recovery.py
@@ -15,6 +15,20 @@ from xahaud_scripts.testnet.scenario import (
 )
 
 
+async def _await_log(ctx, log, pattern, *, nodes, name, since=None, deadline=36):
+    # Catch the runner's ScenarioAssertion, not the builtin. The scenario
+    # module shadows AssertionError without subclassing it.
+    for attempt in range(deadline):
+        try:
+            ctx.assert_log(pattern, nodes=nodes, **({"since": since} if since else {}))
+            return
+        except ScenarioAssertion:
+            if attempt == deadline - 1:
+                raise
+            if attempt % 6 == 5:
+                log(f"{name}: attempt {attempt + 1}/{deadline}")
+            await ctx.sleep(5, name=name)
+
 
 async def scenario(ctx, log):
     nodes = [0, 1, 2, 3]
@@ -25,22 +39,16 @@ async def scenario(ctx, log):
     # Baseline: knowledge reaches the end of the chain. The tail observer
     # receives paired traffic from the upgraded mid-chain node. Admission at
     # the tail implies the whole upstream chain, so wait on that log fact —
-    # four hops can trail the validator's fast-bootstrap ledger count.
+    # three hops can trail the validator's fast-bootstrap ledger count.
     await ctx.wait_for_ledgers(2, node_id=0, timeout=120)
-    deadline = 24
-    for attempt in range(deadline):
-        try:
-            ctx.assert_log(
-                "manifest_validation single_manifest_processed .*sequence=1",
-                nodes=[3],
-            )
-            break
-        except ScenarioAssertion:
-            if attempt == deadline - 1:
-                raise
-            if attempt % 6 == 5:
-                log(f"await-baseline-chain: attempt {attempt + 1}/{deadline}")
-            await ctx.sleep(5, name="await-baseline-chain")
+    await _await_log(
+        ctx,
+        log,
+        "manifest_validation single_manifest_processed .*sequence=1",
+        nodes=[3],
+        name="await-baseline-chain",
+        deadline=24,
+    )
     ctx.assert_log(
         "manifest_validation single_manifest_processed .*sequence=1",
         nodes=[2],
@@ -55,21 +63,15 @@ async def scenario(ctx, log):
     # Wait on the terminal log fact: resumed paired forwarding downstream is
     # the last event in the recovery chain, so re-learning and re-admission
     # must precede it.
-    deadline = 36
-    for attempt in range(deadline):
-        try:
-            ctx.assert_log(
-                "manifest_validation send_prerequisite .*sequence=1",
-                since=wiped,
-                nodes=[2],
-            )
-            break
-        except ScenarioAssertion:
-            if attempt == deadline - 1:
-                raise
-            if attempt % 6 == 5:
-                log(f"await-resumed-forwarding: attempt {attempt + 1}/{deadline}")
-            await ctx.sleep(5, name="await-resumed-forwarding")
+    await _await_log(
+        ctx,
+        log,
+        "manifest_validation send_prerequisite .*sequence=1",
+        nodes=[2],
+        name="await-resumed-forwarding",
+        since=wiped,
+        deadline=36,
+    )
 
     # Recovery: the wiped node re-learned the validator identity from live
     # traffic (the old upstream's connect-time dump arrives as a singleton

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -454,6 +454,8 @@ public:
         auto const sk = randomSecretKey();
         auto const pk = derivePublicKey(KeyType::ed25519, sk);
 
+        BEAST_EXPECT(!cache.getManifestSnapshot(pk));
+
         // getSigningKey should return same key if there is no manifest
         BEAST_EXPECT(cache.getSigningKey(pk) == pk);
 
@@ -468,6 +470,17 @@ public:
                 sk, KeyType::ed25519, kp0.second, KeyType::secp256k1, 0)));
         BEAST_EXPECT(cache.getSigningKey(pk) == kp0.first);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == pk);
+        if (auto const snapshot = cache.getManifestSnapshot(kp0.first))
+        {
+            BEAST_EXPECT(snapshot->masterKey == pk);
+            BEAST_EXPECT(snapshot->signingKey == kp0.first);
+            BEAST_EXPECT(snapshot->sequence == 0);
+            BEAST_EXPECT(!snapshot->revoked());
+        }
+        else
+        {
+            fail("current signing key resolves its manifest snapshot");
+        }
 
         // getSigningKey should return the latest ephemeral public key
         // for the listed validator master public key
@@ -481,6 +494,16 @@ public:
         BEAST_EXPECT(cache.getSigningKey(pk) == kp1.first);
         BEAST_EXPECT(cache.getMasterKey(kp1.first) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
+        BEAST_EXPECT(!cache.getManifestSnapshot(kp0.first));
+        if (auto const snapshot = cache.getManifestSnapshot(pk))
+        {
+            BEAST_EXPECT(snapshot->signingKey == kp1.first);
+            BEAST_EXPECT(snapshot->sequence == 1);
+        }
+        else
+        {
+            fail("master key resolves its current manifest snapshot");
+        }
 
         // getSigningKey and getMasterKey should fail if a new manifest is
         // applied with the same signing key but a higher sequence
@@ -502,6 +525,16 @@ public:
         BEAST_EXPECT(cache.getSigningKey(pk) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
         BEAST_EXPECT(cache.getMasterKey(kp1.first) == kp1.first);
+        if (auto const snapshot = cache.getManifestSnapshot(pk))
+        {
+            BEAST_EXPECT(snapshot->revoked());
+            BEAST_EXPECT(!snapshot->signingKey);
+        }
+        else
+        {
+            fail("master key resolves its revocation snapshot");
+        }
+        BEAST_EXPECT(!cache.getManifestSnapshot(kp1.first));
     }
 
     void

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -1255,6 +1255,60 @@ private:
                 !payloads.empty() && payloads.back() == correctionNormal);
         }
 
+        // The connection assertion does not authorize an ordinary unlisted
+        // rotation. Without a matching validation it remains only the one
+        // bounded pending candidate and cannot alter retained state.
+        auto const correctionNextSigningSecret = randomSecretKey();
+        protocol::TMManifests ordinaryResponse;
+        ordinaryResponse.add_list()->set_stobject(makeManifest(
+            correctionMasterSecret,
+            correctionMasterKey,
+            correctionNextSigningSecret,
+            1));
+        BEAST_EXPECT(
+            correctionPeer->receive(ordinaryResponse, protocol::mtMANIFESTS));
+        {
+            auto const current =
+                env.app().validatorManifests().getManifestSnapshot(
+                    correctionMasterKey);
+            BEAST_EXPECT(
+                current && !current->revoked() && current->sequence == 0 &&
+                current->signingKey == correctionSigningKey);
+        }
+
+        // The response qualification is only an ingress gate. A forged
+        // terminal answer still reaches ordinary manifest verification and
+        // cannot apply or relay.
+        auto const forgedResponseMasterSecret = randomSecretKey();
+        STObject forgedRevocation(sfGeneric);
+        forgedRevocation[sfSequence] =
+            std::numeric_limits<std::uint32_t>::max();
+        forgedRevocation[sfPublicKey] = correctionMasterKey;
+        sign(
+            forgedRevocation,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            forgedResponseMasterSecret,
+            sfMasterSignature);
+        protocol::TMManifests forgedResponse;
+        forgedResponse.add_list()->set_stobject(serialize(forgedRevocation));
+        auto const beforeForgedResponse =
+            PeerTest::sentTypes(correctionPeerId).size();
+        BEAST_EXPECT(
+            correctionPeer->receive(forgedResponse, protocol::mtMANIFESTS));
+        env.app().getJobQueue().rendezvous();
+        {
+            auto const current =
+                env.app().validatorManifests().getManifestSnapshot(
+                    correctionMasterKey);
+            BEAST_EXPECT(
+                current && !current->revoked() && current->sequence == 0 &&
+                current->signingKey == correctionSigningKey);
+        }
+        BEAST_EXPECT(
+            PeerTest::sentTypes(correctionPeerId).size() ==
+            beforeForgedResponse);
+
         STObject correctionRevocation(sfGeneric);
         correctionRevocation[sfSequence] =
             std::numeric_limits<std::uint32_t>::max();

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -29,6 +29,7 @@
 #include <xrpl/protocol/Sign.h>
 #include <algorithm>
 #include <condition_variable>
+#include <future>
 #include <limits>
 #include <mutex>
 
@@ -166,12 +167,25 @@ private:
         bool
         receive(MessageType const& message, protocol::MessageType type)
         {
-            Message wire(message, type);
-            auto const& buffer = wire.getBuffer(compression::Compressed::Off);
-            std::size_t hint = 0;
-            auto const [consumed, ec] =
-                invokeProtocolMessage(boost::asio::buffer(buffer), *this, hint);
-            return !ec && consumed == buffer.size();
+            auto wire = std::make_shared<Message>(message, type);
+            auto completed = std::make_shared<std::promise<bool>>();
+            auto result = completed->get_future();
+            dispatchOnStrand([this, wire, completed]() {
+                try
+                {
+                    auto const& buffer =
+                        wire->getBuffer(compression::Compressed::Off);
+                    std::size_t hint = 0;
+                    auto const [consumed, ec] = invokeProtocolMessage(
+                        boost::asio::buffer(buffer), *this, hint);
+                    completed->set_value(!ec && consumed == buffer.size());
+                }
+                catch (...)
+                {
+                    completed->set_exception(std::current_exception());
+                }
+            });
+            return result.get();
         }
 
         void
@@ -1066,12 +1080,11 @@ private:
         oversizedObject.add_list()->set_stobject(std::string(4097, 'x'));
         BEAST_EXPECT(peer->receive(oversizedObject, protocol::mtMANIFESTS));
 
-        // A strictly stale singleton proves its sender is behind for a
-        // retained master, and draws the retained manifest back — or the
-        // revocation, the freshest possible answer. Equal-sequence arrivals
-        // are ordinary always-send traffic and draw nothing; the shared
-        // repair ledger bounds every answer to once per sequence per
-        // connection.
+        // A strictly lower sequence claims its sender is behind for a retained
+        // master, and draws the retained manifest back — or the revocation,
+        // the freshest possible answer. Equal-sequence arrivals are ordinary
+        // always-send traffic and draw nothing; the shared repair ledger
+        // suppresses duplicate answers while its row survives.
         testcase("stale singleton draws the fresher manifest back");
         addPeer(env, peers, disabled);
         auto const stalePeer = peers.back();
@@ -1112,7 +1125,7 @@ private:
             BEAST_EXPECT(
                 types.size() == beforeStale + 1 &&
                 types.back() == protocol::mtMANIFESTS);
-            auto const payloads = PeerTest::sentManifestPayloads();
+            auto const payloads = PeerTest::sentManifestPayloads(stalePeerId);
             BEAST_EXPECT(
                 behindCurrent && !payloads.empty() &&
                 payloads.back() == behindCurrent->serialized);
@@ -1185,11 +1198,142 @@ private:
                 types.size() >= 2 &&
                 types[types.size() - 2] == protocol::mtMANIFESTS &&
                 types.back() == protocol::mtMANIFESTS);
-            auto const payloads = PeerTest::sentManifestPayloads();
+            auto const payloads = PeerTest::sentManifestPayloads(stalePeerId);
             BEAST_EXPECT(
                 !payloads.empty() &&
                 payloads.back() == buriedRevocationSerialized);
         }
+
+        // A terminal response is stronger than an unsolicited unlisted
+        // revocation only when this connection previously asserted an older
+        // retained manifest for the same master. The response can then end
+        // that already-retained authority and relay onward; it still cannot
+        // allocate a new master.
+        testcase("retained revocation response crosses local listing");
+        addPeer(env, peers, disabled);
+        auto const correctionPeer = peers.back();
+        auto const correctionPeerId = correctionPeer->id();
+
+        auto const correctionMasterSecret = randomSecretKey();
+        auto const correctionMasterKey =
+            derivePublicKey(KeyType::ed25519, correctionMasterSecret);
+        auto const correctionSigningSecret = randomSecretKey();
+        auto const correctionSigningKey =
+            derivePublicKey(KeyType::secp256k1, correctionSigningSecret);
+        auto const correctionNormal = makeManifest(
+            correctionMasterSecret,
+            correctionMasterKey,
+            correctionSigningSecret,
+            0);
+        {
+            auto parsed = deserializeManifest(correctionNormal);
+            BEAST_EXPECT(parsed);
+            if (!parsed)
+                return;
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*parsed)) == ManifestDisposition::accepted);
+        }
+        BEAST_EXPECT(!env.app().validators().listed(correctionMasterKey));
+
+        auto const beforeAssertion =
+            PeerTest::sentTypes(correctionPeerId).size();
+        protocol::TMValidation assertedValidation;
+        assertedValidation.set_validation("asserted validation");
+        env.app().overlay().broadcast(assertedValidation, correctionSigningKey);
+        BEAST_EXPECT(
+            PeerTest::waitForMessages(correctionPeerId, beforeAssertion + 2));
+        {
+            auto const types = PeerTest::sentTypes(correctionPeerId);
+            BEAST_EXPECT(
+                types.size() == beforeAssertion + 2 &&
+                types[types.size() - 2] == protocol::mtMANIFESTS &&
+                types.back() == protocol::mtVALIDATION);
+            auto const payloads =
+                PeerTest::sentManifestPayloads(correctionPeerId);
+            BEAST_EXPECT(
+                !payloads.empty() && payloads.back() == correctionNormal);
+        }
+
+        STObject correctionRevocation(sfGeneric);
+        correctionRevocation[sfSequence] =
+            std::numeric_limits<std::uint32_t>::max();
+        correctionRevocation[sfPublicKey] = correctionMasterKey;
+        sign(
+            correctionRevocation,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            correctionMasterSecret,
+            sfMasterSignature);
+        auto const correctionRevocationSerialized =
+            serialize(correctionRevocation);
+        {
+            protocol::TMManifests response;
+            response.add_list()->set_stobject(correctionRevocationSerialized);
+            BEAST_EXPECT(
+                correctionPeer->receive(response, protocol::mtMANIFESTS));
+        }
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(
+            env.app().validatorManifests().revoked(correctionMasterKey));
+        BEAST_EXPECT(
+            PeerTest::waitForMessages(correctionPeerId, beforeAssertion + 3));
+        {
+            auto const payloads =
+                PeerTest::sentManifestPayloads(correctionPeerId);
+            BEAST_EXPECT(
+                payloads.size() >= 2 &&
+                payloads.back() == correctionRevocationSerialized);
+        }
+
+        // Retention alone is insufficient: without an older assertion on
+        // this connection, an unlisted revocation remains neither admitted
+        // nor relayed.
+        addPeer(env, peers, disabled);
+        auto const unsolicitedPeer = peers.back();
+        auto const unsolicitedPeerId = unsolicitedPeer->id();
+        auto const unsolicitedMasterSecret = randomSecretKey();
+        auto const unsolicitedMasterKey =
+            derivePublicKey(KeyType::ed25519, unsolicitedMasterSecret);
+        auto const unsolicitedSigningSecret = randomSecretKey();
+        {
+            auto parsed = deserializeManifest(makeManifest(
+                unsolicitedMasterSecret,
+                unsolicitedMasterKey,
+                unsolicitedSigningSecret,
+                0));
+            BEAST_EXPECT(parsed);
+            if (!parsed)
+                return;
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*parsed)) == ManifestDisposition::accepted);
+        }
+        STObject unsolicitedRevocation(sfGeneric);
+        unsolicitedRevocation[sfSequence] =
+            std::numeric_limits<std::uint32_t>::max();
+        unsolicitedRevocation[sfPublicKey] = unsolicitedMasterKey;
+        sign(
+            unsolicitedRevocation,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            unsolicitedMasterSecret,
+            sfMasterSignature);
+        protocol::TMManifests unsolicited;
+        unsolicited.add_list()->set_stobject(serialize(unsolicitedRevocation));
+        auto const beforeUnsolicited =
+            PeerTest::sentTypes(unsolicitedPeerId).size();
+        BEAST_EXPECT(
+            unsolicitedPeer->receive(unsolicited, protocol::mtMANIFESTS));
+        env.app().getJobQueue().rendezvous();
+        auto const unsolicitedCurrent =
+            env.app().validatorManifests().getManifestSnapshot(
+                unsolicitedMasterKey);
+        BEAST_EXPECT(
+            unsolicitedCurrent && !unsolicitedCurrent->revoked() &&
+            unsolicitedCurrent->sequence == 0);
+        BEAST_EXPECT(
+            PeerTest::sentTypes(unsolicitedPeerId).size() == beforeUnsolicited);
 
         // A naked validation that authenticates against the current cached
         // manifest is an implicit request for that manifest. The recipient

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -150,8 +150,11 @@ private:
                                 buffer.size() - compression::headerBytes)))
                     {
                         for (auto const& manifest : manifests.list())
-                            sentManifestPayloads_.push_back(
-                                manifest.stobject());
+                        {
+                            auto const payload = manifest.stobject();
+                            sentManifestPayloads_.push_back(payload);
+                            sentPeerManifests_.emplace_back(id(), payload);
+                        }
                     }
                 }
                 sendTx_++;
@@ -186,6 +189,7 @@ private:
             sentTypes_.clear();
             sentPeerTypes_.clear();
             sentManifestPayloads_.clear();
+            sentPeerManifests_.clear();
         }
         static bool
         waitForMessages(std::size_t count)
@@ -231,6 +235,16 @@ private:
             std::lock_guard lock(sentMutex_);
             return sentManifestPayloads_;
         }
+        static std::vector<std::string>
+        sentManifestPayloads(Peer::id_t peer)
+        {
+            std::lock_guard lock(sentMutex_);
+            std::vector<std::string> result;
+            for (auto const& [recipient, payload] : sentPeerManifests_)
+                if (recipient == peer)
+                    result.push_back(payload);
+            return result;
+        }
         inline static std::size_t sid_ = 0;
         inline static std::uint16_t queueTx_ = 0;
         inline static std::uint16_t sendTx_ = 0;
@@ -239,6 +253,8 @@ private:
         inline static std::vector<int> sentTypes_;
         inline static std::vector<std::pair<Peer::id_t, int>> sentPeerTypes_;
         inline static std::vector<std::string> sentManifestPayloads_;
+        inline static std::vector<std::pair<Peer::id_t, std::string>>
+            sentPeerManifests_;
     };
 
     std::uint16_t lid_{0};
@@ -1097,13 +1113,18 @@ private:
             BEAST_EXPECT(
                 types.size() == beforeRepair + 1 &&
                 types.back() == protocol::mtMANIFESTS);
-            auto const payloads = PeerTest::sentManifestPayloads();
+            auto const payloads =
+                PeerTest::sentManifestPayloads(repairSourceId);
             BEAST_EXPECT(
                 !payloads.empty() && payloads.back() == memorySerialized);
         }
 
         // Duplicate: a later distinct validation under the same manifest
-        // sequence draws no second repair.
+        // sequence still posts a repair attempt; the strand no-ops it.
+        // Unknown-signer and paired traffic never post. The sentinel below
+        // is a later strand-FIFO send, so exactly two singletons prove the
+        // duplicate did not sneak a send, and the never-posted cases sent
+        // nothing either.
         BEAST_EXPECT(repairSource->receive(
             makeValidationAt(
                 memoryMasterKey,

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -1050,6 +1050,173 @@ private:
         oversizedObject.add_list()->set_stobject(std::string(4097, 'x'));
         BEAST_EXPECT(peer->receive(oversizedObject, protocol::mtMANIFESTS));
 
+        // A naked validation that authenticates against the current cached
+        // manifest is an implicit request for that manifest. The recipient
+        // repairs the sender with one singleton on the same connection, at
+        // most once per master/sequence. Duplicate, unknown-signer, and
+        // paired traffic draw nothing; a later repairable master proves via
+        // strand FIFO that those declines happened rather than raced.
+        testcase("naked validation repairs the sender");
+        addPeer(env, peers, disabled);
+        auto const repairSource = peers.back();
+        auto const repairSourceId = repairSource->id();
+
+        auto const memoryMasterSecret = randomSecretKey();
+        auto const memoryMasterKey =
+            derivePublicKey(KeyType::ed25519, memoryMasterSecret);
+        listMaster(memoryMasterKey);
+        auto const memorySigningSecret = randomSecretKey();
+        auto const memorySigningKey =
+            derivePublicKey(KeyType::secp256k1, memorySigningSecret);
+        auto const memorySerialized = makeManifest(
+            memoryMasterSecret, memoryMasterKey, memorySigningSecret, 0);
+        {
+            auto parsed = deserializeManifest(memorySerialized);
+            BEAST_EXPECT(parsed);
+            if (!parsed)
+                return;
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*parsed)) == ManifestDisposition::accepted);
+        }
+
+        auto const beforeRepair = PeerTest::sentTypes(repairSourceId).size();
+        BEAST_EXPECT(repairSource->receive(
+            makeValidationAt(
+                memoryMasterKey,
+                memorySigningKey,
+                memorySigningSecret,
+                env.app().timeKeeper().closeTime(),
+                uint256{101}),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(
+            PeerTest::waitForMessages(repairSourceId, beforeRepair + 1));
+        {
+            auto const types = PeerTest::sentTypes(repairSourceId);
+            BEAST_EXPECT(
+                types.size() == beforeRepair + 1 &&
+                types.back() == protocol::mtMANIFESTS);
+            auto const payloads = PeerTest::sentManifestPayloads();
+            BEAST_EXPECT(
+                !payloads.empty() && payloads.back() == memorySerialized);
+        }
+
+        // Duplicate: a later distinct validation under the same manifest
+        // sequence draws no second repair.
+        BEAST_EXPECT(repairSource->receive(
+            makeValidationAt(
+                memoryMasterKey,
+                memorySigningKey,
+                memorySigningSecret,
+                env.app().timeKeeper().closeTime() + std::chrono::seconds{1},
+                uint256{102}),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+
+        // Unknown signer: dropped before any response can exist.
+        auto const strangerSecret = randomSecretKey();
+        auto const strangerKey =
+            derivePublicKey(KeyType::secp256k1, strangerSecret);
+        BEAST_EXPECT(repairSource->receive(
+            makeValidationAt(
+                strangerKey,
+                strangerKey,
+                strangerSecret,
+                env.app().timeKeeper().closeTime(),
+                uint256{103}),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+
+        // Paired: the sender proved it holds the prerequisite; no repair.
+        auto const pairedMasterSecret = randomSecretKey();
+        auto const pairedMasterKey =
+            derivePublicKey(KeyType::ed25519, pairedMasterSecret);
+        auto const pairedSigningSecret = randomSecretKey();
+        auto const pairedSigningKey =
+            derivePublicKey(KeyType::secp256k1, pairedSigningSecret);
+        {
+            protocol::TMManifests pairedPrerequisite;
+            pairedPrerequisite.add_list()->set_stobject(makeManifest(
+                pairedMasterSecret, pairedMasterKey, pairedSigningSecret, 0));
+            BEAST_EXPECT(repairSource->receive(
+                pairedPrerequisite, protocol::mtMANIFESTS));
+        }
+        BEAST_EXPECT(repairSource->receive(
+            makeValidationAt(
+                pairedMasterKey,
+                pairedSigningKey,
+                pairedSigningSecret,
+                env.app().timeKeeper().closeTime(),
+                uint256{104}),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+
+        // Sentinel: a second repairable master must arrive after the three
+        // declines above on the same strand, so exactly two repair
+        // singletons prove the ledger's bound held.
+        auto const memoryMasterSecret1 = randomSecretKey();
+        auto const memoryMasterKey1 =
+            derivePublicKey(KeyType::ed25519, memoryMasterSecret1);
+        listMaster(memoryMasterKey1);
+        auto const memorySigningSecret1 = randomSecretKey();
+        auto const memorySigningKey1 =
+            derivePublicKey(KeyType::secp256k1, memorySigningSecret1);
+        {
+            auto parsed = deserializeManifest(makeManifest(
+                memoryMasterSecret1,
+                memoryMasterKey1,
+                memorySigningSecret1,
+                0));
+            BEAST_EXPECT(parsed);
+            if (!parsed)
+                return;
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*parsed)) == ManifestDisposition::accepted);
+        }
+        BEAST_EXPECT(repairSource->receive(
+            makeValidationAt(
+                memoryMasterKey1,
+                memorySigningKey1,
+                memorySigningSecret1,
+                env.app().timeKeeper().closeTime(),
+                uint256{105}),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(
+            PeerTest::waitForMessages(repairSourceId, beforeRepair + 2));
+        {
+            auto const types = PeerTest::sentTypes(repairSourceId);
+            BEAST_EXPECT(types.size() == beforeRepair + 2);
+            BEAST_EXPECT(
+                types.size() >= 2 &&
+                types[types.size() - 2] == protocol::mtMANIFESTS &&
+                types.back() == protocol::mtMANIFESTS);
+        }
+
+        // The sender half of the invariant: a validation whose signing key
+        // has no cached manifest still broadcasts, naked.
+        auto const orphanSecret = randomSecretKey();
+        auto const orphanKey =
+            derivePublicKey(KeyType::secp256k1, orphanSecret);
+        auto orphanValidation = makeValidationAt(
+            orphanKey,
+            orphanKey,
+            orphanSecret,
+            env.app().timeKeeper().closeTime(),
+            uint256{106});
+        auto const beforeOrphan = PeerTest::sentTypes(repairSourceId).size();
+        env.app().overlay().broadcast(orphanValidation, orphanKey);
+        BEAST_EXPECT(
+            PeerTest::waitForMessages(repairSourceId, beforeOrphan + 1));
+        {
+            auto const types = PeerTest::sentTypes(repairSourceId);
+            BEAST_EXPECT(
+                types.size() == beforeOrphan + 1 &&
+                types.back() == protocol::mtVALIDATION);
+        }
+
         // A naked validation whose signer has no trusted or retained master
         // mapping is not useful, and must not front-run the real validation
         // hash. A later verified pair remains processable and relays in wire
@@ -1234,6 +1401,26 @@ private:
                 .getHashRouter()
                 .addSuppressionPeerWithStatus(forgedValidationHash, 65000)
                 .first);
+
+        // A forged naked validation for a repairable signer authenticates
+        // nothing and must draw no repair singleton. Terminal fee case:
+        // isolate it on its own connection.
+        addPeer(env, peers, disabled);
+        auto const forgedNakedPeer = peers.back();
+        auto const forgedNakedId = forgedNakedPeer->id();
+        auto forgedNakedValidation = makeValidationAt(
+            memoryMasterKey,
+            memorySigningKey,
+            memorySigningSecret,
+            env.app().timeKeeper().closeTime() + std::chrono::seconds{2},
+            uint256{107});
+        auto* forgedNakedBytes = forgedNakedValidation.mutable_validation();
+        if (BEAST_EXPECT(!forgedNakedBytes->empty()))
+            forgedNakedBytes->back() ^= 0x01;
+        BEAST_EXPECT(forgedNakedPeer->receive(
+            forgedNakedValidation, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(PeerTest::sentTypes(forgedNakedId).empty());
     }
 
     void

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -192,6 +192,25 @@ private:
             return sentCv_.wait_for(
                 lock, 5s, [count] { return sentTypes_.size() >= count; });
         }
+        static bool
+        waitForMessageQuiescence()
+        {
+            using namespace std::chrono_literals;
+            auto const deadline = std::chrono::steady_clock::now() + 5s;
+            std::unique_lock lock(sentMutex_);
+            for (;;)
+            {
+                auto const count = sentTypes_.size();
+                auto const quietUntil =
+                    std::min(deadline, std::chrono::steady_clock::now() + 50ms);
+                if (!sentCv_.wait_until(lock, quietUntil, [count] {
+                        return sentTypes_.size() != count;
+                    }))
+                    return true;
+                if (std::chrono::steady_clock::now() >= deadline)
+                    return false;
+            }
+        }
         static std::vector<int>
         sentTypes()
         {
@@ -558,7 +577,9 @@ private:
     {
         testcase("incoming manifest candidate is connection-bounded");
 
-        jtx::Env env(*this);
+        auto config = jtx::envconfig();
+        config->WORKERS = 1;
+        jtx::Env env(*this, std::move(config));
         std::vector<std::shared_ptr<PeerTest>> peers;
         std::uint16_t disabled = 0;
         PeerTest::init();
@@ -643,6 +664,142 @@ private:
                 {}));
             BEAST_EXPECT(env.app().validators().listed(masterKey));
         };
+
+        struct JobGate
+        {
+            std::mutex mutex;
+            std::condition_variable cv;
+            bool started = false;
+            bool released = false;
+        };
+        auto holdJobQueue = [&]() {
+            auto gate = std::make_shared<JobGate>();
+            BEAST_EXPECT(env.app().getJobQueue().addJob(
+                jtCLIENT, "hold manifest pair verification", [gate]() {
+                    std::unique_lock lock(gate->mutex);
+                    gate->started = true;
+                    gate->cv.notify_all();
+                    gate->cv.wait(lock, [gate] { return gate->released; });
+                }));
+            {
+                std::unique_lock lock(gate->mutex);
+                BEAST_EXPECT(
+                    gate->cv.wait_for(lock, std::chrono::seconds{5}, [gate] {
+                        return gate->started;
+                    }));
+            }
+            return gate;
+        };
+        auto releaseJobQueue = [&](std::shared_ptr<JobGate> const& gate) {
+            {
+                std::lock_guard lock(gate->mutex);
+                gate->released = true;
+            }
+            gate->cv.notify_all();
+            env.app().getJobQueue().rendezvous();
+        };
+        auto validationJobCount = [&]() {
+            return env.app().getJobQueue().getJobCountTotal(jtVALIDATION_t) +
+                env.app().getJobQueue().getJobCountTotal(jtVALIDATION_ut);
+        };
+
+        // A claimed candidate owns exactly one crypto job. While that job is
+        // held, one later candidate may occupy the now-free connection slot;
+        // its validation is deliberately dropped and heals when the sender
+        // repeats the pair after the first job completes.
+        testcase("manifest pair verification is one-in-flight");
+        auto const burstMasterSecret0 = randomSecretKey();
+        auto const burstMasterKey0 =
+            derivePublicKey(KeyType::ed25519, burstMasterSecret0);
+        listMaster(burstMasterKey0);
+        auto const burstSigningSecret0 = randomSecretKey();
+        auto const burstSigningKey0 =
+            derivePublicKey(KeyType::secp256k1, burstSigningSecret0);
+        auto const burstManifest0 = makeManifest(
+            burstMasterSecret0, burstMasterKey0, burstSigningSecret0, 0);
+        auto const burstValidation0 = makeValidation(
+            burstMasterKey0, burstSigningKey0, burstSigningSecret0);
+
+        auto const burstMasterSecret1 = randomSecretKey();
+        auto const burstMasterKey1 =
+            derivePublicKey(KeyType::ed25519, burstMasterSecret1);
+        listMaster(burstMasterKey1);
+        auto const burstSigningSecret1 = randomSecretKey();
+        auto const burstSigningKey1 =
+            derivePublicKey(KeyType::secp256k1, burstSigningSecret1);
+        auto const burstManifest1 = makeManifest(
+            burstMasterSecret1, burstMasterKey1, burstSigningSecret1, 0);
+        auto const burstValidation1 = makeValidation(
+            burstMasterKey1, burstSigningKey1, burstSigningSecret1);
+
+        auto const gate0 = holdJobQueue();
+        auto const jobsBeforeBurst = validationJobCount();
+        BEAST_EXPECT(receiveManifest(burstManifest0));
+        BEAST_EXPECT(peer->receive(burstValidation0, protocol::mtVALIDATION));
+        BEAST_EXPECT(receiveManifest(burstManifest1));
+        BEAST_EXPECT(peer->receive(burstValidation1, protocol::mtVALIDATION));
+        BEAST_EXPECT(validationJobCount() == jobsBeforeBurst + 1);
+        releaseJobQueue(gate0);
+
+        auto const burstAdmitted0 =
+            env.app().validatorManifests().getManifestSnapshot(burstMasterKey0);
+        BEAST_EXPECT(
+            burstAdmitted0 && burstAdmitted0->signingKey == burstSigningKey0);
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            burstMasterKey1));
+
+        // The second candidate stayed bounded in the waiting slot. A repeated
+        // pair after completion proves that it was neither displaced nor
+        // permanently wedged by the first job.
+        BEAST_EXPECT(receiveManifest(burstManifest1));
+        BEAST_EXPECT(peer->receive(burstValidation1, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const burstAdmitted1 =
+            env.app().validatorManifests().getManifestSnapshot(burstMasterKey1);
+        BEAST_EXPECT(
+            burstAdmitted1 && burstAdmitted1->signingKey == burstSigningKey1);
+
+        // One forged listed-looking candidate cannot be copied into an
+        // unbounded number of distinct validation jobs. The peer is expected
+        // to receive a terminal signature charge when the sole job runs, so
+        // isolate this pressure control on its own connection.
+        addPeer(env, peers, disabled);
+        auto const burstPeer = peers.back();
+        auto const forgedBurstMasterSecret = randomSecretKey();
+        auto const forgedBurstMasterKey =
+            derivePublicKey(KeyType::ed25519, forgedBurstMasterSecret);
+        listMaster(forgedBurstMasterKey);
+        auto const forgedBurstSigningSecret = randomSecretKey();
+        auto const forgedBurstSigningKey =
+            derivePublicKey(KeyType::secp256k1, forgedBurstSigningSecret);
+        auto const wrongBurstMasterSecret = randomSecretKey();
+        protocol::TMManifests forgedBurstManifest;
+        forgedBurstManifest.add_list()->set_stobject(makeManifest(
+            forgedBurstMasterSecret,
+            forgedBurstMasterKey,
+            forgedBurstSigningSecret,
+            0,
+            &wrongBurstMasterSecret));
+
+        auto const gate1 = holdJobQueue();
+        auto const jobsBeforeForgedBurst = validationJobCount();
+        BEAST_EXPECT(
+            burstPeer->receive(forgedBurstManifest, protocol::mtMANIFESTS));
+        for (std::uint64_t i = 0; i < 8; ++i)
+        {
+            auto validation = makeValidationAt(
+                forgedBurstMasterKey,
+                forgedBurstSigningKey,
+                forgedBurstSigningSecret,
+                env.app().timeKeeper().closeTime(),
+                uint256{i + 10});
+            BEAST_EXPECT(
+                burstPeer->receive(validation, protocol::mtVALIDATION));
+        }
+        BEAST_EXPECT(validationJobCount() == jobsBeforeForgedBurst + 1);
+        releaseJobQueue(gate1);
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            forgedBurstMasterKey));
 
         // A normal manifest is only structurally staged on receipt. The first
         // candidate owns the connection's bounded slot until a matching
@@ -900,6 +1057,7 @@ private:
             repairMasterSecret, repairMasterKey, repairSigningSecret, 0);
         auto const repairValidation = makeValidation(
             repairMasterKey, repairSigningKey, repairSigningSecret);
+        BEAST_EXPECT(PeerTest::waitForMessageQuiescence());
         auto const messagesBeforeRepair = PeerTest::sentTypes().size();
 
         BEAST_EXPECT(peer->receive(repairValidation, protocol::mtVALIDATION));
@@ -969,6 +1127,35 @@ private:
                 .getHashRouter()
                 .addSuppressionPeerWithStatus(collisionValidationHash1, 65001)
                 .first);
+
+        // The key-role refusal completed the sole in-flight job. A fresh
+        // candidate on the same connection can therefore claim the slot and
+        // complete normally.
+        auto const afterFailureMasterSecret = randomSecretKey();
+        auto const afterFailureMasterKey =
+            derivePublicKey(KeyType::ed25519, afterFailureMasterSecret);
+        listMaster(afterFailureMasterKey);
+        auto const afterFailureSigningSecret = randomSecretKey();
+        auto const afterFailureSigningKey =
+            derivePublicKey(KeyType::secp256k1, afterFailureSigningSecret);
+        BEAST_EXPECT(receiveManifest(makeManifest(
+            afterFailureMasterSecret,
+            afterFailureMasterKey,
+            afterFailureSigningSecret,
+            0)));
+        BEAST_EXPECT(peer->receive(
+            makeValidation(
+                afterFailureMasterKey,
+                afterFailureSigningKey,
+                afterFailureSigningSecret),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const admittedAfterFailure =
+            env.app().validatorManifests().getManifestSnapshot(
+                afterFailureMasterKey);
+        BEAST_EXPECT(
+            admittedAfterFailure &&
+            admittedAfterFailure->signingKey == afterFailureSigningKey);
 
         // A valid manifest followed by a parseable validation with a bad
         // signature must not gain cache admission merely because the signing

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -18,11 +18,18 @@
 //==============================================================================
 #include <test/jtx.h>
 #include <test/jtx/Env.h>
+#include <xrpld/app/misc/HashRouter.h>
+#include <xrpld/app/misc/Manifest.h>
+#include <xrpld/app/misc/ValidatorList.h>
 #include <xrpld/overlay/detail/OverlayImpl.h>
 #include <xrpld/overlay/detail/PeerImp.h>
 #include <xrpld/peerfinder/detail/SlotImp.h>
 #include <xrpl/basics/make_SSLContext.h>
 #include <xrpl/beast/unit_test.h>
+#include <xrpl/protocol/Sign.h>
+#include <condition_variable>
+#include <limits>
+#include <mutex>
 
 namespace ripple {
 
@@ -123,10 +130,45 @@ private:
         {
         }
         void
-        send(std::shared_ptr<Message> const&) override
+        send(std::shared_ptr<Message> const& message) override
         {
-            sendTx_++;
+            auto const& buffer =
+                message->getBuffer(compression::Compressed::Off);
+            auto const type = (static_cast<int>(buffer[4]) << 8) |
+                static_cast<int>(buffer[5]);
+            {
+                std::lock_guard lock(sentMutex_);
+                sentTypes_.push_back(type);
+                if (type == protocol::mtMANIFESTS)
+                {
+                    protocol::TMManifests manifests;
+                    if (manifests.ParseFromArray(
+                            buffer.data() + compression::headerBytes,
+                            static_cast<int>(
+                                buffer.size() - compression::headerBytes)))
+                    {
+                        for (auto const& manifest : manifests.list())
+                            sentManifestPayloads_.push_back(
+                                manifest.stobject());
+                    }
+                }
+                sendTx_++;
+            }
+            sentCv_.notify_all();
         }
+
+        template <class MessageType>
+        bool
+        receive(MessageType const& message, protocol::MessageType type)
+        {
+            Message wire(message, type);
+            auto const& buffer = wire.getBuffer(compression::Compressed::Off);
+            std::size_t hint = 0;
+            auto const [consumed, ec] =
+                invokeProtocolMessage(boost::asio::buffer(buffer), *this, hint);
+            return !ec && consumed == buffer.size();
+        }
+
         void
         addTxQueue(const uint256& hash) override
         {
@@ -135,13 +177,40 @@ private:
         static void
         init()
         {
+            std::lock_guard lock(sentMutex_);
             queueTx_ = 0;
             sendTx_ = 0;
             sid_ = 0;
+            sentTypes_.clear();
+            sentManifestPayloads_.clear();
+        }
+        static bool
+        waitForMessages(std::size_t count)
+        {
+            using namespace std::chrono_literals;
+            std::unique_lock lock(sentMutex_);
+            return sentCv_.wait_for(
+                lock, 5s, [count] { return sentTypes_.size() >= count; });
+        }
+        static std::vector<int>
+        sentTypes()
+        {
+            std::lock_guard lock(sentMutex_);
+            return sentTypes_;
+        }
+        static std::vector<std::string>
+        sentManifestPayloads()
+        {
+            std::lock_guard lock(sentMutex_);
+            return sentManifestPayloads_;
         }
         inline static std::size_t sid_ = 0;
         inline static std::uint16_t queueTx_ = 0;
         inline static std::uint16_t sendTx_ = 0;
+        inline static std::mutex sentMutex_;
+        inline static std::condition_variable sentCv_;
+        inline static std::vector<int> sentTypes_;
+        inline static std::vector<std::string> sentManifestPayloads_;
     };
 
     std::uint16_t lid_{0};
@@ -241,11 +310,737 @@ private:
     }
 
     void
+    testManifestBeforeValidation()
+    {
+        testcase("manifest precedes validation per connection");
+
+        jtx::Env env(*this);
+        std::vector<std::shared_ptr<PeerTest>> peers;
+        std::uint16_t disabled = 0;
+        PeerTest::init();
+        lid_ = 0;
+        rid_ = 0;
+        addPeer(env, peers, disabled);
+
+        auto const masterSecret = randomSecretKey();
+        auto const masterKey = derivePublicKey(KeyType::ed25519, masterSecret);
+        BEAST_EXPECT(env.app().validators().load(
+            std::nullopt, {toBase58(TokenType::NodePublic, masterKey)}, {}));
+        BEAST_EXPECT(env.app().validators().listed(masterKey));
+
+        auto makeManifest = [&](SecretKey const& signingSecret, int sequence) {
+            auto const signingKey =
+                derivePublicKey(KeyType::secp256k1, signingSecret);
+            STObject st(sfGeneric);
+            st[sfSequence] = sequence;
+            st[sfPublicKey] = masterKey;
+            st[sfSigningPubKey] = signingKey;
+            sign(st, HashPrefix::manifest, KeyType::secp256k1, signingSecret);
+            sign(
+                st,
+                HashPrefix::manifest,
+                KeyType::ed25519,
+                masterSecret,
+                sfMasterSignature);
+            Serializer serializer;
+            st.add(serializer);
+            auto manifest = deserializeManifest(std::string(
+                static_cast<char const*>(serializer.data()),
+                serializer.size()));
+            if (!manifest)
+                Throw<std::runtime_error>("could not create test manifest");
+            return std::move(*manifest);
+        };
+
+        auto const signingSecret0 = randomSecretKey();
+        auto const signingKey0 =
+            derivePublicKey(KeyType::secp256k1, signingSecret0);
+        BEAST_EXPECT(
+            env.app().validatorManifests().applyManifest(makeManifest(
+                signingSecret0, 0)) == ManifestDisposition::accepted);
+
+        protocol::TMValidation validation;
+        validation.set_validation("validation");
+        env.app().overlay().broadcast(validation, signingKey0);
+        BEAST_EXPECT(PeerTest::waitForMessages(2));
+        BEAST_EXPECT(
+            (PeerTest::sentTypes() ==
+             std::vector<int>{protocol::mtMANIFESTS, protocol::mtVALIDATION}));
+
+        // The sender cannot infer the receiver's local validator policy, so
+        // even a locally listed prerequisite accompanies every validation.
+        env.app().overlay().broadcast(validation, signingKey0);
+        BEAST_EXPECT(PeerTest::waitForMessages(4));
+        BEAST_EXPECT(
+            (PeerTest::sentTypes() ==
+             std::vector<int>{
+                 protocol::mtMANIFESTS,
+                 protocol::mtVALIDATION,
+                 protocol::mtMANIFESTS,
+                 protocol::mtVALIDATION}));
+
+        // A new signing key/sequence is ordered before its first validation.
+        auto const signingSecret1 = randomSecretKey();
+        auto const signingKey1 =
+            derivePublicKey(KeyType::secp256k1, signingSecret1);
+        auto manifest1 = makeManifest(signingSecret1, 1);
+        BEAST_EXPECT(
+            env.app().validatorManifests().applyManifest(
+                std::move(manifest1)) == ManifestDisposition::accepted);
+        auto const corrected =
+            env.app().validatorManifests().getManifestSnapshot(masterKey);
+        BEAST_EXPECT(
+            corrected && corrected->sequence == 1 &&
+            corrected->signingKey == signingKey1);
+        env.app().overlay().broadcast(validation, signingKey1);
+        BEAST_EXPECT(PeerTest::waitForMessages(6));
+        BEAST_EXPECT(
+            (PeerTest::sentTypes() ==
+             std::vector<int>{
+                 protocol::mtMANIFESTS,
+                 protocol::mtVALIDATION,
+                 protocol::mtMANIFESTS,
+                 protocol::mtVALIDATION,
+                 protocol::mtMANIFESTS,
+                 protocol::mtVALIDATION}));
+
+        // Unlisted prerequisites obey the same stateless pairing rule.
+        PeerTest::init();
+        auto const ephemeralMasterSecret = randomSecretKey();
+        auto const ephemeralMasterKey =
+            derivePublicKey(KeyType::ed25519, ephemeralMasterSecret);
+        auto const ephemeralSigningSecret = randomSecretKey();
+        auto const ephemeralSigningKey =
+            derivePublicKey(KeyType::secp256k1, ephemeralSigningSecret);
+        STObject ephemeralObject(sfGeneric);
+        ephemeralObject[sfSequence] = 0;
+        ephemeralObject[sfPublicKey] = ephemeralMasterKey;
+        ephemeralObject[sfSigningPubKey] = ephemeralSigningKey;
+        sign(
+            ephemeralObject,
+            HashPrefix::manifest,
+            KeyType::secp256k1,
+            ephemeralSigningSecret);
+        sign(
+            ephemeralObject,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            ephemeralMasterSecret,
+            sfMasterSignature);
+        Serializer ephemeralSerializer;
+        ephemeralObject.add(ephemeralSerializer);
+        auto ephemeralManifest = deserializeManifest(std::string(
+            static_cast<char const*>(ephemeralSerializer.data()),
+            ephemeralSerializer.size()));
+        BEAST_EXPECT(ephemeralManifest);
+        if (!ephemeralManifest)
+            return;
+        BEAST_EXPECT(
+            env.app().validatorManifests().applyManifest(std::move(
+                *ephemeralManifest)) == ManifestDisposition::accepted);
+        env.app().overlay().broadcast(validation, ephemeralSigningKey);
+        env.app().overlay().broadcast(validation, ephemeralSigningKey);
+        BEAST_EXPECT(PeerTest::waitForMessages(4));
+        BEAST_EXPECT(
+            (PeerTest::sentTypes() ==
+             std::vector<int>{
+                 protocol::mtMANIFESTS,
+                 protocol::mtVALIDATION,
+                 protocol::mtMANIFESTS,
+                 protocol::mtVALIDATION}));
+    }
+
+    void
+    testManifestRevocation()
+    {
+        testcase("manifest revocation propagation");
+
+        jtx::Env env(*this);
+        std::vector<std::shared_ptr<PeerTest>> peers;
+        std::uint16_t disabled = 0;
+        PeerTest::init();
+        lid_ = 0;
+        rid_ = 0;
+        addPeer(env, peers, disabled);
+
+        auto const masterSecret = randomSecretKey();
+        auto const masterKey = derivePublicKey(KeyType::ed25519, masterSecret);
+        BEAST_EXPECT(env.app().validators().load(
+            std::nullopt, {toBase58(TokenType::NodePublic, masterKey)}, {}));
+        BEAST_EXPECT(env.app().validators().listed(masterKey));
+        auto const signingSecret = randomSecretKey();
+        auto const signingKey =
+            derivePublicKey(KeyType::secp256k1, signingSecret);
+
+        auto serialize = [](STObject const& object) {
+            Serializer serializer;
+            object.add(serializer);
+            return std::string(
+                static_cast<char const*>(serializer.data()), serializer.size());
+        };
+
+        STObject manifestObject(sfGeneric);
+        manifestObject[sfSequence] = 0;
+        manifestObject[sfPublicKey] = masterKey;
+        manifestObject[sfSigningPubKey] = signingKey;
+        sign(
+            manifestObject,
+            HashPrefix::manifest,
+            KeyType::secp256k1,
+            signingSecret);
+        sign(
+            manifestObject,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            masterSecret,
+            sfMasterSignature);
+        auto const manifestSerialized = serialize(manifestObject);
+        auto manifest = deserializeManifest(manifestSerialized);
+        BEAST_EXPECT(manifest);
+        if (!manifest)
+            return;
+        BEAST_EXPECT(
+            env.app().validatorManifests().applyManifest(
+                std::move(*manifest)) == ManifestDisposition::accepted);
+
+        STObject revocationObject(sfGeneric);
+        revocationObject[sfSequence] =
+            std::numeric_limits<std::uint32_t>::max();
+        revocationObject[sfPublicKey] = masterKey;
+        sign(
+            revocationObject,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            masterSecret,
+            sfMasterSignature);
+        auto const revocationSerialized = serialize(revocationObject);
+
+        // Revocation has no following validation, so accepted-manifest relay
+        // remains its immediate propagation path.
+        auto revocations = std::make_shared<protocol::TMManifests>();
+        revocations->add_list()->set_stobject(revocationSerialized);
+        BEAST_EXPECT(
+            peers.front()->receive(*revocations, protocol::mtMANIFESTS));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(env.app().validatorManifests().revoked(masterKey));
+        BEAST_EXPECT(PeerTest::waitForMessages(1));
+        BEAST_EXPECT(
+            (PeerTest::sentTypes() == std::vector<int>{protocol::mtMANIFESTS}));
+        BEAST_EXPECT(
+            (PeerTest::sentManifestPayloads() ==
+             std::vector<std::string>{revocationSerialized}));
+
+        // A later validation under the revoked signing key must not resurrect
+        // or resend the superseded manifest.
+        PeerTest::init();
+        protocol::TMValidation validation;
+        validation.set_validation("validation");
+        env.app().overlay().broadcast(validation, signingKey);
+        BEAST_EXPECT(PeerTest::waitForMessages(1));
+        BEAST_EXPECT((
+            PeerTest::sentTypes() == std::vector<int>{protocol::mtVALIDATION}));
+        BEAST_EXPECT(PeerTest::sentManifestPayloads().empty());
+
+        // Ambient stale/newer correction replies are deliberately parked: a
+        // stale singleton cannot turn manifest relay into ping-pong.
+        PeerTest::init();
+        auto stale = std::make_shared<protocol::TMManifests>();
+        stale->add_list()->set_stobject(manifestSerialized);
+        dynamic_cast<OverlayImpl&>(env.app().overlay())
+            .onManifests(stale, peers.front());
+        BEAST_EXPECT(PeerTest::sentTypes().empty());
+        BEAST_EXPECT(PeerTest::sentManifestPayloads().empty());
+        BEAST_EXPECT(env.app().validatorManifests().revoked(masterKey));
+    }
+
+    void
+    testIncomingManifestCandidate()
+    {
+        testcase("incoming manifest candidate is connection-bounded");
+
+        jtx::Env env(*this);
+        std::vector<std::shared_ptr<PeerTest>> peers;
+        std::uint16_t disabled = 0;
+        PeerTest::init();
+        lid_ = 0;
+        rid_ = 0;
+        addPeer(env, peers, disabled);
+        auto const peer = peers.front();
+
+        auto serialize = [](STObject const& object) {
+            Serializer serializer;
+            object.add(serializer);
+            return std::string(
+                static_cast<char const*>(serializer.data()), serializer.size());
+        };
+
+        auto makeManifest = [&](SecretKey const& masterSecret,
+                                PublicKey const& masterKey,
+                                SecretKey const& signingSecret,
+                                std::uint32_t sequence,
+                                SecretKey const* signatureMaster = nullptr) {
+            auto const signingKey =
+                derivePublicKey(KeyType::secp256k1, signingSecret);
+            STObject object(sfGeneric);
+            object[sfSequence] = sequence;
+            object[sfPublicKey] = masterKey;
+            object[sfSigningPubKey] = signingKey;
+            sign(
+                object,
+                HashPrefix::manifest,
+                KeyType::secp256k1,
+                signingSecret);
+            sign(
+                object,
+                HashPrefix::manifest,
+                KeyType::ed25519,
+                signatureMaster ? *signatureMaster : masterSecret,
+                sfMasterSignature);
+            return serialize(object);
+        };
+
+        auto makeValidationAt = [&](PublicKey const& masterKey,
+                                    PublicKey const& signingKey,
+                                    SecretKey const& signingSecret,
+                                    NetClock::time_point signTime,
+                                    uint256 ledgerHash) {
+            STValidation validation(
+                signTime,
+                signingKey,
+                signingSecret,
+                calcNodeID(masterKey),
+                [ledgerHash](STValidation& value) {
+                    value.setFieldH256(sfLedgerHash, ledgerHash);
+                    value.setFieldU32(sfLedgerSequence, 1);
+                });
+            auto const serialized = validation.getSerialized();
+            protocol::TMValidation message;
+            message.set_validation(serialized.data(), serialized.size());
+            return message;
+        };
+
+        auto makeValidation = [&](PublicKey const& masterKey,
+                                  PublicKey const& signingKey,
+                                  SecretKey const& signingSecret) {
+            return makeValidationAt(
+                masterKey,
+                signingKey,
+                signingSecret,
+                env.app().timeKeeper().closeTime(),
+                uint256{1});
+        };
+
+        auto receiveManifest = [&](std::string const& serialized) {
+            protocol::TMManifests message;
+            message.add_list()->set_stobject(serialized);
+            return peer->receive(message, protocol::mtMANIFESTS);
+        };
+
+        auto listMaster = [&](PublicKey const& masterKey) {
+            BEAST_EXPECT(env.app().validators().load(
+                std::nullopt,
+                {toBase58(TokenType::NodePublic, masterKey)},
+                {}));
+            BEAST_EXPECT(env.app().validators().listed(masterKey));
+        };
+
+        // A normal manifest is only structurally staged on receipt. The first
+        // candidate owns the connection's bounded slot until a matching
+        // validation consumes it; interleaved singleton manifests cannot
+        // displace it.
+        auto const masterSecret0 = randomSecretKey();
+        auto const masterKey0 =
+            derivePublicKey(KeyType::ed25519, masterSecret0);
+        listMaster(masterKey0);
+        auto const signingSecret0 = randomSecretKey();
+        auto const signingKey0 =
+            derivePublicKey(KeyType::secp256k1, signingSecret0);
+        auto const serialized0 =
+            makeManifest(masterSecret0, masterKey0, signingSecret0, 0);
+        BEAST_EXPECT(receiveManifest(serialized0));
+        BEAST_EXPECT(
+            !env.app().validatorManifests().getManifestSnapshot(masterKey0));
+
+        auto const displacedMasterSecret = randomSecretKey();
+        auto const displacedMasterKey =
+            derivePublicKey(KeyType::ed25519, displacedMasterSecret);
+        listMaster(displacedMasterKey);
+        auto const displacedSigningSecret = randomSecretKey();
+        auto const displacedSigningKey =
+            derivePublicKey(KeyType::secp256k1, displacedSigningSecret);
+        BEAST_EXPECT(receiveManifest(makeManifest(
+            displacedMasterSecret,
+            displacedMasterKey,
+            displacedSigningSecret,
+            0)));
+
+        auto const validation0 =
+            makeValidation(masterKey0, signingKey0, signingSecret0);
+        BEAST_EXPECT(peer->receive(validation0, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const admitted0 =
+            env.app().validatorManifests().getManifestSnapshot(masterKey0);
+        BEAST_EXPECT(admitted0 && admitted0->signingKey == signingKey0);
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            displacedMasterKey));
+
+        // Consuming the first candidate releases the slot for later traffic.
+        BEAST_EXPECT(receiveManifest(makeManifest(
+            displacedMasterSecret,
+            displacedMasterKey,
+            displacedSigningSecret,
+            0)));
+        BEAST_EXPECT(peer->receive(
+            makeValidation(
+                displacedMasterKey,
+                displacedSigningKey,
+                displacedSigningSecret),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const admittedDisplaced =
+            env.app().validatorManifests().getManifestSnapshot(
+                displacedMasterKey);
+        BEAST_EXPECT(
+            admittedDisplaced &&
+            admittedDisplaced->signingKey == displacedSigningKey);
+
+        // A lost validation must not wedge a sequence bump on this
+        // connection. A newer manifest for the same master supersedes the
+        // unconsumed candidate in the same bounded slot.
+        auto const advancingMasterSecret = randomSecretKey();
+        auto const advancingMasterKey =
+            derivePublicKey(KeyType::ed25519, advancingMasterSecret);
+        listMaster(advancingMasterKey);
+        auto const advancingSigningSecret8 = randomSecretKey();
+        BEAST_EXPECT(receiveManifest(makeManifest(
+            advancingMasterSecret,
+            advancingMasterKey,
+            advancingSigningSecret8,
+            8)));
+        auto const advancingSigningSecret9 = randomSecretKey();
+        auto const advancingSigningKey9 =
+            derivePublicKey(KeyType::secp256k1, advancingSigningSecret9);
+        BEAST_EXPECT(receiveManifest(makeManifest(
+            advancingMasterSecret,
+            advancingMasterKey,
+            advancingSigningSecret9,
+            9)));
+        BEAST_EXPECT(peer->receive(
+            makeValidation(
+                advancingMasterKey,
+                advancingSigningKey9,
+                advancingSigningSecret9),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const admittedAdvancing =
+            env.app().validatorManifests().getManifestSnapshot(
+                advancingMasterKey);
+        BEAST_EXPECT(
+            admittedAdvancing && admittedAdvancing->sequence == 9 &&
+            admittedAdvancing->signingKey == advancingSigningKey9);
+
+        // Old peers may send a one-item startup cache before status traffic.
+        // Unrelated frames neither admit nor discard the bounded candidate.
+        auto const masterSecret1 = randomSecretKey();
+        auto const masterKey1 =
+            derivePublicKey(KeyType::ed25519, masterSecret1);
+        listMaster(masterKey1);
+        auto const signingSecret1 = randomSecretKey();
+        auto const signingKey1 =
+            derivePublicKey(KeyType::secp256k1, signingSecret1);
+        BEAST_EXPECT(receiveManifest(
+            makeManifest(masterSecret1, masterKey1, signingSecret1, 0)));
+        protocol::TMPing ping;
+        ping.set_type(protocol::TMPing::ptPING);
+        ping.set_seq(1);
+        BEAST_EXPECT(peer->receive(ping, protocol::mtPING));
+
+        // A matching but non-current validation does not consume the
+        // candidate; the subsequent current validation still proves it.
+        BEAST_EXPECT(peer->receive(
+            makeValidationAt(
+                masterKey1,
+                signingKey1,
+                signingSecret1,
+                NetClock::time_point{},
+                uint256{1}),
+            protocol::mtVALIDATION));
+        BEAST_EXPECT(peer->receive(
+            makeValidation(masterKey1, signingKey1, signingSecret1),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const admitted1 =
+            env.app().validatorManifests().getManifestSnapshot(masterKey1);
+        BEAST_EXPECT(admitted1 && admitted1->signingKey == signingKey1);
+
+        // A validation for another signing key does not consume or apply the
+        // candidate. A later matching validation may still prove it.
+        auto const masterSecret2 = randomSecretKey();
+        auto const masterKey2 =
+            derivePublicKey(KeyType::ed25519, masterSecret2);
+        listMaster(masterKey2);
+        auto const signingSecret2 = randomSecretKey();
+        BEAST_EXPECT(receiveManifest(
+            makeManifest(masterSecret2, masterKey2, signingSecret2, 0)));
+        auto const otherSecret = randomSecretKey();
+        auto const otherKey = derivePublicKey(KeyType::secp256k1, otherSecret);
+        BEAST_EXPECT(peer->receive(
+            makeValidation(otherKey, otherKey, otherSecret),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(
+            !env.app().validatorManifests().getManifestSnapshot(masterKey2));
+        auto const signingKey2 =
+            derivePublicKey(KeyType::secp256k1, signingSecret2);
+        BEAST_EXPECT(peer->receive(
+            makeValidation(masterKey2, signingKey2, signingSecret2),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const admitted2 =
+            env.app().validatorManifests().getManifestSnapshot(masterKey2);
+        BEAST_EXPECT(admitted2 && admitted2->signingKey == signingKey2);
+
+        // A fully valid pair for an unlisted identity remains ephemeral. It
+        // cannot create a permanent ManifestCache entry merely by proving
+        // control of keys the peer minted itself.
+        auto const unlistedMasterSecret = randomSecretKey();
+        auto const unlistedMasterKey =
+            derivePublicKey(KeyType::ed25519, unlistedMasterSecret);
+        auto const unlistedSigningSecret = randomSecretKey();
+        auto const unlistedSigningKey =
+            derivePublicKey(KeyType::secp256k1, unlistedSigningSecret);
+        auto const unlistedSerialized = makeManifest(
+            unlistedMasterSecret, unlistedMasterKey, unlistedSigningSecret, 0);
+        BEAST_EXPECT(receiveManifest(unlistedSerialized));
+        BEAST_EXPECT(peer->receive(
+            makeValidation(
+                unlistedMasterKey, unlistedSigningKey, unlistedSigningSecret),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            unlistedMasterKey));
+
+        // A legacy/pre-existing cache row is observation, not admission
+        // authority. A valid advancing pair remains ephemeral until local
+        // policy lists the master.
+        auto const residueMasterSecret = randomSecretKey();
+        auto const residueMasterKey =
+            derivePublicKey(KeyType::ed25519, residueMasterSecret);
+        auto const residueSigningSecret0 = randomSecretKey();
+        auto const residueSigningKey0 =
+            derivePublicKey(KeyType::secp256k1, residueSigningSecret0);
+        auto residue0 = deserializeManifest(makeManifest(
+            residueMasterSecret, residueMasterKey, residueSigningSecret0, 0));
+        BEAST_EXPECT(residue0);
+        if (!residue0)
+            return;
+        BEAST_EXPECT(
+            env.app().validatorManifests().applyManifest(
+                std::move(*residue0)) == ManifestDisposition::accepted);
+
+        auto const residueSigningSecret1 = randomSecretKey();
+        auto const residueSigningKey1 =
+            derivePublicKey(KeyType::secp256k1, residueSigningSecret1);
+        BEAST_EXPECT(receiveManifest(makeManifest(
+            residueMasterSecret, residueMasterKey, residueSigningSecret1, 1)));
+        BEAST_EXPECT(peer->receive(
+            makeValidation(
+                residueMasterKey, residueSigningKey1, residueSigningSecret1),
+            protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        auto const residueCurrent =
+            env.app().validatorManifests().getManifestSnapshot(
+                residueMasterKey);
+        BEAST_EXPECT(
+            residueCurrent && residueCurrent->sequence == 0 &&
+            residueCurrent->signingKey == residueSigningKey0);
+
+        // The legacy batch compatibility lane obeys the same durable-cache
+        // admission boundary.
+        protocol::TMManifests unlistedLegacyBatch;
+        unlistedLegacyBatch.add_list()->set_stobject(unlistedSerialized);
+        unlistedLegacyBatch.add_list()->set_stobject(unlistedSerialized);
+        BEAST_EXPECT(peer->receive(unlistedLegacyBatch, protocol::mtMANIFESTS));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            unlistedMasterKey));
+
+        // Oversized legacy batches are charged and refused rather than
+        // processed after the charge.
+        auto const masterSecret5 = randomSecretKey();
+        auto const masterKey5 =
+            derivePublicKey(KeyType::ed25519, masterSecret5);
+        auto const signingSecret5 = randomSecretKey();
+        auto const serialized5 =
+            makeManifest(masterSecret5, masterKey5, signingSecret5, 0);
+        protocol::TMManifests oversized;
+        for (int i = 0; i < 101; ++i)
+            oversized.add_list()->set_stobject(serialized5);
+        BEAST_EXPECT(peer->receive(oversized, protocol::mtMANIFESTS));
+        BEAST_EXPECT(
+            !env.app().validatorManifests().getManifestSnapshot(masterKey5));
+
+        protocol::TMManifests oversizedObject;
+        oversizedObject.add_list()->set_stobject(std::string(4097, 'x'));
+        BEAST_EXPECT(peer->receive(oversizedObject, protocol::mtMANIFESTS));
+
+        // A naked validation whose signer has no trusted or retained master
+        // mapping is not useful, and must not front-run the real validation
+        // hash. A later verified pair remains processable and relays in wire
+        // order to another connection.
+        testcase("naked validation cannot front-run verified pair");
+        addPeer(env, peers, disabled);
+        auto const repairMasterSecret = randomSecretKey();
+        auto const repairMasterKey =
+            derivePublicKey(KeyType::ed25519, repairMasterSecret);
+        auto const repairSigningSecret = randomSecretKey();
+        auto const repairSigningKey =
+            derivePublicKey(KeyType::secp256k1, repairSigningSecret);
+        auto const repairManifest = makeManifest(
+            repairMasterSecret, repairMasterKey, repairSigningSecret, 0);
+        auto const repairValidation = makeValidation(
+            repairMasterKey, repairSigningKey, repairSigningSecret);
+        auto const messagesBeforeRepair = PeerTest::sentTypes().size();
+
+        BEAST_EXPECT(peer->receive(repairValidation, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(PeerTest::sentTypes().size() == messagesBeforeRepair);
+
+        BEAST_EXPECT(receiveManifest(repairManifest));
+        BEAST_EXPECT(peer->receive(repairValidation, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(PeerTest::waitForMessages(messagesBeforeRepair + 2));
+        auto const repairedTypes = PeerTest::sentTypes();
+        if (repairedTypes.size() >= 2)
+        {
+            BEAST_EXPECT(
+                repairedTypes[repairedTypes.size() - 2] ==
+                protocol::mtMANIFESTS);
+            BEAST_EXPECT(repairedTypes.back() == protocol::mtVALIDATION);
+        }
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            repairMasterKey));
+
+        // A signing key retained for one master cannot be endorsed for a
+        // second master through the ephemeral pair path. Rejection must also
+        // happen before the pair claims the validation's ordinary suppression
+        // identity, so later valid traffic is not poisoned.
+        testcase("manifest key-role collision is terminal");
+        auto const collisionSigningSecret = randomSecretKey();
+        auto const collisionSigningKey =
+            derivePublicKey(KeyType::secp256k1, collisionSigningSecret);
+        auto const collisionMasterSecret0 = randomSecretKey();
+        auto const collisionMasterKey0 =
+            derivePublicKey(KeyType::ed25519, collisionMasterSecret0);
+        auto collisionManifest0 = deserializeManifest(makeManifest(
+            collisionMasterSecret0,
+            collisionMasterKey0,
+            collisionSigningSecret,
+            0));
+        BEAST_EXPECT(collisionManifest0);
+        if (!collisionManifest0)
+            return;
+        BEAST_EXPECT(
+            env.app().validatorManifests().applyManifest(std::move(
+                *collisionManifest0)) == ManifestDisposition::accepted);
+
+        auto const collisionMasterSecret1 = randomSecretKey();
+        auto const collisionMasterKey1 =
+            derivePublicKey(KeyType::ed25519, collisionMasterSecret1);
+        auto const collisionManifest1 = makeManifest(
+            collisionMasterSecret1,
+            collisionMasterKey1,
+            collisionSigningSecret,
+            0);
+        auto const collisionValidation1 = makeValidation(
+            collisionMasterKey1, collisionSigningKey, collisionSigningSecret);
+        auto const messagesBeforeCollision = PeerTest::sentTypes().size();
+        BEAST_EXPECT(receiveManifest(collisionManifest1));
+        BEAST_EXPECT(
+            peer->receive(collisionValidation1, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(PeerTest::sentTypes().size() == messagesBeforeCollision);
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            collisionMasterKey1));
+        auto const collisionValidationHash1 =
+            sha512Half(makeSlice(collisionValidation1.validation()));
+        BEAST_EXPECT(
+            env.app()
+                .getHashRouter()
+                .addSuppressionPeerWithStatus(collisionValidationHash1, 65001)
+                .first);
+
+        // A valid manifest followed by a parseable validation with a bad
+        // signature must not gain cache admission merely because the signing
+        // key claim matches. Keep this terminal fee case last: the production
+        // resource policy intentionally makes the synthetic peer unusable
+        // after feeInvalidSignature.
+        auto const invalidMasterSecret = randomSecretKey();
+        auto const invalidMasterKey =
+            derivePublicKey(KeyType::ed25519, invalidMasterSecret);
+        listMaster(invalidMasterKey);
+        auto const invalidSigningSecret = randomSecretKey();
+        auto const invalidSigningKey =
+            derivePublicKey(KeyType::secp256k1, invalidSigningSecret);
+        BEAST_EXPECT(receiveManifest(makeManifest(
+            invalidMasterSecret, invalidMasterKey, invalidSigningSecret, 0)));
+        auto invalidValidation = makeValidation(
+            invalidMasterKey, invalidSigningKey, invalidSigningSecret);
+        auto* serializedValidation = invalidValidation.mutable_validation();
+        if (BEAST_EXPECT(!serializedValidation->empty()))
+            serializedValidation->back() ^= 0x01;
+        BEAST_EXPECT(peer->receive(invalidValidation, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            invalidMasterKey));
+
+        // Matching does not imply trust: a structurally valid manifest with a
+        // forged master signature is rejected. Give this second terminal-fee
+        // case its own peer so it cannot inherit the preceding disconnect.
+        addPeer(env, peers, disabled);
+        auto const forgedPeer = peers.back();
+        auto const forgedMasterSecret = randomSecretKey();
+        auto const forgedMasterKey =
+            derivePublicKey(KeyType::ed25519, forgedMasterSecret);
+        listMaster(forgedMasterKey);
+        auto const forgedSigningSecret = randomSecretKey();
+        auto const forgedSigningKey =
+            derivePublicKey(KeyType::secp256k1, forgedSigningSecret);
+        auto const wrongMasterSecret = randomSecretKey();
+        protocol::TMManifests forgedManifest;
+        forgedManifest.add_list()->set_stobject(makeManifest(
+            forgedMasterSecret,
+            forgedMasterKey,
+            forgedSigningSecret,
+            0,
+            &wrongMasterSecret));
+        BEAST_EXPECT(
+            forgedPeer->receive(forgedManifest, protocol::mtMANIFESTS));
+        auto const forgedValidation = makeValidation(
+            forgedMasterKey, forgedSigningKey, forgedSigningSecret);
+        BEAST_EXPECT(
+            forgedPeer->receive(forgedValidation, protocol::mtVALIDATION));
+        env.app().getJobQueue().rendezvous();
+        BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
+            forgedMasterKey));
+        auto const forgedValidationHash =
+            sha512Half(makeSlice(forgedValidation.validation()));
+        BEAST_EXPECT(
+            env.app()
+                .getHashRouter()
+                .addSuppressionPeerWithStatus(forgedValidationHash, 65000)
+                .first);
+    }
+
+    void
     run() override
     {
         bool log = false;
         std::set<Peer::id_t> skip = {0, 1, 2, 3, 4};
         testConfig(log);
+        testManifestBeforeValidation();
+        testIncomingManifestCandidate();
+        testManifestRevocation();
         // relay to all peers, no hash queue
         testRelay("feature disabled", false, 10, 0, 10, 25, 10, 0);
         // relay to nPeers - skip (10-5=5)

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -27,6 +27,7 @@
 #include <xrpl/basics/make_SSLContext.h>
 #include <xrpl/beast/unit_test.h>
 #include <xrpl/protocol/Sign.h>
+#include <algorithm>
 #include <condition_variable>
 #include <limits>
 #include <mutex>
@@ -139,6 +140,7 @@ private:
             {
                 std::lock_guard lock(sentMutex_);
                 sentTypes_.push_back(type);
+                sentPeerTypes_.emplace_back(id(), type);
                 if (type == protocol::mtMANIFESTS)
                 {
                     protocol::TMManifests manifests;
@@ -182,6 +184,7 @@ private:
             sendTx_ = 0;
             sid_ = 0;
             sentTypes_.clear();
+            sentPeerTypes_.clear();
             sentManifestPayloads_.clear();
         }
         static bool
@@ -193,29 +196,34 @@ private:
                 lock, 5s, [count] { return sentTypes_.size() >= count; });
         }
         static bool
-        waitForMessageQuiescence()
+        waitForMessages(Peer::id_t peer, std::size_t count)
         {
             using namespace std::chrono_literals;
-            auto const deadline = std::chrono::steady_clock::now() + 5s;
             std::unique_lock lock(sentMutex_);
-            for (;;)
-            {
-                auto const count = sentTypes_.size();
-                auto const quietUntil =
-                    std::min(deadline, std::chrono::steady_clock::now() + 50ms);
-                if (!sentCv_.wait_until(lock, quietUntil, [count] {
-                        return sentTypes_.size() != count;
-                    }))
-                    return true;
-                if (std::chrono::steady_clock::now() >= deadline)
-                    return false;
-            }
+            return sentCv_.wait_for(lock, 5s, [peer, count] {
+                return static_cast<std::size_t>(std::count_if(
+                           sentPeerTypes_.begin(),
+                           sentPeerTypes_.end(),
+                           [peer](auto const& message) {
+                               return message.first == peer;
+                           })) >= count;
+            });
         }
         static std::vector<int>
         sentTypes()
         {
             std::lock_guard lock(sentMutex_);
             return sentTypes_;
+        }
+        static std::vector<int>
+        sentTypes(Peer::id_t peer)
+        {
+            std::lock_guard lock(sentMutex_);
+            std::vector<int> result;
+            for (auto const& [recipient, type] : sentPeerTypes_)
+                if (recipient == peer)
+                    result.push_back(type);
+            return result;
         }
         static std::vector<std::string>
         sentManifestPayloads()
@@ -229,6 +237,7 @@ private:
         inline static std::mutex sentMutex_;
         inline static std::condition_variable sentCv_;
         inline static std::vector<int> sentTypes_;
+        inline static std::vector<std::pair<Peer::id_t, int>> sentPeerTypes_;
         inline static std::vector<std::string> sentManifestPayloads_;
     };
 
@@ -1047,6 +1056,7 @@ private:
         // order to another connection.
         testcase("naked validation cannot front-run verified pair");
         addPeer(env, peers, disabled);
+        auto const repairRecipient = peers.back()->id();
         auto const repairMasterSecret = randomSecretKey();
         auto const repairMasterKey =
             derivePublicKey(KeyType::ed25519, repairMasterSecret);
@@ -1057,24 +1067,28 @@ private:
             repairMasterSecret, repairMasterKey, repairSigningSecret, 0);
         auto const repairValidation = makeValidation(
             repairMasterKey, repairSigningKey, repairSigningSecret);
-        BEAST_EXPECT(PeerTest::waitForMessageQuiescence());
-        auto const messagesBeforeRepair = PeerTest::sentTypes().size();
+        auto const messagesBeforeRepair =
+            PeerTest::sentTypes(repairRecipient).size();
 
         BEAST_EXPECT(peer->receive(repairValidation, protocol::mtVALIDATION));
         env.app().getJobQueue().rendezvous();
-        BEAST_EXPECT(PeerTest::sentTypes().size() == messagesBeforeRepair);
+        BEAST_EXPECT(
+            PeerTest::sentTypes(repairRecipient).size() ==
+            messagesBeforeRepair);
 
         BEAST_EXPECT(receiveManifest(repairManifest));
         BEAST_EXPECT(peer->receive(repairValidation, protocol::mtVALIDATION));
         env.app().getJobQueue().rendezvous();
-        BEAST_EXPECT(PeerTest::waitForMessages(messagesBeforeRepair + 2));
-        auto const repairedTypes = PeerTest::sentTypes();
-        if (repairedTypes.size() >= 2)
+        BEAST_EXPECT(PeerTest::waitForMessages(
+            repairRecipient, messagesBeforeRepair + 2));
+        auto const repairedTypes = PeerTest::sentTypes(repairRecipient);
+        if (repairedTypes.size() >= messagesBeforeRepair + 2)
         {
             BEAST_EXPECT(
-                repairedTypes[repairedTypes.size() - 2] ==
-                protocol::mtMANIFESTS);
-            BEAST_EXPECT(repairedTypes.back() == protocol::mtVALIDATION);
+                repairedTypes[messagesBeforeRepair] == protocol::mtMANIFESTS);
+            BEAST_EXPECT(
+                repairedTypes[messagesBeforeRepair + 1] ==
+                protocol::mtVALIDATION);
         }
         BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
             repairMasterKey));
@@ -1112,12 +1126,15 @@ private:
             0);
         auto const collisionValidation1 = makeValidation(
             collisionMasterKey1, collisionSigningKey, collisionSigningSecret);
-        auto const messagesBeforeCollision = PeerTest::sentTypes().size();
+        auto const messagesBeforeCollision =
+            PeerTest::sentTypes(repairRecipient).size();
         BEAST_EXPECT(receiveManifest(collisionManifest1));
         BEAST_EXPECT(
             peer->receive(collisionValidation1, protocol::mtVALIDATION));
         env.app().getJobQueue().rendezvous();
-        BEAST_EXPECT(PeerTest::sentTypes().size() == messagesBeforeCollision);
+        BEAST_EXPECT(
+            PeerTest::sentTypes(repairRecipient).size() ==
+            messagesBeforeCollision);
         BEAST_EXPECT(!env.app().validatorManifests().getManifestSnapshot(
             collisionMasterKey1));
         auto const collisionValidationHash1 =

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -1066,6 +1066,131 @@ private:
         oversizedObject.add_list()->set_stobject(std::string(4097, 'x'));
         BEAST_EXPECT(peer->receive(oversizedObject, protocol::mtMANIFESTS));
 
+        // A strictly stale singleton proves its sender is behind for a
+        // retained master, and draws the retained manifest back — or the
+        // revocation, the freshest possible answer. Equal-sequence arrivals
+        // are ordinary always-send traffic and draw nothing; the shared
+        // repair ledger bounds every answer to once per sequence per
+        // connection.
+        testcase("stale singleton draws the fresher manifest back");
+        addPeer(env, peers, disabled);
+        auto const stalePeer = peers.back();
+        auto const stalePeerId = stalePeer->id();
+
+        auto const behindMasterSecret = randomSecretKey();
+        auto const behindMasterKey =
+            derivePublicKey(KeyType::ed25519, behindMasterSecret);
+        listMaster(behindMasterKey);
+        auto const behindSigningSecret1 = randomSecretKey();
+        auto const behindStale = makeManifest(
+            behindMasterSecret, behindMasterKey, behindSigningSecret1, 1);
+        auto const behindSigningSecret2 = randomSecretKey();
+        {
+            auto parsed = deserializeManifest(makeManifest(
+                behindMasterSecret, behindMasterKey, behindSigningSecret2, 2));
+            BEAST_EXPECT(parsed);
+            if (!parsed)
+                return;
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*parsed)) == ManifestDisposition::accepted);
+        }
+        auto const behindCurrent =
+            env.app().validatorManifests().getManifestSnapshot(behindMasterKey);
+        BEAST_EXPECT(behindCurrent && behindCurrent->sequence == 2);
+
+        auto const beforeStale = PeerTest::sentTypes(stalePeerId).size();
+        {
+            protocol::TMManifests staleMessage;
+            staleMessage.add_list()->set_stobject(behindStale);
+            BEAST_EXPECT(
+                stalePeer->receive(staleMessage, protocol::mtMANIFESTS));
+        }
+        BEAST_EXPECT(PeerTest::waitForMessages(stalePeerId, beforeStale + 1));
+        {
+            auto const types = PeerTest::sentTypes(stalePeerId);
+            BEAST_EXPECT(
+                types.size() == beforeStale + 1 &&
+                types.back() == protocol::mtMANIFESTS);
+            auto const payloads = PeerTest::sentManifestPayloads();
+            BEAST_EXPECT(
+                behindCurrent && !payloads.empty() &&
+                payloads.back() == behindCurrent->serialized);
+        }
+
+        // Duplicate stale and equal-sequence arrivals draw nothing further.
+        {
+            protocol::TMManifests staleAgain;
+            staleAgain.add_list()->set_stobject(behindStale);
+            BEAST_EXPECT(stalePeer->receive(staleAgain, protocol::mtMANIFESTS));
+            protocol::TMManifests equalMessage;
+            if (behindCurrent)
+                equalMessage.add_list()->set_stobject(
+                    behindCurrent->serialized);
+            BEAST_EXPECT(
+                stalePeer->receive(equalMessage, protocol::mtMANIFESTS));
+        }
+        env.app().getJobQueue().rendezvous();
+
+        // A retained revocation is itself the correction: a stale normal
+        // manifest for a revoked master draws the tombstone, and retention —
+        // not listing — is what qualifies a master for an answer.
+        auto const buriedMasterSecret = randomSecretKey();
+        auto const buriedMasterKey =
+            derivePublicKey(KeyType::ed25519, buriedMasterSecret);
+        auto const buriedSigningSecret = randomSecretKey();
+        auto const buriedStale = makeManifest(
+            buriedMasterSecret, buriedMasterKey, buriedSigningSecret, 0);
+        {
+            auto parsed = deserializeManifest(buriedStale);
+            BEAST_EXPECT(parsed);
+            if (!parsed)
+                return;
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*parsed)) == ManifestDisposition::accepted);
+        }
+        STObject buriedRevocation(sfGeneric);
+        buriedRevocation[sfSequence] =
+            std::numeric_limits<std::uint32_t>::max();
+        buriedRevocation[sfPublicKey] = buriedMasterKey;
+        sign(
+            buriedRevocation,
+            HashPrefix::manifest,
+            KeyType::ed25519,
+            buriedMasterSecret,
+            sfMasterSignature);
+        auto const buriedRevocationSerialized = serialize(buriedRevocation);
+        {
+            auto parsed = deserializeManifest(buriedRevocationSerialized);
+            BEAST_EXPECT(parsed);
+            if (!parsed)
+                return;
+            BEAST_EXPECT(
+                env.app().validatorManifests().applyManifest(
+                    std::move(*parsed)) == ManifestDisposition::accepted);
+        }
+        BEAST_EXPECT(env.app().validatorManifests().revoked(buriedMasterKey));
+        {
+            protocol::TMManifests deadMessage;
+            deadMessage.add_list()->set_stobject(buriedStale);
+            BEAST_EXPECT(
+                stalePeer->receive(deadMessage, protocol::mtMANIFESTS));
+        }
+        BEAST_EXPECT(PeerTest::waitForMessages(stalePeerId, beforeStale + 2));
+        {
+            auto const types = PeerTest::sentTypes(stalePeerId);
+            BEAST_EXPECT(types.size() == beforeStale + 2);
+            BEAST_EXPECT(
+                types.size() >= 2 &&
+                types[types.size() - 2] == protocol::mtMANIFESTS &&
+                types.back() == protocol::mtMANIFESTS);
+            auto const payloads = PeerTest::sentManifestPayloads();
+            BEAST_EXPECT(
+                !payloads.empty() &&
+                payloads.back() == buriedRevocationSerialized);
+        }
+
         // A naked validation that authenticates against the current cached
         // manifest is an implicit request for that manifest. The recipient
         // repairs the sender with one singleton on the same connection, at

--- a/src/test/overlay/tx_reduce_relay_test.cpp
+++ b/src/test/overlay/tx_reduce_relay_test.cpp
@@ -1097,14 +1097,14 @@ private:
         }
 
         auto const beforeRepair = PeerTest::sentTypes(repairSourceId).size();
-        BEAST_EXPECT(repairSource->receive(
-            makeValidationAt(
-                memoryMasterKey,
-                memorySigningKey,
-                memorySigningSecret,
-                env.app().timeKeeper().closeTime(),
-                uint256{101}),
-            protocol::mtVALIDATION));
+        auto const memoryValidation = makeValidationAt(
+            memoryMasterKey,
+            memorySigningKey,
+            memorySigningSecret,
+            env.app().timeKeeper().closeTime(),
+            uint256{101});
+        BEAST_EXPECT(
+            repairSource->receive(memoryValidation, protocol::mtVALIDATION));
         env.app().getJobQueue().rendezvous();
         BEAST_EXPECT(
             PeerTest::waitForMessages(repairSourceId, beforeRepair + 1));
@@ -1119,12 +1119,31 @@ private:
                 !payloads.empty() && payloads.back() == memorySerialized);
         }
 
-        // Duplicate: a later distinct validation under the same manifest
-        // sequence still posts a repair attempt; the strand no-ops it.
+        // Another peer loses the admission race for the exact validation.
+        // The HashRouter's relayed fact proves those bytes already passed
+        // validation, so this connection still receives its own repair.
+        addPeer(env, peers, disabled);
+        auto const duplicateSource = peers.back();
+        auto const duplicateSourceId = duplicateSource->id();
+        BEAST_EXPECT(
+            duplicateSource->receive(memoryValidation, protocol::mtVALIDATION));
+        BEAST_EXPECT(PeerTest::waitForMessages(duplicateSourceId, 1));
+        {
+            auto const types = PeerTest::sentTypes(duplicateSourceId);
+            BEAST_EXPECT(
+                types.size() == 1 && types.back() == protocol::mtMANIFESTS);
+            auto const payloads =
+                PeerTest::sentManifestPayloads(duplicateSourceId);
+            BEAST_EXPECT(
+                payloads.size() == 1 && payloads.back() == memorySerialized);
+        }
+
+        // Same connection, same manifest sequence: a later distinct validation
+        // still posts a repair attempt; the strand no-ops it.
         // Unknown-signer and paired traffic never post. The sentinel below
         // is a later strand-FIFO send, so exactly two singletons prove the
-        // duplicate did not sneak a send, and the never-posted cases sent
-        // nothing either.
+        // same-sequence retry did not sneak a send, and the never-posted
+        // cases sent nothing either.
         BEAST_EXPECT(repairSource->receive(
             makeValidationAt(
                 memoryMasterKey,

--- a/src/xrpld/app/consensus/RCLConsensus.cpp
+++ b/src/xrpld/app/consensus/RCLConsensus.cpp
@@ -903,7 +903,7 @@ RCLConsensus::Adaptor::validate(
     // Broadcast to all our peers:
     protocol::TMValidation val;
     val.set_validation(serialized.data(), serialized.size());
-    app_.overlay().broadcast(val);
+    app_.overlay().broadcast(val, v->getSignerPublic());
 
     // Publish to all our subscribers:
     app_.getOPs().pubValidation(v);

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -360,7 +360,7 @@ public:
 
         Unlike getManifest(), revocations are returned. This is used by the
         overlay when ordering a manifest immediately before a validation and
-        when answering a peer that supplied a stale manifest.
+        when repairing a peer that sent an authenticated naked validation.
     */
     std::optional<Snapshot>
     getManifestSnapshot(PublicKey const& pk) const;

--- a/src/xrpld/app/misc/Manifest.h
+++ b/src/xrpld/app/misc/Manifest.h
@@ -25,6 +25,7 @@
 #include <xrpl/protocol/PublicKey.h>
 #include <xrpl/protocol/SecretKey.h>
 
+#include <cstdint>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -254,6 +255,26 @@ class DatabaseCon;
 /** Remembers manifests with the highest sequence number. */
 class ManifestCache
 {
+public:
+    /** An atomic read of one cached validator manifest.
+
+        The snapshot may represent a revocation. If a signing key is supplied,
+        it resolves only while that key is the current key for the manifest.
+    */
+    struct Snapshot
+    {
+        PublicKey masterKey;
+        std::optional<PublicKey> signingKey;
+        std::uint32_t sequence;
+        std::string serialized;
+
+        bool
+        revoked() const
+        {
+            return Manifest::revoked(sequence);
+        }
+    };
+
 private:
     beast::Journal j_;
     std::shared_mutex mutable mutex_;
@@ -265,6 +286,9 @@ private:
     hash_map<PublicKey, PublicKey> signingToMasterKeys_;
 
     std::atomic<std::uint32_t> seq_{0};
+
+    std::optional<ManifestDisposition>
+    checkKeyRolesUnlocked(Manifest const& m) const;
 
 public:
     explicit ManifestCache(
@@ -330,6 +354,17 @@ public:
     std::optional<std::string>
     getManifest(PublicKey const& pk) const;
 
+    /** Return one internally consistent view of the current manifest.
+
+        @param pk A master key or its current ephemeral signing key.
+
+        Unlike getManifest(), revocations are returned. This is used by the
+        overlay when ordering a manifest immediately before a validation and
+        when answering a peer that supplied a stale manifest.
+    */
+    std::optional<Snapshot>
+    getManifestSnapshot(PublicKey const& pk) const;
+
     /** Returns `true` if master key has been revoked in a manifest.
 
         @param pk Master public key
@@ -340,6 +375,22 @@ public:
     */
     bool
     revoked(PublicKey const& pk) const;
+
+    /** Check whether a manifest's keys conflict with retained key roles.
+
+        This does not verify signatures, compare sequences, or mutate the
+        cache. Transport uses it before relaying an unlisted pair: an
+        ephemeral path must not endorse an association the authoritative
+        cache would reject.
+
+        @return A key-role disposition, or `std::nullopt` when admissible.
+
+        @par Thread Safety
+
+        May be called concurrently.
+    */
+    std::optional<ManifestDisposition>
+    checkKeyRoles(Manifest const& m) const;
 
     /** Add manifest to cache.
 

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -354,6 +354,28 @@ ManifestCache::getManifest(PublicKey const& pk) const
     return std::nullopt;
 }
 
+std::optional<ManifestCache::Snapshot>
+ManifestCache::getManifestSnapshot(PublicKey const& pk) const
+{
+    std::shared_lock lock{mutex_};
+
+    auto masterKey = pk;
+    if (auto const signing = signingToMasterKeys_.find(pk);
+        signing != signingToMasterKeys_.end())
+        masterKey = signing->second;
+
+    auto const manifest = map_.find(masterKey);
+    if (manifest == map_.end())
+        return std::nullopt;
+
+    auto const& current = manifest->second;
+    return Snapshot{
+        current.masterKey,
+        current.signingKey,
+        current.sequence,
+        current.serialized};
+}
+
 bool
 ManifestCache::revoked(PublicKey const& pk) const
 {
@@ -364,6 +386,56 @@ ManifestCache::revoked(PublicKey const& pk) const
         return iter->second.revoked();
 
     return false;
+}
+
+std::optional<ManifestDisposition>
+ManifestCache::checkKeyRolesUnlocked(Manifest const& m) const
+{
+    if (auto const x = signingToMasterKeys_.find(m.masterKey);
+        x != signingToMasterKeys_.end())
+    {
+        JLOG(j_.warn()) << to_string(m)
+                        << ": Master key already used as ephemeral key for "
+                        << toBase58(TokenType::NodePublic, x->second);
+        return ManifestDisposition::badMasterKey;
+    }
+
+    if (m.revoked())
+        return std::nullopt;
+
+    if (!m.signingKey)
+    {
+        JLOG(j_.warn()) << to_string(m)
+                        << ": is not revoked and the manifest has no signing "
+                           "key. Hence, the manifest is invalid";
+        return ManifestDisposition::invalid;
+    }
+
+    if (auto const x = signingToMasterKeys_.find(*m.signingKey);
+        x != signingToMasterKeys_.end())
+    {
+        JLOG(j_.warn()) << to_string(m)
+                        << ": Ephemeral key already used as ephemeral key for "
+                        << toBase58(TokenType::NodePublic, x->second);
+        return ManifestDisposition::badEphemeralKey;
+    }
+
+    if (auto const x = map_.find(*m.signingKey); x != map_.end())
+    {
+        JLOG(j_.warn()) << to_string(m)
+                        << ": Ephemeral key used as master key for "
+                        << to_string(x->second);
+        return ManifestDisposition::badEphemeralKey;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<ManifestDisposition>
+ManifestCache::checkKeyRoles(Manifest const& m) const
+{
+    std::shared_lock lock{mutex_};
+    return checkKeyRolesUnlocked(m);
 }
 
 ManifestDisposition
@@ -418,51 +490,8 @@ ManifestCache::applyManifest(Manifest m)
         if (auto stream = j_.warn(); stream && revoked)
             LOG_MANIFEST_ACTION(stream, "Revoked", m.masterKey, m.sequence);
 
-        // Sanity check: the master key of this manifest should not be used as
-        // the ephemeral key of another manifest:
-        if (auto const x = signingToMasterKeys_.find(m.masterKey);
-            x != signingToMasterKeys_.end())
-        {
-            JLOG(j_.warn()) << to_string(m)
-                            << ": Master key already used as ephemeral key for "
-                            << toBase58(TokenType::NodePublic, x->second);
-
-            return ManifestDisposition::badMasterKey;
-        }
-
-        if (!revoked)
-        {
-            if (!m.signingKey)
-            {
-                JLOG(j_.warn()) << to_string(m)
-                                << ": is not revoked and the manifest has no "
-                                   "signing key. Hence, the manifest is "
-                                   "invalid";
-                return ManifestDisposition::invalid;
-            }
-
-            // Sanity check: the ephemeral key of this manifest should not be
-            // used as the master or ephemeral key of another manifest:
-            if (auto const x = signingToMasterKeys_.find(*m.signingKey);
-                x != signingToMasterKeys_.end())
-            {
-                JLOG(j_.warn())
-                    << to_string(m)
-                    << ": Ephemeral key already used as ephemeral key for "
-                    << toBase58(TokenType::NodePublic, x->second);
-
-                return ManifestDisposition::badEphemeralKey;
-            }
-
-            if (auto const x = map_.find(*m.signingKey); x != map_.end())
-            {
-                JLOG(j_.warn())
-                    << to_string(m) << ": Ephemeral key used as master key for "
-                    << to_string(x->second);
-
-                return ManifestDisposition::badEphemeralKey;
-            }
-        }
+        if (auto const disposition = checkKeyRolesUnlocked(m))
+            return *disposition;
 
         return std::nullopt;
     };
@@ -524,7 +553,6 @@ ManifestCache::applyManifest(Manifest m)
         signingToMasterKeys_.emplace(*m.signingKey, m.masterKey);
 
     iter->second = std::move(m);
-
     // Something has changed. Keep track of it.
     seq_++;
 
@@ -584,8 +612,13 @@ ManifestCache::load(
 
         auto mo = deserializeManifest(base64_decode(revocationStr));
 
-        if (!mo || !mo->revoked() ||
-            applyManifest(std::move(*mo)) == ManifestDisposition::invalid)
+        if (!mo || !mo->revoked())
+        {
+            JLOG(j_.error()) << "Invalid validator key revocation in config";
+            return false;
+        }
+
+        if (applyManifest(std::move(*mo)) == ManifestDisposition::invalid)
         {
             JLOG(j_.error()) << "Invalid validator key revocation in config";
             return false;

--- a/src/xrpld/overlay/Overlay.h
+++ b/src/xrpld/overlay/Overlay.h
@@ -145,9 +145,12 @@ public:
     virtual void
     broadcast(protocol::TMProposeSet& m) = 0;
 
-    /** Broadcast a validation. */
+    /** Broadcast a validation.
+     * @param m the serialized validation
+     * @param validator The pubkey that signed the validation
+     */
     virtual void
-    broadcast(protocol::TMValidation& m) = 0;
+    broadcast(protocol::TMValidation& m, PublicKey const& validator) = 0;
 
     /** Relay a proposal.
      * @param m the serialized proposal
@@ -171,7 +174,8 @@ public:
     relay(
         protocol::TMValidation& m,
         uint256 const& uid,
-        PublicKey const& validator) = 0;
+        PublicKey const& validator,
+        std::shared_ptr<protocol::TMManifests const> const& prerequisite) = 0;
 
     /** Relay a transaction. If the tx reduce-relay feature is enabled then
      * randomly select peers to relay to and queue transaction's hash

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -645,13 +645,61 @@ OverlayImpl::onManifests(
         if (auto mo = deserializeManifest(s))
         {
             auto const serialized = mo->serialized;
+            auto const masterKey = mo->masterKey;
+            auto const sequence = mo->sequence;
+            auto const revoked = mo->revoked();
+
+            // Cache membership is observation, not authority: a legacy row
+            // cannot perpetuate itself by presenting a newer signature. This
+            // transport slice admits durable updates only for current local
+            // validator policy.
+            if (!app_.validators().listed(masterKey))
+            {
+                if (n == 1)
+                {
+                    JLOG(journal.debug())
+                        << "manifest_validation single_manifest_ignored master="
+                        << toBase58(TokenType::NodePublic, masterKey)
+                        << " sequence=" << sequence
+                        << " reason=unlisted_new_identity";
+                }
+                continue;
+            }
 
             auto const result =
                 app_.validatorManifests().applyManifest(std::move(*mo));
 
+            if (result == ManifestDisposition::invalid)
+                from->charge(
+                    Resource::feeInvalidSignature,
+                    "invalid validator manifest signature");
+            else if (
+                result == ManifestDisposition::badMasterKey ||
+                result == ManifestDisposition::badEphemeralKey)
+                from->charge(
+                    Resource::feeInvalidData,
+                    "invalid validator manifest key role");
+
+            if (n == 1)
+            {
+                JLOG(journal.debug())
+                    << "manifest_validation single_manifest_processed master="
+                    << toBase58(TokenType::NodePublic, masterKey)
+                    << " sequence=" << sequence
+                    << " disposition=" << to_string(result);
+            }
+
             if (result == ManifestDisposition::accepted)
             {
-                relay.add_list()->set_stobject(s);
+                if (revoked)
+                {
+                    // A revocation has no associated validation to carry it
+                    // onward, so it retains immediate network-wide relay.
+                    relay.add_list()->set_stobject(s);
+                    JLOG(journal.debug())
+                        << "manifest_revocation accepted_for_relay master="
+                        << toBase58(TokenType::NodePublic, masterKey);
+                }
 
                 // N.B.: this is important; the applyManifest call above moves
                 //       the loaded Manifest out of the optional so we need to
@@ -1155,17 +1203,21 @@ OverlayImpl::relay(
 }
 
 void
-OverlayImpl::broadcast(protocol::TMValidation& m)
+OverlayImpl::broadcast(protocol::TMValidation& m, PublicKey const& validator)
 {
-    auto const sm = std::make_shared<Message>(m, protocol::mtVALIDATION);
-    for_each([sm](std::shared_ptr<PeerImp>&& p) { p->send(sm); });
+    auto const sm =
+        std::make_shared<Message>(m, protocol::mtVALIDATION, validator);
+    for_each([sm, validator](std::shared_ptr<PeerImp>&& p) {
+        p->sendValidation(sm, validator);
+    });
 }
 
 std::set<Peer::id_t>
 OverlayImpl::relay(
     protocol::TMValidation& m,
     uint256 const& uid,
-    PublicKey const& validator)
+    PublicKey const& validator,
+    std::shared_ptr<protocol::TMManifests const> const& prerequisite)
 {
     if (auto const toSkip = app_.getHashRouter().shouldRelay(uid))
     {
@@ -1173,41 +1225,11 @@ OverlayImpl::relay(
             std::make_shared<Message>(m, protocol::mtVALIDATION, validator);
         for_each([&](std::shared_ptr<PeerImp>&& p) {
             if (toSkip->find(p->id()) == toSkip->end())
-                p->send(sm);
+                p->sendValidation(sm, validator, prerequisite);
         });
         return *toSkip;
     }
     return {};
-}
-
-std::shared_ptr<Message>
-OverlayImpl::getManifestsMessage()
-{
-    std::lock_guard g(manifestLock_);
-
-    if (auto seq = app_.validatorManifests().sequence();
-        seq != manifestListSeq_)
-    {
-        protocol::TMManifests tm;
-
-        app_.validatorManifests().for_each_manifest(
-            [&tm](std::size_t s) { tm.mutable_list()->Reserve(s); },
-            [&tm, &hr = app_.getHashRouter()](Manifest const& manifest) {
-                tm.add_list()->set_stobject(
-                    manifest.serialized.data(), manifest.serialized.size());
-                hr.addSuppression(manifest.hash());
-            });
-
-        manifestMessage_.reset();
-
-        if (tm.list_size() != 0)
-            manifestMessage_ =
-                std::make_shared<Message>(tm, protocol::mtMANIFESTS);
-
-        manifestListSeq_ = seq;
-    }
-
-    return manifestMessage_;
 }
 
 void

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -631,12 +631,14 @@ OverlayImpl::onPeerDeactivate(Peer::id_t id)
 void
 OverlayImpl::onManifests(
     std::shared_ptr<protocol::TMManifests> const& m,
-    std::shared_ptr<PeerImp> const& from)
+    std::shared_ptr<PeerImp> const& from,
+    ManifestAdmission admission)
 {
     auto const n = m->list_size();
     auto const& journal = from->pjournal();
 
     protocol::TMManifests relay;
+    std::vector<std::pair<PublicKey, std::uint32_t>> relayAssertions;
 
     for (std::size_t i = 0; i < n; ++i)
     {
@@ -650,10 +652,20 @@ OverlayImpl::onManifests(
             auto const revoked = mo->revoked();
 
             // Cache membership is observation, not authority: a legacy row
-            // cannot perpetuate itself by presenting a newer signature. This
-            // transport slice admits durable updates only for current local
-            // validator policy.
-            if (!app_.validators().listed(masterKey))
+            // cannot perpetuate itself by presenting a newer normal
+            // signature. Current local policy admits ordinary updates; the
+            // one response-gated exception can only terminate an existing
+            // retained master.
+            auto const listed = app_.validators().listed(masterKey);
+            auto const retainedRevocationResponse = !listed && revoked &&
+                admission == ManifestAdmission::retainedRevocationResponse &&
+                [&]() {
+                    auto const current =
+                        app_.validatorManifests().getManifestSnapshot(
+                            masterKey);
+                    return current && current->sequence < sequence;
+                }();
+            if (!listed && !retainedRevocationResponse)
             {
                 if (n == 1)
                 {
@@ -696,6 +708,7 @@ OverlayImpl::onManifests(
                     // A revocation has no associated validation to carry it
                     // onward, so it retains immediate network-wide relay.
                     relay.add_list()->set_stobject(s);
+                    relayAssertions.emplace_back(masterKey, sequence);
                     JLOG(journal.debug())
                         << "manifest_revocation accepted_for_relay master="
                         << toBase58(TokenType::NodePublic, masterKey);
@@ -728,8 +741,11 @@ OverlayImpl::onManifests(
     }
 
     if (!relay.list().empty())
-        for_each([m2 = std::make_shared<Message>(relay, protocol::mtMANIFESTS)](
-                     std::shared_ptr<PeerImp>&& p) { p->send(m2); });
+        for_each([m2 = std::make_shared<Message>(relay, protocol::mtMANIFESTS),
+                  assertions = std::move(relayAssertions)](
+                     std::shared_ptr<PeerImp>&& p) {
+            p->sendManifestAssertions(m2, assertions);
+        });
 }
 
 void

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -285,11 +285,14 @@ public:
         }
     }
 
+    enum class ManifestAdmission { localPolicy, retainedRevocationResponse };
+
     // Called when TMManifests is received from a peer
     void
     onManifests(
         std::shared_ptr<protocol::TMManifests> const& m,
-        std::shared_ptr<PeerImp> const& from);
+        std::shared_ptr<PeerImp> const& from,
+        ManifestAdmission admission = ManifestAdmission::localPolicy);
 
     static bool
     isPeerUpgrade(http_request_type const& request);

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -124,13 +124,6 @@ private:
     // Transaction reduce-relay metrics
     metrics::TxMetrics txMetrics_;
 
-    // A message with the list of manifests we send to peers
-    std::shared_ptr<Message> manifestMessage_;
-    // Used to track whether we need to update the cached list of manifests
-    std::optional<std::uint32_t> manifestListSeq_;
-    // Protects the message and the sequence list of manifests
-    std::mutex manifestLock_;
-
     //--------------------------------------------------------------------------
 
 public:
@@ -221,7 +214,7 @@ public:
     broadcast(protocol::TMProposeSet& m) override;
 
     void
-    broadcast(protocol::TMValidation& m) override;
+    broadcast(protocol::TMValidation& m, PublicKey const& validator) override;
 
     std::set<Peer::id_t>
     relay(
@@ -233,16 +226,15 @@ public:
     relay(
         protocol::TMValidation& m,
         uint256 const& uid,
-        PublicKey const& validator) override;
+        PublicKey const& validator,
+        std::shared_ptr<protocol::TMManifests const> const& prerequisite)
+        override;
 
     void
     relay(
         uint256 const&,
         std::optional<std::reference_wrapper<protocol::TMTransaction>> m,
         std::set<Peer::id_t> const& skip) override;
-
-    std::shared_ptr<Message>
-    getManifestsMessage();
 
     //--------------------------------------------------------------------------
     //

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -47,6 +47,7 @@
 #include <mutex>
 #include <numeric>
 #include <sstream>
+#include <utility>
 
 using namespace std::chrono_literals;
 
@@ -58,6 +59,7 @@ std::chrono::milliseconds constexpr peerHighLatency{300};
 
 /** How often we PING the peer to check for latency and sendq probe */
 std::chrono::seconds constexpr peerTimerInterval{60};
+std::size_t constexpr maxManifestBytes = 4096;
 }  // namespace
 
 // TODO: Remove this exclusion once unit tests are added after the hotfix
@@ -289,6 +291,88 @@ PeerImp::send(std::shared_ptr<Message> const& m)
                 shared_from_this(),
                 std::placeholders::_1,
                 std::placeholders::_2)));
+}
+
+void
+PeerImp::sendValidation(
+    std::shared_ptr<Message> const& validation,
+    PublicKey const& signingKey,
+    std::shared_ptr<protocol::TMManifests const> const& prerequisite)
+{
+    if (!strand_.running_in_this_thread())
+        return post(
+            strand_,
+            std::bind(
+                &PeerImp::sendValidation,
+                shared_from_this(),
+                validation,
+                signingKey,
+                prerequisite));
+
+    if (gracefulClose_ || detaching_)
+        return;
+
+    // Admit the pair as one operation. Otherwise send(manifest) could succeed,
+    // send(validation) could be squelched, and the connection would observe a
+    // credential with no associated validation.
+    if (!squelch_.expireSquelch(signingKey))
+        return;
+
+    std::optional<PublicKey> prerequisiteMaster;
+    std::uint32_t prerequisiteSequence = 0;
+    std::shared_ptr<protocol::TMManifests const> manifest = prerequisite;
+    if (!manifest)
+    {
+        if (auto const snapshot =
+                app_.validatorManifests().getManifestSnapshot(signingKey);
+            snapshot && !snapshot->revoked() && snapshot->signingKey &&
+            *snapshot->signingKey == signingKey)
+        {
+            auto value = std::make_shared<protocol::TMManifests>();
+            value->add_list()->set_stobject(snapshot->serialized);
+            manifest = value;
+            prerequisiteMaster = snapshot->masterKey;
+            prerequisiteSequence = snapshot->sequence;
+        }
+    }
+    else if (manifest->list_size() == 1)
+    {
+        if (auto parsed = deserializeManifest(manifest->list(0).stobject()))
+        {
+            prerequisiteMaster = parsed->masterKey;
+            prerequisiteSequence = parsed->sequence;
+        }
+    }
+
+    // UNLs are local. This sender cannot infer that the receiver retains the
+    // same identities, and there is deliberately no association ACK or
+    // per-connection receiver table in this cut. Therefore every validation
+    // with an available prerequisite carries it immediately beforehand.
+    bool const sendPrerequisite = manifest && prerequisiteMaster;
+
+    if (sendPrerequisite)
+    {
+        JLOG(p_journal_.debug())
+            << "manifest_validation send_prerequisite peer=" << id_
+            << " master="
+            << (prerequisiteMaster
+                    ? toBase58(TokenType::NodePublic, *prerequisiteMaster)
+                    : "unknown")
+            << " sequence=" << prerequisiteSequence;
+        send(std::make_shared<Message>(*manifest, protocol::mtMANIFESTS));
+    }
+
+    send(validation);
+    if (sendPrerequisite)
+    {
+        JLOG(p_journal_.debug())
+            << "manifest_validation pair_enqueued peer=" << id_
+            << " order=manifest,validation master="
+            << (prerequisiteMaster
+                    ? toBase58(TokenType::NodePublic, *prerequisiteMaster)
+                    : "unknown")
+            << " sequence=" << prerequisiteSequence;
+    }
 }
 
 void
@@ -870,9 +954,6 @@ PeerImp::doProtocolStart()
             });
     }
 
-    if (auto m = overlay_.getManifestsMessage())
-        send(m);
-
     setTimer();
 }
 
@@ -1058,10 +1139,130 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
     }
 
     if (s > 100)
+    {
         fee_.update(Resource::feeModerateBurdenPeer, "oversize");
+        return;
+    }
 
+    for (auto const& item : m->list())
+    {
+        if (item.stobject().size() > maxManifestBytes)
+        {
+            fee_.update(
+                Resource::feeModerateBurdenPeer, "oversized manifest object");
+            return;
+        }
+    }
+
+    auto const that = shared_from_this();
+
+    // A single normal manifest is a bounded, connection-scoped candidate for
+    // a later matching validation. Structural decoding is cheap enough
+    // to identify its signing key; signature verification waits until that
+    // validation claims the same key. Revocations have no following validation
+    // and therefore retain immediate verification/application semantics.
+    if (s == 1)
+    {
+        auto const& serialized = m->list(0).stobject();
+        auto manifest = deserializeManifest(serialized, p_journal_);
+        if (!manifest)
+        {
+            fee_.update(Resource::feeMalformedRequest, "malformed manifest");
+            return;
+        }
+
+        if (manifest->revoked())
+        {
+            // A fresh self-signed revocation has no more claim on permanent
+            // state than a fresh ordinary manifest. This transport slice has
+            // no durable provenance model, so only current local policy earns
+            // the terminal update.
+            if (!app_.validators().listed(manifest->masterKey))
+            {
+                JLOG(p_journal_.debug())
+                    << "manifest_revocation ignored_unlisted master="
+                    << toBase58(TokenType::NodePublic, manifest->masterKey);
+                return;
+            }
+
+            app_.getJobQueue().addJob(
+                jtMANIFEST, "receiveManifestRevocation", [this, that, m]() {
+                    overlay_.onManifests(m, that);
+                });
+            return;
+        }
+
+        XRPL_ASSERT(
+            manifest->signingKey,
+            "ripple::PeerImp::onMessage(TMManifests) : normal manifest has "
+            "signing key");
+
+        if (publicKeyType(*manifest->signingKey) != KeyType::secp256k1)
+        {
+            fee_.update(
+                Resource::feeInvalidData,
+                "validator manifest signing key is not secp256k1");
+            return;
+        }
+
+        if (auto const current = app_.validatorManifests().getManifestSnapshot(
+                manifest->masterKey);
+            current && current->sequence >= manifest->sequence)
+        {
+            JLOG(p_journal_.debug())
+                << "manifest_validation candidate_ignored peer=" << id_
+                << " reason=global_sequence master="
+                << toBase58(TokenType::NodePublic, manifest->masterKey);
+            return;
+        }
+
+        if (pendingManifest_)
+        {
+            auto const current = app_.validatorManifests().getManifestSnapshot(
+                pendingManifest_->masterKey);
+            if (current && current->sequence >= pendingManifest_->sequence)
+                pendingManifest_.reset();
+        }
+
+        if (pendingManifest_)
+        {
+            auto const pendingRelevant =
+                app_.validators().listed(pendingManifest_->masterKey);
+            auto const incomingRelevant =
+                app_.validators().listed(manifest->masterKey);
+            auto const sameMasterNewer =
+                pendingManifest_->masterKey == manifest->masterKey &&
+                manifest->sequence > pendingManifest_->sequence;
+            if (!sameMasterNewer && (!incomingRelevant || pendingRelevant))
+            {
+                JLOG(p_journal_.debug())
+                    << "manifest_validation candidate_ignored peer=" << id_
+                    << " reason=pending_candidate";
+                return;
+            }
+
+            JLOG(p_journal_.debug())
+                << "manifest_validation candidate_replaced peer=" << id_
+                << " reason="
+                << (sameMasterNewer ? "same_master_newer" : "listed_priority")
+                << " master="
+                << toBase58(TokenType::NodePublic, manifest->masterKey);
+        }
+        pendingManifest_.emplace(PendingManifest{
+            m, manifest->masterKey, *manifest->signingKey, manifest->sequence});
+        JLOG(p_journal_.debug())
+            << "manifest_validation candidate_staged peer=" << id_ << " master="
+            << toBase58(TokenType::NodePublic, manifest->masterKey)
+            << " signing="
+            << toBase58(TokenType::NodePublic, *manifest->signingKey)
+            << " sequence=" << manifest->sequence;
+        return;
+    }
+
+    // Compatibility lane for legacy handshake-era batches. New propagation
+    // sends exactly one manifest immediately before its validation.
     app_.getJobQueue().addJob(
-        jtMANIFEST, "receiveManifests", [this, that = shared_from_this(), m]() {
+        jtMANIFEST, "receiveManifests", [this, that, m]() {
             overlay_.onManifests(m, that);
         });
 }
@@ -2289,18 +2490,63 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
     {
         auto const closeTime = app_.timeKeeper().closeTime();
 
+        if (pendingManifest_)
+        {
+            auto const current = app_.validatorManifests().getManifestSnapshot(
+                pendingManifest_->masterKey);
+            if (current && current->sequence >= pendingManifest_->sequence)
+            {
+                JLOG(p_journal_.debug())
+                    << "manifest_validation candidate_dropped peer=" << id_
+                    << " reason=retained_sequence master="
+                    << toBase58(
+                           TokenType::NodePublic, pendingManifest_->masterKey);
+                pendingManifest_.reset();
+            }
+        }
+
+        std::optional<PendingManifest> manifestContext;
+        SerialIter claimIter(makeSlice(m->validation()));
+        STObject claim(claimIter, sfValidation);
+        auto const claimedKeyBytes = claim.getFieldVL(sfSigningPubKey);
+        if (publicKeyType(makeSlice(claimedKeyBytes)) == KeyType::secp256k1)
+        {
+            PublicKey const claimedKey(makeSlice(claimedKeyBytes));
+            if (pendingManifest_ && claimedKey == pendingManifest_->signingKey)
+            {
+                manifestContext = pendingManifest_;
+            }
+            else if (pendingManifest_)
+            {
+                JLOG(p_journal_.debug())
+                    << "manifest_validation candidate_retained peer=" << id_
+                    << " reason=signing_key_mismatch";
+            }
+        }
+
         std::shared_ptr<STValidation> val;
         {
             SerialIter sit(makeSlice(m->validation()));
             val = std::make_shared<STValidation>(
                 std::ref(sit),
-                [this](PublicKey const& pk) {
+                [this, &manifestContext](PublicKey const& pk) {
+                    if (manifestContext && pk == manifestContext->signingKey)
+                        return calcNodeID(manifestContext->masterKey);
                     return calcNodeID(
                         app_.validatorManifests().getMasterKey(pk));
                 },
                 false);
             val->setSeen(closeTime);
         }
+
+        auto const& signingKey = val->getSignerPublic();
+        auto const masterKey = manifestContext
+            ? manifestContext->masterKey
+            : app_.validatorManifests().getMasterKey(signingKey);
+        JLOG(p_journal_.debug())
+            << "manifest_validation validation_parsed peer=" << id_
+            << " signing=" << toBase58(TokenType::NodePublic, signingKey)
+            << " master=" << toBase58(TokenType::NodePublic, masterKey);
 
         if (!isCurrent(
                 app_.getValidations().parms(),
@@ -2316,26 +2562,79 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
         // RH TODO: when isTrusted = false we should probably also cache a key
         // suppression for 30 seconds to avoid doing a relatively expensive
         // lookup every time a spam packet is received
+        // A pending manifest is still only a claim here. Do not let its
+        // claimed master key promote this work to the trusted queue. The job
+        // verifies both signatures before applying the manifest and making
+        // the final trust decision.
         auto const isTrusted =
             app_.validators().trusted(val->getSignerPublic());
+        auto const candidateListed = manifestContext &&
+            app_.validators().listed(manifestContext->masterKey);
+
+        // A naked validation with neither a trusted signer nor a retained
+        // signing-to-master mapping cannot contribute to consensus and cannot
+        // be repaired locally. Drop it before it claims the validation hash;
+        // a later manifest+validation pair can then be verified normally.
+        if (!manifestContext && !isTrusted && masterKey == signingKey &&
+            !app_.validators().listed(signingKey))
+        {
+            JLOG(p_journal_.debug())
+                << "manifest_validation naked_unknown_dropped peer=" << id_
+                << " signing=" << toBase58(TokenType::NodePublic, signingKey);
+            return;
+        }
 
         // If the operator has specified that untrusted validations be dropped
         // then this happens here I.e. before further wasting CPU verifying the
         // signature of an untrusted key
-        if (!isTrusted && app_.config().RELAY_UNTRUSTED_VALIDATIONS == -1)
+        if (!isTrusted && !candidateListed &&
+            app_.config().RELAY_UNTRUSTED_VALIDATIONS == -1)
             return;
 
-        auto key = sha512Half(makeSlice(m->validation()));
+        if (!isTrusted && !candidateListed &&
+            tracking_.load() == Tracking::diverged)
+        {
+            JLOG(p_journal_.debug())
+                << "Dropping untrusted validation from diverged peer";
+            return;
+        }
+
+        if (!isTrusted && !candidateListed &&
+            app_.getFeeTrack().isLoadedLocal())
+        {
+            JLOG(p_journal_.debug())
+                << "Dropping untrusted validation for load";
+            return;
+        }
+
+        if (manifestContext)
+        {
+            JLOG(p_journal_.debug())
+                << "manifest_validation candidate_matched peer=" << id_
+                << " master="
+                << toBase58(TokenType::NodePublic, manifestContext->masterKey)
+                << " signing=" << toBase58(TokenType::NodePublic, signingKey)
+                << " sequence=" << manifestContext->sequence;
+        }
+
+        auto const key = sha512Half(makeSlice(m->validation()));
+        auto const suppressionKey = manifestContext
+            ? sha512Half(
+                  std::uint32_t{0x4d565031},  // "MVP1"
+                  makeSlice(m->validation()),
+                  makeSlice(manifestContext->message->list(0).stobject()))
+            : key;
 
         if (auto [added, relayed] =
-                app_.getHashRouter().addSuppressionPeerWithStatus(key, id_);
+                app_.getHashRouter().addSuppressionPeerWithStatus(
+                    suppressionKey, id_);
             !added)
         {
             // Count unique messages (Slots has it's own 'HashRouter'), which a
             // peer receives within IDLED seconds since the message has been
             // relayed. Wait WAIT_ON_BOOTUP time to let the server establish
             // connections to peers.
-            if (reduceRelayReady() && relayed &&
+            if (!manifestContext && reduceRelayReady() && relayed &&
                 (stopwatch().now() - *relayed) < reduce_relay::IDLED)
                 overlay_.updateSlotAndSquelch(
                     key, val->getSignerPublic(), id_, protocol::mtVALIDATION);
@@ -2343,40 +2642,33 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
             return;
         }
 
-        if (!isTrusted && (tracking_.load() == Tracking::diverged))
-        {
-            JLOG(p_journal_.debug())
-                << "Dropping untrusted validation from diverged peer";
-        }
-        else if (isTrusted || !app_.getFeeTrack().isLoadedLocal())
-        {
-            std::string const name = [isTrusted, val]() {
-                std::string ret =
-                    isTrusted ? "Trusted validation" : "Untrusted validation";
+        std::string const name = [isTrusted, val]() {
+            std::string ret =
+                isTrusted ? "Trusted validation" : "Untrusted validation";
 
 #ifdef DEBUG
-                ret += " " +
-                    std::to_string(val->getFieldU32(sfLedgerSequence)) + ": " +
-                    to_string(val->getNodeID());
+            ret += " " + std::to_string(val->getFieldU32(sfLedgerSequence)) +
+                ": " + to_string(val->getNodeID());
 #endif
 
-                return ret;
-            }();
+            return ret;
+        }();
 
-            std::weak_ptr<PeerImp> weak = shared_from_this();
-            app_.getJobQueue().addJob(
-                isTrusted ? jtVALIDATION_t : jtVALIDATION_ut,
-                name,
-                [weak, val, m, key]() {
-                    if (auto peer = weak.lock())
-                        peer->checkValidation(val, key, m);
-                });
-        }
-        else
-        {
-            JLOG(p_journal_.debug())
-                << "Dropping untrusted validation for load";
-        }
+        std::weak_ptr<PeerImp> weak = shared_from_this();
+        auto pairedPeer = manifestContext ? shared_from_this() : nullptr;
+        app_.getJobQueue().addJob(
+            isTrusted ? jtVALIDATION_t : jtVALIDATION_ut,
+            name,
+            [weak,
+             pairedPeer = std::move(pairedPeer),
+             val,
+             m,
+             key,
+             manifestContext = std::move(manifestContext)]() mutable {
+                if (auto peer = pairedPeer ? pairedPeer : weak.lock())
+                    peer->checkValidation(
+                        val, key, m, std::move(manifestContext));
+            });
     }
     catch (std::exception const& e)
     {
@@ -2968,10 +3260,32 @@ PeerImp::checkPropose(
 }
 
 void
+PeerImp::releasePendingManifest(PendingManifest claimed)
+{
+    if (!strand_.running_in_this_thread())
+    {
+        post(
+            strand_,
+            std::bind(
+                &PeerImp::releasePendingManifest,
+                shared_from_this(),
+                std::move(claimed)));
+        return;
+    }
+
+    if (pendingManifest_ && pendingManifest_->message == claimed.message &&
+        pendingManifest_->masterKey == claimed.masterKey &&
+        pendingManifest_->signingKey == claimed.signingKey &&
+        pendingManifest_->sequence == claimed.sequence)
+        pendingManifest_.reset();
+}
+
+void
 PeerImp::checkValidation(
     std::shared_ptr<STValidation> const& val,
     uint256 const& key,
-    std::shared_ptr<protocol::TMValidation> const& packet)
+    std::shared_ptr<protocol::TMValidation> const& packet,
+    std::optional<PendingManifest> manifestContext)
 {
     if (!val->isValid())
     {
@@ -2979,6 +3293,105 @@ PeerImp::checkValidation(
         JLOG(p_journal_.debug()) << desc;
         charge(Resource::feeInvalidSignature, desc);
         return;
+    }
+
+    std::shared_ptr<protocol::TMManifests const> prerequisite;
+    if (manifestContext)
+    {
+        auto manifest = deserializeManifest(
+            manifestContext->message->list(0).stobject(), p_journal_);
+        if (!manifest || manifest->revoked() || !manifest->signingKey ||
+            manifest->masterKey != manifestContext->masterKey ||
+            *manifest->signingKey != manifestContext->signingKey ||
+            val->getSignerPublic() != manifestContext->signingKey ||
+            !manifest->verify())
+        {
+            std::string const desc{
+                "Validation prerequisite manifest is invalid"};
+            JLOG(p_journal_.debug()) << desc;
+            charge(Resource::feeInvalidSignature, desc);
+            return;
+        }
+
+        // A valid signature does not make a key association admissible. In
+        // particular, an unlisted pair must not traverse ephemerally when its
+        // signing key is already retained for another master. Use the same
+        // key-role rules as durable cache admission before either path can
+        // relay the pair.
+        if (app_.validatorManifests().checkKeyRoles(*manifest))
+        {
+            std::string const desc{
+                "Validation prerequisite manifest has conflicting key roles"};
+            JLOG(p_journal_.debug()) << desc;
+            charge(Resource::feeInvalidData, desc);
+            return;
+        }
+
+        auto const cacheEligible =
+            app_.validators().listed(manifestContext->masterKey);
+
+        if (cacheEligible)
+        {
+            // Only current local policy may affect the durable cache in this
+            // slice. Cache membership alone is not provenance.
+            overlay_.onManifests(manifestContext->message, shared_from_this());
+
+            auto const current = app_.validatorManifests().getManifestSnapshot(
+                manifestContext->signingKey);
+            if (!current || current->revoked() || !current->signingKey ||
+                current->masterKey != manifestContext->masterKey ||
+                *current->signingKey != manifestContext->signingKey ||
+                current->sequence < manifest->sequence)
+            {
+                JLOG(p_journal_.debug())
+                    << "manifest_validation candidate_rejected peer=" << id_
+                    << " reason=not_current_after_application";
+                // Listed admission failed or raced with another update. Do
+                // not reinterpret that failure as permission to relay the
+                // same association ephemerally.
+                return;
+            }
+            else
+            {
+                auto message = std::make_shared<protocol::TMManifests>();
+                message->add_list()->set_stobject(current->serialized);
+                prerequisite = std::move(message);
+            }
+        }
+        else
+        {
+            // Unlisted validators may still traverse a node configured to
+            // relay untrusted validations, but the pair remains ephemeral.
+            prerequisite = manifestContext->message;
+            JLOG(p_journal_.debug())
+                << "manifest_validation candidate_ephemeral peer=" << id_
+                << " master="
+                << toBase58(TokenType::NodePublic, manifestContext->masterKey);
+        }
+
+        // Both signatures and the admission/ephemeral policy are now proven.
+        // Release only this exact candidate on the peer strand; a newer
+        // replacement that arrived while the job ran must remain intact.
+        releasePendingManifest(*manifestContext);
+
+        if (!app_.validators().trusted(manifestContext->masterKey) &&
+            app_.config().RELAY_UNTRUSTED_VALIDATIONS == -1)
+            return;
+
+        // The pre-verification suppression identity includes both packets.
+        // Only after both signatures pass may this pair claim the actual
+        // validation hash. An invalid prerequisite therefore cannot poison a
+        // later valid validation for the hash-router hold interval.
+        if (auto [added, relayed] =
+                app_.getHashRouter().addSuppressionPeerWithStatus(key, id_);
+            !added)
+        {
+            if (reduceRelayReady() && relayed &&
+                (stopwatch().now() - *relayed) < reduce_relay::IDLED)
+                overlay_.updateSlotAndSquelch(
+                    key, val->getSignerPublic(), id_, protocol::mtVALIDATION);
+            return;
+        }
     }
 
     // FIXME it should be safe to remove this try/catch. Investigate codepaths.
@@ -2991,8 +3404,8 @@ PeerImp::checkValidation(
             // are the source of the message, consequently the message should
             // not be relayed to these peers. But the message must be counted
             // as part of the squelch logic.
-            auto haveMessage =
-                overlay_.relay(*packet, key, val->getSignerPublic());
+            auto haveMessage = overlay_.relay(
+                *packet, key, val->getSignerPublic(), prerequisite);
             if (reduceRelayReady() && !haveMessage.empty())
             {
                 overlay_.updateSlotAndSquelch(

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -3325,11 +3325,14 @@ PeerImp::sendManifestRepair(
     if (gracefulClose_ || detaching_)
         return;
 
-    if (auto const it = manifestRepairSequences_.find(masterKey);
-        it != manifestRepairSequences_.end() && it->second >= sequence)
+    auto const it = manifestRepairSequences_.find(masterKey);
+    if (it != manifestRepairSequences_.end() && it->second >= sequence)
         return;
 
-    if (manifestRepairSequences_.size() >= maxManifestRepairEntries)
+    // Overflow evicts on growth only. Updating an existing master's sequence
+    // must not wipe the rest of the connection's repair ledger.
+    if (it == manifestRepairSequences_.end() &&
+        manifestRepairSequences_.size() >= maxManifestRepairEntries)
         manifestRepairSequences_.clear();
     manifestRepairSequences_[masterKey] = sequence;
 

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -3305,8 +3305,11 @@ PeerImp::checkPropose(
 void
 PeerImp::finishManifestVerification()
 {
+    // Instrumentation is compiled out in NDEBUG builds; the state transition
+    // must not live inside XRPL_ASSERT.
+    auto const wasInFlight = manifestVerificationInFlight_.exchange(false);
     XRPL_ASSERT(
-        manifestVerificationInFlight_.exchange(false),
+        wasInFlight,
         "ripple::PeerImp::finishManifestVerification : verification in "
         "flight");
     JLOG(p_journal_.debug())

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -36,6 +36,7 @@
 #include <xrpl/basics/base64.h>
 #include <xrpl/basics/random.h>
 #include <xrpl/basics/safe_cast.h>
+#include <xrpl/basics/scope.h>
 #include <xrpl/beast/core/LexicalCast.h>
 #include <xrpl/protocol/digest.h>
 
@@ -2512,9 +2513,18 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
         if (publicKeyType(makeSlice(claimedKeyBytes)) == KeyType::secp256k1)
         {
             PublicKey const claimedKey(makeSlice(claimedKeyBytes));
-            if (pendingManifest_ && claimedKey == pendingManifest_->signingKey)
+            if (pendingManifest_ &&
+                claimedKey == pendingManifest_->signingKey &&
+                !manifestVerificationInFlight_)
             {
                 manifestContext = pendingManifest_;
+            }
+            else if (
+                pendingManifest_ && claimedKey == pendingManifest_->signingKey)
+            {
+                JLOG(p_journal_.debug())
+                    << "manifest_validation candidate_retained peer=" << id_
+                    << " reason=verification_in_flight";
             }
             else if (pendingManifest_)
             {
@@ -2656,19 +2666,52 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
 
         std::weak_ptr<PeerImp> weak = shared_from_this();
         auto pairedPeer = manifestContext ? shared_from_this() : nullptr;
-        app_.getJobQueue().addJob(
-            isTrusted ? jtVALIDATION_t : jtVALIDATION_ut,
-            name,
-            [weak,
-             pairedPeer = std::move(pairedPeer),
-             val,
-             m,
-             key,
-             manifestContext = std::move(manifestContext)]() mutable {
-                if (auto peer = pairedPeer ? pairedPeer : weak.lock())
-                    peer->checkValidation(
-                        val, key, m, std::move(manifestContext));
-            });
+        bool const pairedJob = manifestContext.has_value();
+        if (pairedJob)
+        {
+            XRPL_ASSERT(
+                pendingManifest_ &&
+                    pendingManifest_->message == manifestContext->message,
+                "ripple::PeerImp::onMessage(TMValidation) : pending manifest "
+                "claim is current");
+            pendingManifest_.reset();
+            manifestVerificationInFlight_ = true;
+            JLOG(p_journal_.debug())
+                << "manifest_validation candidate_claimed peer=" << id_
+                << " state=verification_in_flight";
+        }
+
+        bool queued = false;
+        try
+        {
+            queued = app_.getJobQueue().addJob(
+                isTrusted ? jtVALIDATION_t : jtVALIDATION_ut,
+                name,
+                [weak,
+                 pairedPeer = std::move(pairedPeer),
+                 val,
+                 m,
+                 key,
+                 manifestContext = std::move(manifestContext)]() mutable {
+                    if (auto peer = pairedPeer ? pairedPeer : weak.lock())
+                        peer->checkValidation(
+                            val, key, m, std::move(manifestContext));
+                });
+        }
+        catch (...)
+        {
+            if (pairedJob)
+                manifestVerificationInFlight_ = false;
+            throw;
+        }
+
+        if (!queued && pairedJob)
+        {
+            manifestVerificationInFlight_ = false;
+            JLOG(p_journal_.debug())
+                << "manifest_validation candidate_rejected peer=" << id_
+                << " reason=job_queue_refused";
+        }
     }
     catch (std::exception const& e)
     {
@@ -3260,24 +3303,14 @@ PeerImp::checkPropose(
 }
 
 void
-PeerImp::releasePendingManifest(PendingManifest claimed)
+PeerImp::finishManifestVerification()
 {
-    if (!strand_.running_in_this_thread())
-    {
-        post(
-            strand_,
-            std::bind(
-                &PeerImp::releasePendingManifest,
-                shared_from_this(),
-                std::move(claimed)));
-        return;
-    }
-
-    if (pendingManifest_ && pendingManifest_->message == claimed.message &&
-        pendingManifest_->masterKey == claimed.masterKey &&
-        pendingManifest_->signingKey == claimed.signingKey &&
-        pendingManifest_->sequence == claimed.sequence)
-        pendingManifest_.reset();
+    XRPL_ASSERT(
+        manifestVerificationInFlight_.exchange(false),
+        "ripple::PeerImp::finishManifestVerification : verification in "
+        "flight");
+    JLOG(p_journal_.debug())
+        << "manifest_validation verification_finished peer=" << id_;
 }
 
 void
@@ -3287,6 +3320,12 @@ PeerImp::checkValidation(
     std::shared_ptr<protocol::TMValidation> const& packet,
     std::optional<PendingManifest> manifestContext)
 {
+    bool const pairedJob = manifestContext.has_value();
+    scope_exit finishPairVerification([this, pairedJob]() {
+        if (pairedJob)
+            finishManifestVerification();
+    });
+
     if (!val->isValid())
     {
         std::string desc{"Validation forwarded by peer is invalid"};
@@ -3368,11 +3407,6 @@ PeerImp::checkValidation(
                 << " master="
                 << toBase58(TokenType::NodePublic, manifestContext->masterKey);
         }
-
-        // Both signatures and the admission/ephemeral policy are now proven.
-        // Release only this exact candidate on the peer strand; a newer
-        // replacement that arrived while the job ran must remain intact.
-        releasePendingManifest(*manifestContext);
 
         if (!app_.validators().trusted(manifestContext->masterKey) &&
             app_.config().RELAY_UNTRUSTED_VALIDATIONS == -1)

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -2506,6 +2506,8 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
             }
         }
 
+        // Claim phase: copy the strand-owned waiting row so admission can be
+        // decided. Ownership has not moved and no job right exists yet.
         std::optional<PendingManifest> manifestContext;
         SerialIter claimIter(makeSlice(m->validation()));
         STObject claim(claimIter, sfValidation);
@@ -2674,6 +2676,8 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
                     pendingManifest_->message == manifestContext->message,
                 "ripple::PeerImp::onMessage(TMValidation) : pending manifest "
                 "claim is current");
+            // Admission commit: move authority out of the strand-owned
+            // waiting row and mint this connection's sole active job token.
             pendingManifest_.reset();
             manifestVerificationInFlight_ = true;
             JLOG(p_journal_.debug())
@@ -2701,13 +2705,13 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
         catch (...)
         {
             if (pairedJob)
-                manifestVerificationInFlight_ = false;
+                finishManifestVerification();
             throw;
         }
 
         if (!queued && pairedJob)
         {
-            manifestVerificationInFlight_ = false;
+            finishManifestVerification();
             JLOG(p_journal_.debug())
                 << "manifest_validation candidate_rejected peer=" << id_
                 << " reason=job_queue_refused";
@@ -3324,6 +3328,9 @@ PeerImp::checkValidation(
     std::optional<PendingManifest> manifestContext)
 {
     bool const pairedJob = manifestContext.has_value();
+    // The queued job owns the moved association. This scope guard is its
+    // all-exits terminal: success, refusal, and exception consume the active
+    // connection token exactly once.
     scope_exit finishPairVerification([this, pairedJob]() {
         if (pairedJob)
             finishManifestVerification();

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -2642,6 +2642,12 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
                     suppressionKey, id_);
             !added)
         {
+            // A previously relayed copy of these exact bytes has already
+            // passed validation. Repair this particular naked sender even
+            // though another peer won global admission for the hash.
+            if (!manifestContext && relayed)
+                sendManifestRepairForSigningKey(val->getSignerPublic());
+
             // Count unique messages (Slots has it's own 'HashRouter'), which a
             // peer receives within IDLED seconds since the message has been
             // relayed. Wait WAIT_ON_BOOTUP time to let the server establish
@@ -3307,6 +3313,17 @@ PeerImp::checkPropose(
 }
 
 void
+PeerImp::sendManifestRepairForSigningKey(PublicKey const& signingKey)
+{
+    if (auto const snapshot =
+            app_.validatorManifests().getManifestSnapshot(signingKey);
+        snapshot && !snapshot->revoked() && snapshot->signingKey &&
+        *snapshot->signingKey == signingKey)
+        sendManifestRepair(
+            snapshot->masterKey, snapshot->sequence, snapshot->serialized);
+}
+
+void
 PeerImp::sendManifestRepair(
     PublicKey const& masterKey,
     std::uint32_t sequence,
@@ -3506,17 +3523,7 @@ PeerImp::checkValidation(
             // this point, and paired traffic proves the sender already holds
             // the prerequisite.
             if (!pairedJob)
-            {
-                if (auto const snapshot =
-                        app_.validatorManifests().getManifestSnapshot(
-                            val->getSignerPublic());
-                    snapshot && !snapshot->revoked() && snapshot->signingKey &&
-                    *snapshot->signingKey == val->getSignerPublic())
-                    sendManifestRepair(
-                        snapshot->masterKey,
-                        snapshot->sequence,
-                        snapshot->serialized);
-            }
+                sendManifestRepairForSigningKey(val->getSignerPublic());
         }
     }
     catch (std::exception const& ex)

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -1214,6 +1214,22 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
                 << "manifest_validation candidate_ignored peer=" << id_
                 << " reason=global_sequence master="
                 << toBase58(TokenType::NodePublic, manifest->masterKey);
+            // A strictly stale candidate proves the sender is behind for a
+            // master this node retains. Answer with the retained manifest —
+            // or the revocation, the freshest possible answer — at most once
+            // per sequence through the bounded repair ledger. Equal-sequence
+            // arrivals are ordinary always-send traffic and draw nothing.
+            if (current->sequence > manifest->sequence)
+            {
+                JLOG(p_journal_.debug())
+                    << "manifest_validation stale_correction peer=" << id_
+                    << " master="
+                    << toBase58(TokenType::NodePublic, manifest->masterKey)
+                    << " theirs=" << manifest->sequence
+                    << " ours=" << current->sequence;
+                sendManifestRepair(
+                    current->masterKey, current->sequence, current->serialized);
+            }
             return;
         }
 

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -3307,6 +3307,42 @@ PeerImp::checkPropose(
 }
 
 void
+PeerImp::sendManifestRepair(
+    PublicKey const& masterKey,
+    std::uint32_t sequence,
+    std::string serialized)
+{
+    if (!strand_.running_in_this_thread())
+        return post(
+            strand_,
+            std::bind(
+                &PeerImp::sendManifestRepair,
+                shared_from_this(),
+                masterKey,
+                sequence,
+                std::move(serialized)));
+
+    if (gracefulClose_ || detaching_)
+        return;
+
+    if (auto const it = manifestRepairSequences_.find(masterKey);
+        it != manifestRepairSequences_.end() && it->second >= sequence)
+        return;
+
+    if (manifestRepairSequences_.size() >= maxManifestRepairEntries)
+        manifestRepairSequences_.clear();
+    manifestRepairSequences_[masterKey] = sequence;
+
+    protocol::TMManifests tm;
+    tm.add_list()->set_stobject(serialized);
+    send(std::make_shared<Message>(tm, protocol::mtMANIFESTS));
+    JLOG(p_journal_.debug())
+        << "manifest_validation repair_sent peer=" << id_
+        << " master=" << toBase58(TokenType::NodePublic, masterKey)
+        << " sequence=" << sequence;
+}
+
+void
 PeerImp::finishManifestVerification()
 {
     // Instrumentation is compiled out in NDEBUG builds; the state transition
@@ -3457,6 +3493,26 @@ PeerImp::checkValidation(
                     val->getSignerPublic(),
                     std::move(haveMessage),
                     protocol::mtVALIDATION);
+            }
+
+            // A naked validation that just authenticated against the current
+            // cached manifest is an implicit request for that manifest.
+            // Repair the sender on this connection only; the strand-owned
+            // repair ledger bounds it to one singleton per master/sequence.
+            // Forged, malformed, and unknown-signer traffic never reaches
+            // this point, and paired traffic proves the sender already holds
+            // the prerequisite.
+            if (!pairedJob)
+            {
+                if (auto const snapshot =
+                        app_.validatorManifests().getManifestSnapshot(
+                            val->getSignerPublic());
+                    snapshot && !snapshot->revoked() && snapshot->signingKey &&
+                    *snapshot->signingKey == val->getSignerPublic())
+                    sendManifestRepair(
+                        snapshot->masterKey,
+                        snapshot->sequence,
+                        snapshot->serialized);
             }
         }
     }

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -360,6 +360,10 @@ PeerImp::sendValidation(
                     ? toBase58(TokenType::NodePublic, *prerequisiteMaster)
                     : "unknown")
             << " sequence=" << prerequisiteSequence;
+        if (auto const retained = app_.validatorManifests().getManifestSnapshot(
+                *prerequisiteMaster);
+            retained && retained->sequence >= prerequisiteSequence)
+            recordManifestAssertion(*prerequisiteMaster, prerequisiteSequence);
         send(std::make_shared<Message>(*manifest, protocol::mtMANIFESTS));
     }
 
@@ -1175,10 +1179,17 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
         if (manifest->revoked())
         {
             // A fresh self-signed revocation has no more claim on permanent
-            // state than a fresh ordinary manifest. This transport slice has
-            // no durable provenance model, so only current local policy earns
-            // the terminal update.
-            if (!app_.validators().listed(manifest->masterKey))
+            // state than a fresh ordinary manifest. Current local policy may
+            // admit it directly; an unlisted response may only terminate a
+            // master already retained here after this connection asserted an
+            // older sequence.
+            auto const listed = app_.validators().listed(manifest->masterKey);
+            auto const current = app_.validatorManifests().getManifestSnapshot(
+                manifest->masterKey);
+            auto const retainedResponse = !listed && current &&
+                current->sequence < manifest->sequence &&
+                assertedOlderManifest(manifest->masterKey, manifest->sequence);
+            if (!listed && !retainedResponse)
             {
                 JLOG(p_journal_.debug())
                     << "manifest_revocation ignored_unlisted master="
@@ -1187,8 +1198,16 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
             }
 
             app_.getJobQueue().addJob(
-                jtMANIFEST, "receiveManifestRevocation", [this, that, m]() {
-                    overlay_.onManifests(m, that);
+                jtMANIFEST,
+                "receiveManifestRevocation",
+                [this, that, m, retainedResponse]() {
+                    overlay_.onManifests(
+                        m,
+                        that,
+                        retainedResponse
+                            ? OverlayImpl::ManifestAdmission::
+                                  retainedRevocationResponse
+                            : OverlayImpl::ManifestAdmission::localPolicy);
                 });
             return;
         }
@@ -1214,11 +1233,12 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
                 << "manifest_validation candidate_ignored peer=" << id_
                 << " reason=global_sequence master="
                 << toBase58(TokenType::NodePublic, manifest->masterKey);
-            // A strictly stale candidate proves the sender is behind for a
-            // master this node retains. Answer with the retained manifest —
-            // or the revocation, the freshest possible answer — at most once
-            // per sequence through the bounded repair ledger. Equal-sequence
-            // arrivals are ordinary always-send traffic and draw nothing.
+            // A strictly lower sequence claims that the sender is behind for
+            // a master this node retains. Answer with the retained manifest —
+            // or the revocation, the freshest possible answer — without
+            // treating this unverified trigger as ingress authority. The
+            // shared repair ledger suppresses repeats while its row survives;
+            // equal-sequence always-send traffic draws nothing.
             if (current->sequence > manifest->sequence)
             {
                 JLOG(p_journal_.debug())
@@ -3358,16 +3378,11 @@ PeerImp::sendManifestRepair(
     if (gracefulClose_ || detaching_)
         return;
 
-    auto const it = manifestRepairSequences_.find(masterKey);
-    if (it != manifestRepairSequences_.end() && it->second >= sequence)
+    auto const it = manifestAssertionSequences_.find(masterKey);
+    if (it != manifestAssertionSequences_.end() && it->second >= sequence)
         return;
 
-    // Overflow evicts on growth only. Updating an existing master's sequence
-    // must not wipe the rest of the connection's repair ledger.
-    if (it == manifestRepairSequences_.end() &&
-        manifestRepairSequences_.size() >= maxManifestRepairEntries)
-        manifestRepairSequences_.clear();
-    manifestRepairSequences_[masterKey] = sequence;
+    recordManifestAssertion(masterKey, sequence);
 
     protocol::TMManifests tm;
     tm.add_list()->set_stobject(serialized);
@@ -3376,6 +3391,63 @@ PeerImp::sendManifestRepair(
         << "manifest_validation repair_sent peer=" << id_
         << " master=" << toBase58(TokenType::NodePublic, masterKey)
         << " sequence=" << sequence;
+}
+
+void
+PeerImp::recordManifestAssertion(
+    PublicKey const& masterKey,
+    std::uint32_t sequence)
+{
+    XRPL_ASSERT(
+        strand_.running_in_this_thread(),
+        "ripple::PeerImp::recordManifestAssertion : on strand");
+
+    auto const it = manifestAssertionSequences_.find(masterKey);
+    if (it != manifestAssertionSequences_.end())
+    {
+        if (it->second < sequence)
+            it->second = sequence;
+        return;
+    }
+
+    if (manifestAssertionSequences_.size() >= maxManifestAssertionEntries)
+        manifestAssertionSequences_.clear();
+    manifestAssertionSequences_.emplace(masterKey, sequence);
+}
+
+bool
+PeerImp::assertedOlderManifest(
+    PublicKey const& masterKey,
+    std::uint32_t sequence) const
+{
+    XRPL_ASSERT(
+        strand_.running_in_this_thread(),
+        "ripple::PeerImp::assertedOlderManifest : on strand");
+
+    auto const it = manifestAssertionSequences_.find(masterKey);
+    return it != manifestAssertionSequences_.end() && it->second < sequence;
+}
+
+void
+PeerImp::sendManifestAssertions(
+    std::shared_ptr<Message> const& message,
+    std::vector<std::pair<PublicKey, std::uint32_t>> assertions)
+{
+    if (!strand_.running_in_this_thread())
+        return post(
+            strand_,
+            std::bind(
+                &PeerImp::sendManifestAssertions,
+                shared_from_this(),
+                message,
+                std::move(assertions)));
+
+    if (gracefulClose_ || detaching_)
+        return;
+
+    for (auto const& [masterKey, sequence] : assertions)
+        recordManifestAssertion(masterKey, sequence);
+    send(message);
 }
 
 void

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -175,6 +175,24 @@ private:
     http_response_type response_;
     boost::beast::http::fields const& headers_;
     std::queue<std::shared_ptr<Message>> send_queue_;
+    /** One unverified manifest awaiting a later matching validation.
+
+        Normal manifests are structurally decoded on receipt but are not
+        signature-verified or admitted to the global cache until a validation
+        on this connection claims the same signing key. A claim copies this
+        association into its verification job; the slot itself remains until
+        cache advancement or an allowed replacement. Access is serialized by
+        strand_.
+    */
+    struct PendingManifest
+    {
+        std::shared_ptr<protocol::TMManifests> message;
+        PublicKey masterKey;
+        PublicKey signingKey;
+        std::uint32_t sequence;
+    };
+    std::optional<PendingManifest> pendingManifest_;
+
     bool gracefulClose_ = false;
     int large_sendq_ = 0;
     std::unique_ptr<LoadEvent> load_event_;
@@ -486,6 +504,18 @@ private:
     void
     doProtocolStart();
 
+    /** Send a validation after its current manifest on this connection.
+
+        Both existing protocol envelopes are enqueued on strand_ in wire
+        order. No receiver-side association or acknowledgement is assumed, so
+        an available prerequisite is sent with every validation.
+    */
+    void
+    sendValidation(
+        std::shared_ptr<Message> const& validation,
+        PublicKey const& signingKey,
+        std::shared_ptr<protocol::TMManifests const> const& prerequisite = {});
+
     // Called when protocol message bytes are received
     void
     onReadMessage(error_code ec, std::size_t bytes_transferred);
@@ -635,7 +665,11 @@ private:
     checkValidation(
         std::shared_ptr<STValidation> const& val,
         uint256 const& key,
-        std::shared_ptr<protocol::TMValidation> const& packet);
+        std::shared_ptr<protocol::TMValidation> const& packet,
+        std::optional<PendingManifest> manifestContext);
+
+    void
+    releasePendingManifest(PendingManifest claimed);
 
     void
     sendLedgerBase(

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -179,9 +179,9 @@ private:
 
         Normal manifests are structurally decoded on receipt but are not
         signature-verified or admitted to the global cache until a validation
-        on this connection claims the same signing key. A claim copies this
-        association into its verification job; the slot itself remains until
-        cache advancement or an allowed replacement. Access is serialized by
+        on this connection claims the same signing key. An admitted claim
+        moves the association into the sole in-flight verification job, which
+        frees this slot for one later candidate. Access is serialized by
         strand_.
     */
     struct PendingManifest
@@ -192,6 +192,7 @@ private:
         std::uint32_t sequence;
     };
     std::optional<PendingManifest> pendingManifest_;
+    std::atomic_bool manifestVerificationInFlight_{false};
 
     bool gracefulClose_ = false;
     int large_sendq_ = 0;
@@ -669,7 +670,7 @@ private:
         std::optional<PendingManifest> manifestContext);
 
     void
-    releasePendingManifest(PendingManifest claimed);
+    finishManifestVerification();
 
     void
     sendLedgerBase(

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -200,16 +200,16 @@ private:
     // the job terminal executes on a JobQueue worker, not the peer strand.
     std::atomic_bool manifestVerificationInFlight_{false};
 
-    // The bounded repair ledger for this connection. A naked validation that
-    // authenticates against the current cached manifest for its signing key
-    // is an implicit request for that manifest; this records which
-    // master/sequence singletons were already returned on this connection.
-    // Owner/executor: this peer's strand. Entries only exist for masters the
-    // durable cache resolves. The ledger is cleared wholesale only when a
-    // new master would exceed the cap; a lost entry costs one duplicate
-    // singleton repair.
-    static constexpr std::size_t maxManifestRepairEntries = 256;
-    hash_map<PublicKey, std::uint32_t> manifestRepairSequences_;
+    // The bounded assertion ledger for this connection. Every retained
+    // manifest sent here records its master/sequence. Backward repair hints
+    // therefore deduplicate against prior prerequisites and each other, and a
+    // terminal response can prove it answers state this connection actually
+    // asserted. Ephemeral pairs do not allocate rows.
+    // Owner/executor: this peer's strand. The ledger is cleared wholesale only
+    // when a new master would exceed the cap; forgetting is safe and may cost
+    // one duplicate repair or one missed best-effort correction.
+    static constexpr std::size_t maxManifestAssertionEntries = 256;
+    hash_map<PublicKey, std::uint32_t> manifestAssertionSequences_;
 
     bool gracefulClose_ = false;
     int large_sendq_ = 0;
@@ -478,6 +478,14 @@ public:
         return txReduceRelayEnabled_;
     }
 
+protected:
+    /** Dispatch derived-class work through this peer's serialized executor. */
+    void
+    dispatchOnStrand(std::function<void()> work)
+    {
+        boost::asio::dispatch(strand_, std::move(work));
+    }
+
 private:
     void
     close();
@@ -710,6 +718,18 @@ private:
         PublicKey const& masterKey,
         std::uint32_t sequence,
         std::string serialized);
+
+    void
+    recordManifestAssertion(PublicKey const& masterKey, std::uint32_t sequence);
+
+    bool
+    assertedOlderManifest(PublicKey const& masterKey, std::uint32_t sequence)
+        const;
+
+    void
+    sendManifestAssertions(
+        std::shared_ptr<Message> const& message,
+        std::vector<std::pair<PublicKey, std::uint32_t>> assertions);
 
     void
     sendLedgerBase(

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -205,8 +205,9 @@ private:
     // is an implicit request for that manifest; this records which
     // master/sequence singletons were already returned on this connection.
     // Owner/executor: this peer's strand. Entries only exist for masters the
-    // durable cache resolves, and the ledger is cleared wholesale on
-    // overflow; a lost entry costs one duplicate singleton repair.
+    // durable cache resolves. The ledger is cleared wholesale only when a
+    // new master would exceed the cap; a lost entry costs one duplicate
+    // singleton repair.
     static constexpr std::size_t maxManifestRepairEntries = 256;
     hash_map<PublicKey, std::uint32_t> manifestRepairSequences_;
 

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -200,6 +200,16 @@ private:
     // the job terminal executes on a JobQueue worker, not the peer strand.
     std::atomic_bool manifestVerificationInFlight_{false};
 
+    // The bounded repair ledger for this connection. A naked validation that
+    // authenticates against the current cached manifest for its signing key
+    // is an implicit request for that manifest; this records which
+    // master/sequence singletons were already returned on this connection.
+    // Owner/executor: this peer's strand. Entries only exist for masters the
+    // durable cache resolves, and the ledger is cleared wholesale on
+    // overflow; a lost entry costs one duplicate singleton repair.
+    static constexpr std::size_t maxManifestRepairEntries = 256;
+    hash_map<PublicKey, std::uint32_t> manifestRepairSequences_;
+
     bool gracefulClose_ = false;
     int large_sendq_ = 0;
     std::unique_ptr<LoadEvent> load_event_;
@@ -682,6 +692,20 @@ private:
     */
     void
     finishManifestVerification();
+
+    /** Return a cached manifest to the peer that sent its validation naked.
+
+        A naked validation that has authenticated against the current cached
+        manifest for its signing key is an implicit request for that
+        manifest. The strand consults the bounded repair ledger and sends at
+        most one singleton per master/sequence on this connection. Callable
+        from a verification job; the send hops to the strand.
+    */
+    void
+    sendManifestRepair(
+        PublicKey const& masterKey,
+        std::uint32_t sequence,
+        std::string serialized);
 
     void
     sendLedgerBase(

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -177,7 +177,8 @@ private:
     std::queue<std::shared_ptr<Message>> send_queue_;
     /** One unverified manifest awaiting a later matching validation.
 
-        Normal manifests are structurally decoded on receipt but are not
+        Owner/executor: this peer's strand. Normal manifests are structurally
+        decoded on receipt but are not
         signature-verified or admitted to the global cache until a validation
         on this connection claims the same signing key. An admitted claim
         moves the association into the sole in-flight verification job, which
@@ -192,6 +193,11 @@ private:
         std::uint32_t sequence;
     };
     std::optional<PendingManifest> pendingManifest_;
+
+    // The one active verification-obligation token for this connection. The
+    // strand mints it when pending ownership moves into a job; admission
+    // rollback or that job's terminal clears it exactly once. Atomic because
+    // the job terminal executes on a JobQueue worker, not the peer strand.
     std::atomic_bool manifestVerificationInFlight_{false};
 
     bool gracefulClose_ = false;
@@ -669,6 +675,11 @@ private:
         std::shared_ptr<protocol::TMValidation> const& packet,
         std::optional<PendingManifest> manifestContext);
 
+    /** Consume the connection's sole active verification-obligation token.
+
+        This is the only terminal operation for both failed job admission and
+        every exit from an admitted verification job.
+    */
     void
     finishManifestVerification();
 

--- a/src/xrpld/overlay/detail/PeerImp.h
+++ b/src/xrpld/overlay/detail/PeerImp.h
@@ -703,6 +703,9 @@ private:
         from a verification job; the send hops to the strand.
     */
     void
+    sendManifestRepairForSigningKey(PublicKey const& signingKey);
+
+    void
     sendManifestRepair(
         PublicKey const& masterKey,
         std::uint32_t sequence,


### PR DESCRIPTION
<!-- ai-docs
id = "discussions.2026-08-29-manifest-validation-driven-propagation-pr"
kind = "discussion"
title = "Draft PR: validation-driven manifest propagation"
-->
# Experiment: send validator manifests with validations

Today a server keeps every accepted validator manifest forever and sends the
whole cache to each new connection. That cache can grow without bound, but the
size quietly buys real resilience: a new or restarted server can learn old
manifests from almost any peer, dormant validators remain recognizable after
topology changes, and revocations already seen do not have to be rediscovered.

This experiment asks whether normal manifests still need that ambient gossip.
A manifest is useful when a validation refers to its signing key. When this
server relays a validation and has the matching manifest, it sends one
`TMManifests` entry immediately before the existing `TMValidation` on that
connection. There is no new message type and no feature bit. New servers stop
dumping the cache at connect time; they still accept small legacy batches from
old peers and refuse oversized ones. Because the prerequisite is sent again
with every validation, a missed or mixed-version hop can repair on the next
round.

When the manifest is not available at all, the validation still goes out
naked, so mixed-version traffic is not stuck waiting for a prerequisite.
The naked form also works in reverse. Once a recipient authenticates a naked
validation against its own current cached manifest, the validation doubles as
an implicit request: the recipient returns that one manifest as a singleton
`TMManifests` on the same connection. A late sender of the same validation is
repaired too, but only after those exact bytes have already been verified
and relayed. Forged, malformed, unknown-signer, and already-paired traffic
draws no repair. Each connection records retained manifests it has sent in a
small ledger of at most 256 masters. Overflow may permit a duplicate repair or
lose a best-effort correction opportunity, but cannot grow connection memory.

Taken together, the wire now speaks a small implied protocol, carried
entirely by the two message types the network has always had. Every message
doubles as a speech act. A manifest sent before a validation is an
assertion: this is the identity behind what follows. A naked validation is
a request: supply the identity if you can. A stale manifest is an assertion
of outdated belief, and can draw back the retained state — or the revocation,
the freshest possible answer — while the connection remembers that response.
And because every retained manifest a server sends is remembered as its own
assertion, a valid terminal answer about the same master, on the same
connection, is an admissible response: having raised the subject, the server
is willing to hear that the identity has ended, but never to store anyone new
or admit an ordinary rotation through this exception.
There is no negotiation and no new envelope; the grammar is ordering,
freshness, and demonstrated need in messages old software already
understands. Revocations, which validation traffic can never carry forward,
thereby gain a demand-driven path through nodes that both retained and asserted
the older identity. A fresh bridge that carried the pair only ephemerally is
still a gap; the tombstone does not acquire storage rights merely by arriving.

Each connection holds at most one unverified manifest and runs at most one
paired verification job. The manifest and validation signatures must pass,
and the keys must match, before the pair can change validator state. Locally
listed identities may be stored; a newly invented unlisted identity can still
ride with its validation but is not kept. The bound is on this server, not on
the sender's honesty.

That was enough for a three-node all-new network, and for an upgraded ->
release -> upgraded relay, using only existing protocol messages. In the
mixed run, the new node repaired the old relay's later naked validations.
Active propagation can be local to a connection and repeated, instead of
depending on an unbounded global cache.

The forever cache was also an informal replicated history: any peer could
re-supply manifests that others had lost. Validation traffic replaces that
network memory for active validators, because a manifest is re-sent whenever
its validator validates. That replacement now has live evidence: a server
with a wiped manifest store re-learned a validator's identity from ordinary
traffic and resumed forwarding pairs, and a mid-run key rotation propagated
through an old relay, superseded the retained knowledge, and re-armed the
repair path at the new sequence. A revocation has no later valid validation
to re-advertise it, so it most depended on the connect-time dump. Listed
revocations still verify, apply, and relay immediately when they arrive.
Additionally, an unlisted terminal response may end a master already retained
locally when that connection previously asserted an older sequence. This
repairs stale retained paths, but not fresh ephemeral bridges or dormant paths.
Replacing the lost network memory still needs a separate bounded durable
source; this experiment does not provide one.

At the transport pin (`cd782a3ae`) the focused native suites passed 45 cases
and 1,313 assertions, plus the all-new and mixed-version three-node live
scenarios. The accepted repair pin (`c20e8ac2b`) adds the repair path; the
mixed scenario shows it in the logs, and the 1,307-assertion focused slice
passed three consecutive repeats. A live lifecycle suite now also exercises
mid-run rotation, revocation, and wallet-wipe recovery across mixed
binaries — with five validators, revoking one leaves the network closing
ledgers at exact quorum — and passed twice consecutively. At the
response-gated terminal pin (`824d516a8`), both FITH and ordinary five-suite
gates passed 48 cases and 1,390 assertions. The refusal-control pin
(`cfe4ce176`) adds explicit forged-terminal and ordinary-rotation negatives;
its strand-realistic focused suite passed three consecutive runs of 20 cases
and 957 assertions, and the ordinary five-suite gate passed 48 cases and
1,395 assertions.
