### PR TITLE
fix(server): preserve idle JSON-RPC keep-alives

### DIFF
--- a/include/xrpl/server/detail/BaseHTTPPeer.h
+++ b/include/xrpl/server/detail/BaseHTTPPeer.h
@@ -300,7 +300,13 @@ BaseHTTPPeer<Handler, Impl>::do_read(yield_context do_yield)
 {
     complete_ = false;
     error_code ec;
-    start_timer();
+    // Do not treat an established keep-alive waiting for its next request as
+    // an unfinished loopback request.
+    if (request_count_ == 0)
+        start_timer();
+    else
+        boost::beast::get_lowest_layer(impl().stream_)
+            .expires_after(std::chrono::seconds(timeoutSeconds));
     boost::beast::http::async_read(
         impl().stream_, read_buf_, message_, do_yield[ec]);
     cancel_timer();

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -28,7 +28,9 @@
 #include <xrpl/protocol/jss.h>
 
 #include <boost/lexical_cast.hpp>
+#include <chrono>
 #include <optional>
+#include <thread>
 #include <utility>
 
 namespace ripple {
@@ -907,6 +909,24 @@ public:
     }
 
     void
+    testJSONRPCClientKeepAlive()
+    {
+        testcase("JSON-RPC keep-alive survives test work");
+        using namespace std::chrono_literals;
+        using namespace jtx;
+
+        Env env{*this};
+        env.client().invoke("server_info", {});
+
+        // The normal loopback message timeout is three seconds. Established
+        // Env connections have a separate idle lease because test work can
+        // legitimately take longer between RPCs.
+        std::this_thread::sleep_for(4s);
+        auto const response = env.client().invoke("server_info", {});
+        BEAST_EXPECT(response[jss::result][jss::status] == "success");
+    }
+
+    void
     run() override
     {
         using namespace test::jtx;
@@ -933,6 +953,7 @@ public:
         testSignAndSubmit(all);
         testFeatures(all);
         testExceptionalShutdown();
+        testJSONRPCClientKeepAlive();
     }
 };
 


### PR DESCRIPTION
Fixes intermittent `end_of_stream` failures in the Clang Actions jobs while Catalogue and TransactionHistory reuse jtx's HTTP/1.1 client:
https://github.com/Xahau/xahaud/actions/runs/33032604844/job/98388329022#step:12:1627

The 3-second loopback message deadline was also closing established idle keep-alives. Keep it for initial request/write work, but use the existing 30-second interval while waiting for the next request.

Adds a deterministic regression. Draft until CI confirms.