### PR TITLE
Add RemitLimitAmount amendment: optional LimitAmount on Remit AmountEntry

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -34,6 +34,7 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
+XRPL_FEATURE(RemitLimitAmount,           Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(OnChainManifests,           Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (HookMap,                    Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FIX    (GuardDepth32,               Supported::yes, VoteBehavior::DefaultNo)

--- a/src/libxrpl/protocol/InnerObjectFormats.cpp
+++ b/src/libxrpl/protocol/InnerObjectFormats.cpp
@@ -147,6 +147,7 @@ InnerObjectFormats::InnerObjectFormats()
         sfAmountEntry.getCode(),
         {
             {sfAmount, soeREQUIRED},
+            {sfLimitAmount, soeOPTIONAL},
         });
 
     add(sfMintURIToken.jsonName,

--- a/src/test/app/Remit_test.cpp
+++ b/src/test/app/Remit_test.cpp
@@ -106,6 +106,36 @@ struct Remit_test : public beast::unit_test::suite
         return STAmount(iou, 0);
     }
 
+    static STAmount
+    lineLimit(
+        jtx::Env const& env,
+        jtx::Account const& account,
+        jtx::Account const& gw,
+        jtx::IOU const& iou)
+    {
+        auto const sle = env.le(keylet::line(account, gw, iou.currency));
+        if (!sle)
+            return STAmount(iou, 0);
+        bool const accountHigh = account.id() > gw.id();
+        return (*sle)[accountHigh ? sfHighLimit : sfLowLimit];
+    }
+
+    // Whether `account`'s own side of its line with `peer` has NoRipple set.
+    static bool
+    lineNoRipple(
+        jtx::Env const& env,
+        jtx::Account const& account,
+        jtx::Account const& peer,
+        jtx::IOU const& iou)
+    {
+        auto const sle = env.le(keylet::line(account, peer, iou.currency));
+        if (!sle)
+            return false;
+        bool const accountHigh = account.id() > peer.id();
+        return (sle->getFlags() &
+                (accountHigh ? lsfHighNoRipple : lsfLowNoRipple)) != 0;
+    }
+
     static bool
     validateSequence(
         jtx::Env const& env,
@@ -2925,6 +2955,425 @@ struct Remit_test : public beast::unit_test::suite
     }
 
     void
+    testLimitAmount(FeatureBitset features)
+    {
+        testcase("limit amount");
+        using namespace jtx;
+
+        bool const enabled = features[featureRemitLimitAmount];
+
+        // Amendment disabled: LimitAmount is rejected outright.
+        if (!enabled)
+        {
+            Env env{*this, features};
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            auto const USD = gw["USD"];
+
+            env.fund(XRP(1000), alice, bob, gw);
+            env.close();
+            env.trust(USD(100'000), alice);
+            env.close();
+            env(pay(gw, alice, USD(10'000)));
+            env.close();
+
+            env(remit::remit(alice, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(1000)),
+                ter(temDISABLED));
+            return;
+        }
+
+        // Malformed LimitAmount entries.
+        {
+            Env env{*this, features};
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            auto const gw2 = Account("gw2");
+            auto const USD = gw["USD"];
+            auto const EUR = gw["EUR"];
+            auto const USD2 = gw2["USD"];
+
+            env.fund(XRP(1000), alice, bob, gw, gw2);
+            env.close();
+            env.trust(USD(100'000), alice);
+            env.close();
+            env(pay(gw, alice, USD(10'000)));
+            env.close();
+
+            // LimitAmount is XAH.
+            env(remit::remit(alice, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, XRP(10)),
+                ter(temBAD_CURRENCY));
+
+            // LimitAmount currency does not match Amount's currency.
+            env(remit::remit(alice, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, EUR(1000)),
+                ter(temBAD_CURRENCY));
+
+            // LimitAmount issuer does not match Amount's issuer.
+            env(remit::remit(alice, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD2(1000)),
+                ter(temBAD_CURRENCY));
+
+            // LimitAmount is negative.
+            env(remit::remit(alice, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(-1000)),
+                ter(temBAD_AMOUNT));
+
+            // LimitAmount is zero.
+            env(remit::remit(alice, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(0)),
+                ter(temBAD_AMOUNT));
+        }
+
+        // Situation 1: a Remit-created (Limit 0) trust line cannot receive
+        // a Payment from a third party; setting LimitAmount fixes this.
+        {
+            Env env{*this, features};
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const carol = Account("carol");
+            auto const gw = Account("gw");
+            auto const USD = gw["USD"];
+
+            // alice/bob must not be DefaultRipple, or the LimitAmount gate
+            // (see Remit.cpp) silently skips setting the trust line limit.
+            // gw (the issuer) keeps DefaultRipple on, as any real gateway
+            // would, so its lines aren't automatically marked NoRipple.
+            env.fund(XRP(1000), noripple(alice, bob), carol, gw);
+            env.close();
+            env.trust(USD(100'000), carol);
+            env.close();
+            env(pay(gw, carol, USD(100)));
+            env.close();
+
+            // baseline: no LimitAmount, line created at Limit 0
+            env(remit::remit(gw, bob), remit::amts({USD(10)}), ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, USD.issue()) == USD(10));
+            BEAST_EXPECT(lineLimit(env, bob, gw, USD) == USD(0));
+
+            // a third party cannot pay into the Limit-0 line
+            env(pay(carol, bob, USD(5)), ter(tecPATH_DRY));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, USD.issue()) == USD(10));
+
+            // with LimitAmount, the same scenario succeeds
+            env(remit::remit(gw, alice),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(1000)),
+                ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(lineLimit(env, alice, gw, USD) == USD(1000));
+
+            env(pay(carol, alice, USD(5)), ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(alice, USD.issue()) == USD(15));
+        }
+
+        // LimitAmount also works when the Remit sender is not the issuer.
+        {
+            Env env{*this, features};
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            auto const USD = gw["USD"];
+
+            env.fund(XRP(1000), noripple(bob), alice, gw);
+            env.close();
+            env.trust(USD(100'000), alice);
+            env.close();
+            env(pay(gw, alice, USD(100)));
+            env.close();
+
+            env(remit::remit(alice, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(1000)),
+                ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, USD.issue()) == USD(10));
+            BEAST_EXPECT(lineLimit(env, bob, gw, USD) == USD(1000));
+        }
+
+        // Situation 2: a Remit-created (Limit 0, default flags) line is
+        // auto-deleted at balance zero; LimitAmount keeps it alive.
+        {
+            Env env{*this, features};
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            auto const USD = gw["USD"];
+
+            env.fund(XRP(1000), noripple(alice), bob, gw);
+            env.close();
+
+            // baseline: no LimitAmount
+            env(remit::remit(gw, bob), remit::amts({USD(10)}), ter(tesSUCCESS));
+            env.close();
+            auto const preOwnerCount = env.ownerCount(bob);
+            env(pay(bob, gw, USD(10)));
+            env.close();
+            BEAST_EXPECT(!env.le(keylet::line(bob, gw, USD.currency)));
+            BEAST_EXPECT(env.ownerCount(bob) < preOwnerCount);
+
+            // with LimitAmount, the line survives balance zero
+            env(remit::remit(gw, alice),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(1000)),
+                ter(tesSUCCESS));
+            env.close();
+            auto const preAliceOwnerCount = env.ownerCount(alice);
+            env(pay(alice, gw, USD(10)));
+            env.close();
+            BEAST_EXPECT(env.le(keylet::line(alice, gw, USD.currency)));
+            BEAST_EXPECT(lineLimit(env, alice, gw, USD) == USD(1000));
+            BEAST_EXPECT(env.balance(alice, USD.issue()) == USD(0));
+            BEAST_EXPECT(env.ownerCount(alice) == preAliceOwnerCount);
+        }
+
+        // Existing line: LimitAmount must never overwrite an existing limit
+        // -- the whole Remit is rejected instead, so nothing is
+        // transferred.
+        {
+            Env env{*this, features};
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            auto const USD = gw["USD"];
+
+            env.fund(XRP(1000), alice, bob, gw);
+            env.close();
+            env.trust(USD(50), bob);
+            env.close();
+            BEAST_EXPECT(lineLimit(env, bob, gw, USD) == USD(50));
+            auto const preBobUSD = env.balance(bob, USD.issue());
+
+            env(remit::remit(gw, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(1000)),
+                ter(tecNO_PERMISSION));
+            env.close();
+            BEAST_EXPECT(lineLimit(env, bob, gw, USD) == USD(50));
+            BEAST_EXPECT(env.balance(bob, USD.issue()) == preBobUSD);
+
+            // regression guard: the same Remit without LimitAmount still
+            // works normally against an existing line.
+            env(remit::remit(gw, bob), remit::amts({USD(10)}), ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, USD.issue()) == preBobUSD + USD(10));
+        }
+
+        // DefaultRipple destination: LimitAmount is rejected -- the whole
+        // Remit fails, no line is created, nothing is transferred.
+        {
+            Env env{*this, features};
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            auto const USD = gw["USD"];
+
+            env.fund(XRP(1000), alice, bob, gw);
+            env.close();
+            env(fset(bob, asfDefaultRipple));
+            env.close();
+            auto const preBobBal = env.balance(bob);
+
+            env(remit::remit(gw, bob),
+                remit::amts({USD(10)}),
+                remit::limit_amount(0, USD(1000)),
+                ter(tecNO_PERMISSION));
+            env.close();
+            BEAST_EXPECT(!env.le(keylet::line(bob, gw, USD.currency)));
+            BEAST_EXPECT(env.balance(bob) == preBobBal);
+
+            // regression guard: the same Remit without LimitAmount still
+            // works normally against a DefaultRipple destination.
+            env(remit::remit(gw, bob), remit::amts({USD(10)}), ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(bob, USD.issue()) == USD(10));
+        }
+    }
+
+    void
+    testLimitAmountRippling(FeatureBitset features)
+    {
+        testcase("limit amount rippling attack");
+        using namespace jtx;
+
+        // These scenarios only make sense with LimitAmount enabled.
+        if (!features[featureRemitLimitAmount])
+            return;
+
+        // Scenario A: attacker Remits to a DefaultRipple=true issuer (gw).
+        // The DefaultRipple gate must hold: gw's side of the new line
+        // must stay at Limit 0, and the attacker must not be able to
+        // ripple its own currency through gw into a genuine holder.
+        {
+            Env env{*this, features};
+            auto const gw = Account("gw");
+            auto const holder = Account("holder");
+            auto const attacker = Account("attacker");
+            auto const USDgw = gw["USD"];
+            auto const USDA = attacker["USD"];
+
+            env.fund(XRP(1000), gw, holder, attacker);
+            env.close();
+            env(fset(gw, asfDefaultRipple));
+            env.close();
+
+            env.trust(USDgw(1000), holder);
+            env.close();
+            env(pay(gw, holder, USDgw(100)));
+            env.close();
+
+            // attacker Remits USD_A(1) to gw with a large LimitAmount.
+            // OBSERVED: the whole Remit is now rejected (tecNO_PERMISSION)
+            // since gw is DefaultRipple -- no line is created at all, and
+            // nothing is transferred (not even the incidental USD_A(1)
+            // that used to land before this design change).
+            env(remit::remit(attacker, gw),
+                remit::amts({USDA(1)}),
+                remit::limit_amount(0, USDA(1'000'000)),
+                ter(tecNO_PERMISSION));
+            env.close();
+            BEAST_EXPECT(!env.le(keylet::line(gw, attacker, USDA.currency)));
+            BEAST_EXPECT(env.balance(gw, USDA.issue()) == USDA(0));
+
+            // Attack: attacker pays holder USD_gw, sourcing from its own
+            // USD_A, rippling through gw. OBSERVED: fails with tecPATH_DRY
+            // -- there is no gw-attacker line at all now (the Remit was
+            // rejected outright), so the SendMax leg has no liquidity.
+            env(pay(attacker, holder, USDgw(50)),
+                sendmax(USDA(50)),
+                path(gw),
+                ter(tecPATH_DRY));
+            env.close();
+            BEAST_EXPECT(env.balance(holder, USDgw.issue()) == USDgw(100));
+            BEAST_EXPECT(env.balance(gw, USDA.issue()) == USDA(0));
+
+            // Control: gw itself trusts USD_A directly (no Remit/gate
+            // involved) -- this is expected to actually allow the ripple,
+            // proving the attack vector is real when the limit is nonzero.
+            env(trust(gw, USDA(1'000'000)));
+            env.close();
+
+            // OBSERVED: succeeds once gw's limit is nonzero.
+            env(pay(attacker, holder, USDgw(50)),
+                sendmax(USDA(50)),
+                path(gw),
+                ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(holder, USDgw.issue()) == USDgw(150));
+            // no incidental Remit transfer this time (the Remit was
+            // rejected above), so just the 50 from the attack.
+            BEAST_EXPECT(env.balance(gw, USDA.issue()) == USDA(50));
+        }
+
+        // Scenario B: attacker Remits to a plain (DefaultRipple=false)
+        // account (bob) which later becomes an issuer. Compare against
+        // bob self-granting the same trust via TrustSet.
+        {
+            Env env{*this, features};
+            auto const bob = Account("bob");
+            auto const carol = Account("carol");
+            auto const attacker = Account("attacker");
+            auto const USDA = attacker["USD"];
+            auto const USDbob = bob["USD"];
+
+            env.fund(XRP(1000), noripple(bob), carol, attacker);
+            env.close();
+
+            // attacker Remits USD_A(1) to bob with a large LimitAmount.
+            env(remit::remit(attacker, bob),
+                remit::amts({USDA(1)}),
+                remit::limit_amount(0, USDA(1'000'000)),
+                ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(
+                lineLimit(env, bob, attacker, USDA) == USDA(1'000'000));
+            // the line was created while bob had DefaultRipple=false, so
+            // bob's own side is auto-marked NoRipple.
+            BEAST_EXPECT(lineNoRipple(env, bob, attacker, USDA));
+            BEAST_EXPECT(env.balance(bob, USDA.issue()) == USDA(1));
+
+            // bob becomes an issuer.
+            env(fset(bob, asfDefaultRipple));
+            env.close();
+            env(trust(carol, USDbob(1000)));
+            env.close();
+            // this line is created after bob's DefaultRipple is on, so
+            // bob's side is NOT auto-marked NoRipple.
+            BEAST_EXPECT(!lineNoRipple(env, bob, carol, USDbob));
+
+            // Attack: attacker pays carol USD_bob, sourcing from USD_A,
+            // rippling through bob. OBSERVED: succeeds -- checkNoRipple
+            // only blocks when BOTH legs at bob have NoRipple set, and
+            // here only the bob-attacker leg does, so the attacker mints
+            // USD_bob to carol despite the gate having fired on the other
+            // line.
+            env(pay(attacker, carol, USDbob(50)),
+                sendmax(USDA(50)),
+                path(bob),
+                ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(carol, USDbob.issue()) == USDbob(50));
+            // 1 from the initial Remit transfer + 50 from the attack.
+            BEAST_EXPECT(env.balance(bob, USDA.issue()) == USDA(51));
+        }
+
+        // Comparison: identical to Scenario B, but bob grants the trust
+        // himself via TrustSet instead of via Remit+LimitAmount.
+        {
+            Env env{*this, features};
+            auto const bob = Account("bob");
+            auto const carol = Account("carol");
+            auto const attacker = Account("attacker");
+            auto const USDA = attacker["USD"];
+            auto const USDbob = bob["USD"];
+
+            env.fund(XRP(1000), noripple(bob), carol, attacker);
+            env.close();
+
+            env(trust(bob, USDA(1'000'000)));
+            env.close();
+            // OBSERVED: unlike a Remit-created line, a self-initiated
+            // TrustSet does NOT auto-apply the "receiver DefaultRipple"
+            // NoRipple default to the initiator's own side -- that
+            // auto-behavior lives in the payment-credit path
+            // (trustCreate via rippleCreditIOU), not in SetTrust, which
+            // only sets NoRipple when tfSetNoRipple is explicitly passed.
+            // So bob's side here is NOT NoRipple, unlike Scenario B.
+            BEAST_EXPECT(!lineNoRipple(env, bob, attacker, USDA));
+
+            env(fset(bob, asfDefaultRipple));
+            env.close();
+            env(trust(carol, USDbob(1000)));
+            env.close();
+            BEAST_EXPECT(!lineNoRipple(env, bob, carol, USDbob));
+
+            // OBSERVED: succeeds, same as Scenario B -- the attack outcome
+            // (funds minted to carol) is identical either way, though the
+            // NoRipple flag state that produces it differs (see above).
+            env(pay(attacker, carol, USDbob(50)),
+                sendmax(USDA(50)),
+                path(bob),
+                ter(tesSUCCESS));
+            env.close();
+            BEAST_EXPECT(env.balance(carol, USDbob.issue()) == USDbob(50));
+            // no Remit was used here, so no incidental +1.
+            BEAST_EXPECT(env.balance(bob, USDA.issue()) == USDA(50));
+        }
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnabled(features);
@@ -2956,6 +3405,9 @@ public:
         auto const sa = supported_amendments();
         testWithFeats(sa - featureXahauGenesis);
         testWithFeats(sa);
+        testLimitAmount(sa);
+        testLimitAmount(sa - featureRemitLimitAmount);
+        testLimitAmountRippling(sa | featureRemitLimitAmount);
     }
 };
 

--- a/src/test/jtx/impl/remit.cpp
+++ b/src/test/jtx/impl/remit.cpp
@@ -55,6 +55,13 @@ amts::operator()(Env& env, JTx& jt) const
 }
 
 void
+limit_amount::operator()(Env& env, JTx& jt) const
+{
+    jt.jv[sfAmounts.jsonName][index_][sfAmountEntry.jsonName]
+         [sfLimitAmount.jsonName] = limit_.getJson(JsonOptions::none);
+}
+
+void
 blob::operator()(Env& env, JTx& jt) const
 {
     jt.jv[sfBlob.jsonName] = blob_;

--- a/src/test/jtx/remit.h
+++ b/src/test/jtx/remit.h
@@ -51,6 +51,23 @@ public:
     operator()(Env&, JTx& jtx) const;
 };
 
+/** Sets the optional "LimitAmount" on an entry of the JTx's Amounts array. */
+class limit_amount
+{
+private:
+    std::size_t index_;
+    STAmount limit_;
+
+public:
+    limit_amount(std::size_t index, STAmount const& limit)
+        : index_(index), limit_(limit)
+    {
+    }
+
+    void
+    operator()(Env&, JTx& jtx) const;
+};
+
 /** Set the optional "Blob" on a JTx */
 class blob
 {

--- a/src/xrpld/app/tx/detail/Remit.cpp
+++ b/src/xrpld/app/tx/detail/Remit.cpp
@@ -137,6 +137,39 @@ Remit::preflight(PreflightContext const& ctx)
                 return temBAD_CURRENCY;
             }
 
+            if (sEntry.isFieldPresent(sfLimitAmount))
+            {
+                if (!ctx.rules.enabled(featureRemitLimitAmount))
+                    return temDISABLED;
+
+                STAmount const limitAmount =
+                    sEntry.getFieldAmount(sfLimitAmount);
+
+                if (isXRP(amount) || isXRP(limitAmount))
+                {
+                    JLOG(ctx.j.warn()) << "Malformed transaction: "
+                                          "LimitAmount not allowed for XAH.";
+                    return temBAD_CURRENCY;
+                }
+
+                if (!isLegalNet(limitAmount) || limitAmount.signum() <= 0)
+                {
+                    JLOG(ctx.j.warn())
+                        << "Malformed transaction: bad LimitAmount: "
+                        << limitAmount.getFullText();
+                    return temBAD_AMOUNT;
+                }
+
+                if (limitAmount.getCurrency() != amount.getCurrency() ||
+                    limitAmount.getIssuer() != amount.getIssuer())
+                {
+                    JLOG(ctx.j.warn())
+                        << "Malformed transaction: LimitAmount currency/"
+                           "issuer must match Amount.";
+                    return temBAD_CURRENCY;
+                }
+            }
+
             if (isXRP(amount))
             {
                 if (nativeAlready)
@@ -564,8 +597,30 @@ Remit::doApply()
 
             // if the target trustline doesn't exist we need to create it and
             // pay its reserve
-            if (!sb.exists(
-                    keylet::line(dstAccID, issuerAccID, amount.getCurrency())))
+            bool const lineExisted = sb.exists(
+                keylet::line(dstAccID, issuerAccID, amount.getCurrency()));
+
+            // a LimitAmount is only permitted when it will set the limit of
+            // a trustline this Remit is creating: never allow it to
+            // overwrite an existing line's limit, and never allow it on a
+            // DefaultRipple destination, since that would let an attacker
+            // ripple worthless tokens through the issuer and mint its IOU
+            // (see StepChecks.h checkNoRipple: NoRipple only blocks
+            // rippling when both lines on the middle account have it set,
+            // and a DefaultRipple issuer's existing lines lack NoRipple).
+            // Reject the whole Remit rather than silently ignoring the
+            // LimitAmount, so nothing is transferred.
+            if (sEntry.isFieldPresent(sfLimitAmount) &&
+                sb.rules().enabled(featureRemitLimitAmount) &&
+                (lineExisted || (flags & lsfDefaultRipple)))
+            {
+                JLOG(j.warn())
+                    << "Remit: LimitAmount not permitted -- trustline "
+                       "already exists or destination is DefaultRipple.";
+                return tecNO_PERMISSION;
+            }
+
+            if (!lineExisted)
             {
                 if (nativeRemit + objectReserve < nativeRemit)
                     return tecINTERNAL;
@@ -584,6 +639,32 @@ Remit::doApply()
                     true);
                 !isTesSuccess(result))
                 return result;
+
+            // if this entry specifies a LimitAmount, set the destination's
+            // trust line limit. The check above already guarantees the line
+            // did not exist and the destination isn't DefaultRipple, and
+            // preflight already guarantees signum() > 0.
+            if (sb.rules().enabled(featureRemitLimitAmount) &&
+                sEntry.isFieldPresent(sfLimitAmount))
+            {
+                STAmount const limitAmount =
+                    sEntry.getFieldAmount(sfLimitAmount);
+                auto sleLine = sb.peek(
+                    keylet::line(dstAccID, issuerAccID, amount.getCurrency()));
+
+                if (!sleLine)
+                {
+                    JLOG(j.warn()) << "Remit: trustline does not exist.";
+                    return tefINTERNAL;  // LCOV_EXCL_LINE
+                }
+
+                bool const dstHigh = dstAccID > issuerAccID;
+                STAmount limitToSet(limitAmount);
+                limitToSet.setIssuer(dstAccID);
+                sleLine->setFieldAmount(
+                    dstHigh ? sfHighLimit : sfLowLimit, limitToSet);
+                sb.update(sleLine);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

Remit-created trust lines are created with Limit 0, so the destination cannot receive the same token via Payment afterwards (`tecPATH_DRY`) and the line is auto-deleted once its balance returns to zero.

This adds an optional `sfLimitAmount` to `AmountEntry`, gated by the new `RemitLimitAmount` amendment. When present, the destination side limit of the trust line created by this Remit is set to LimitAmount.

Rules:
- `LimitAmount` must be an IOU with the same currency/issuer as `Amount` and strictly positive (`temBAD_CURRENCY` / `temBAD_AMOUNT` otherwise).
- `tecNO_PERMISSION` if the trust line already exists or the destination has `DefaultRipple` set. NoRipple only blocks rippling when both lines on the middle account have it, so raising the limit on a `DefaultRipple` issuer would let an attacker ripple worthless tokens through it.

Tests cover both situations above, the malformed cases, and the rippling attack scenarios (`DefaultRipple` issuer destination, and a destination that later enables `DefaultRipple`).

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->