### PR TITLE
feat: add NoRecipientLimit amendment

### DIFF
--- a/hook/ls_flags.h
+++ b/hook/ls_flags.h
@@ -37,6 +37,8 @@ enum ltRIPPLE_STATE {
     lsfHighFreeze = 0x00800000,
     lsfLowDeepFreeze = 0x02000000,
     lsfHighDeepFreeze = 0x04000000,
+    lsfLowPersist = 0x08000000,
+    lsfHighPersist = 0x10000000,
     lsfAMMNode = 0x01000000,
 };
 enum ltSIGNER_LIST {

--- a/hook/tx_flags.h
+++ b/hook/tx_flags.h
@@ -55,7 +55,9 @@ enum TrustSetFlags : uint32_t {
     tfSetFreeze = 0x00100000,
     tfClearFreeze = 0x00200000,
     tfSetDeepFreeze = 0x00400000,
-    tfClearDeepFreeze = 0x00800000
+    tfClearDeepFreeze = 0x00800000,
+    tfSetPersist = 0x01000000,
+    tfClearPersist = 0x02000000
 };
 
 enum EnableAmendmentFlags : uint32_t {

--- a/include/xrpl/protocol/LedgerFormats.h
+++ b/include/xrpl/protocol/LedgerFormats.h
@@ -155,6 +155,7 @@ enum LedgerSpecificFlags {
     lsfPassive = 0x00010000,
     lsfSell = 0x00020000,  // True, offer was placed as a sell.
 
+    //@@start ripple-state-flags
     // ltRIPPLE_STATE
     lsfLowReserve = 0x00010000,  // True, if entry counts toward reserve.
     lsfHighReserve = 0x00020000,
@@ -166,8 +167,11 @@ enum LedgerSpecificFlags {
     lsfHighFreeze = 0x00800000,     // True, high side has set freeze flag
     lsfLowDeepFreeze = 0x02000000,  // True, low side has set deep freeze flag
     lsfHighDeepFreeze = 0x04000000, // True, high side has set deep freeze flag
+    lsfLowPersist = 0x08000000,     // True, low side keeps the line at zero
+    lsfHighPersist = 0x10000000,    // True, high side keeps the line at zero
     lsfAMMNode = 0x01000000,     // True, trust line to AMM. Used by client
                                  // apps to identify payments via AMM.
+    //@@end ripple-state-flags
 
     // ltSIGNER_LIST
     lsfOneOwnerCount = 0x00010000,  // True, uses only one OwnerCount

--- a/include/xrpl/protocol/LedgerFormats.h
+++ b/include/xrpl/protocol/LedgerFormats.h
@@ -155,7 +155,6 @@ enum LedgerSpecificFlags {
     lsfPassive = 0x00010000,
     lsfSell = 0x00020000,  // True, offer was placed as a sell.
 
-    //@@start ripple-state-flags
     // ltRIPPLE_STATE
     lsfLowReserve = 0x00010000,  // True, if entry counts toward reserve.
     lsfHighReserve = 0x00020000,
@@ -171,7 +170,6 @@ enum LedgerSpecificFlags {
     lsfHighPersist = 0x10000000,    // True, high side keeps the line at zero
     lsfAMMNode = 0x01000000,     // True, trust line to AMM. Used by client
                                  // apps to identify payments via AMM.
-    //@@end ripple-state-flags
 
     // ltSIGNER_LIST
     lsfOneOwnerCount = 0x00010000,  // True, uses only one OwnerCount

--- a/include/xrpl/protocol/TxFlags.h
+++ b/include/xrpl/protocol/TxFlags.h
@@ -125,11 +125,14 @@ enum TrustSetFlags : uint32_t {
     tfSetFreeze = 0x00100000,
     tfClearFreeze = 0x00200000,
     tfSetDeepFreeze = 0x00400000,
-    tfClearDeepFreeze = 0x00800000
+    tfClearDeepFreeze = 0x00800000,
+    tfSetPersist = 0x01000000,
+    tfClearPersist = 0x02000000
 };
 constexpr std::uint32_t tfTrustSetMask =
     ~(tfUniversal | tfSetfAuth | tfSetNoRipple | tfClearNoRipple | tfSetFreeze |
-      tfClearFreeze | tfSetDeepFreeze | tfClearDeepFreeze);
+      tfClearFreeze | tfSetDeepFreeze | tfClearDeepFreeze | tfSetPersist |
+      tfClearPersist);
 
 // EnableAmendment flags:
 enum EnableAmendmentFlags : uint32_t {

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -34,6 +34,7 @@
 // If you add an amendment here, then do not forget to increment `numFeatures`
 // in include/xrpl/protocol/Feature.h.
 
+XRPL_FEATURE(NoRecipientLimit,           Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(OnChainManifests,           Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (HookMap,                    Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FIX    (GuardDepth32,               Supported::yes, VoteBehavior::DefaultNo)

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -529,8 +529,15 @@ class Check_test : public beast::unit_test::suite
             env.close();
             env(check::create(gw1, alice, USD(50)), ter(tecFROZEN));
             env.close();
-            env(pay(gw1, alice, USD(1)), ter(tecPATH_DRY));
+            //@@start check-create-gate
+            // A pure issue cannot be frozen; what refused this payment was
+            // alice's limit of zero, which no longer caps her issuer under
+            // NoRecipientLimit.
+            env(pay(gw1, alice, USD(1)),
+                ter(features[featureNoRecipientLimit] ? TER(tesSUCCESS)
+                                                      : TER(tecPATH_DRY)));
             env.close();
+            //@@end check-create-gate
 
             // Clear that freeze.
             env(trust(alice, USD(0), tfClearFreeze));
@@ -736,14 +743,18 @@ class Check_test : public beast::unit_test::suite
             // bob sets up the trust line, but not at a high enough limit.
             env(trust(bob, USD(9.5)));
             env.close();
-            if (!cashCheckMakesTrustLine)
+            //@@start check-cash-gate
+            if (!cashCheckMakesTrustLine && !features[featureNoRecipientLimit])
             {
                 // If cashing a check is allowed to exceed the trust line
-                // limit then this returns tesSUCCESS and the check is
-                // removed from the ledger which would mess up later tests.
+                // limit (CheckCashMakesTrustLine, or NoRecipientLimit
+                // exempting bob from his limit on his issuer) then this
+                // returns tesSUCCESS and the check is removed from the
+                // ledger which would mess up later tests.
                 env(check::cash(bob, chkId1, USD(10)), ter(tecPATH_PARTIAL));
                 env.close();
             }
+            //@@end check-cash-gate
 
             // bob sets the trust line limit high enough but asks for more
             // than the check's SendMax.
@@ -829,9 +840,24 @@ class Check_test : public beast::unit_test::suite
                 // a payment to bob cannot exceed that trust line, but cashing
                 // a check can.
 
-                // Payment of 20 USD fails.
-                env(pay(gw, bob, USD(20)), ter(tecPATH_PARTIAL));
-                env.close();
+                //@@start check-payment-gate
+                // Payment of 20 USD fails, unless recipients are exempt
+                // from their limit, in which case it succeeds and is undone
+                // so the check below still tells the same story.
+                if (features[featureNoRecipientLimit])
+                {
+                    env(pay(gw, bob, USD(20)));
+                    env.close();
+                    env.require(balance(bob, USD(30)));
+                    env(pay(bob, gw, USD(20)));
+                    env.close();
+                }
+                else
+                {
+                    env(pay(gw, bob, USD(20)), ter(tecPATH_PARTIAL));
+                    env.close();
+                }
+                //@@end check-payment-gate
 
                 uint256 const chkId20{getCheckIndex(gw, env.seq(gw))};
                 env(check::create(gw, bob, USD(20)));
@@ -977,7 +1003,10 @@ class Check_test : public beast::unit_test::suite
 
             // bob tries to cash the check again but fails because his trust
             // limit is too low.
-            if (!cashCheckMakesTrustLine)
+            //@@start check-auth-cash-gate
+            bool const exceedsLimit =
+                cashCheckMakesTrustLine || features[featureNoRecipientLimit];
+            if (!exceedsLimit)
             {
                 // If cashing a check is allowed to exceed the trust line
                 // limit then this returns tesSUCCESS and the check is
@@ -994,7 +1023,8 @@ class Check_test : public beast::unit_test::suite
             //  o If it can build a trust line, then the check is allowed to
             //    exceed the trust limit and bob gets the full transfer.
             env(check::cash(bob, chkId, check::DeliverMin(USD(4))));
-            STAmount const bobGot = cashCheckMakesTrustLine ? USD(7) : USD(5);
+            STAmount const bobGot = exceedsLimit ? USD(7) : USD(5);
+            //@@end check-auth-cash-gate
             verifyDeliveredAmount(env, bobGot);
             env.require(balance(alice, USD(8) - bobGot));
             env.require(balance(bob, bobGot));
@@ -2689,9 +2719,13 @@ class Check_test : public beast::unit_test::suite
         testEnabled(features);
         testCreateValid(features);
         testCreateDisallowIncoming(features);
+        //@@start check-wiring
         testCreateInvalid(features);
+        testCreateInvalid(features - featureNoRecipientLimit);
         testCashXRP(features);
         testCashIOU(features);
+        testCashIOU(features - featureNoRecipientLimit);
+        //@@end check-wiring
         testCashXferFee(features);
         testCashQuality(features);
         testCashInvalid(features);

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -529,7 +529,6 @@ class Check_test : public beast::unit_test::suite
             env.close();
             env(check::create(gw1, alice, USD(50)), ter(tecFROZEN));
             env.close();
-            //@@start check-create-gate
             // A pure issue cannot be frozen; what refused this payment was
             // alice's limit of zero, which no longer caps her issuer under
             // NoRecipientLimit.
@@ -537,7 +536,6 @@ class Check_test : public beast::unit_test::suite
                 ter(features[featureNoRecipientLimit] ? TER(tesSUCCESS)
                                                       : TER(tecPATH_DRY)));
             env.close();
-            //@@end check-create-gate
 
             // Clear that freeze.
             env(trust(alice, USD(0), tfClearFreeze));
@@ -743,7 +741,6 @@ class Check_test : public beast::unit_test::suite
             // bob sets up the trust line, but not at a high enough limit.
             env(trust(bob, USD(9.5)));
             env.close();
-            //@@start check-cash-gate
             if (!cashCheckMakesTrustLine && !features[featureNoRecipientLimit])
             {
                 // If cashing a check is allowed to exceed the trust line
@@ -754,7 +751,6 @@ class Check_test : public beast::unit_test::suite
                 env(check::cash(bob, chkId1, USD(10)), ter(tecPATH_PARTIAL));
                 env.close();
             }
-            //@@end check-cash-gate
 
             // bob sets the trust line limit high enough but asks for more
             // than the check's SendMax.
@@ -840,7 +836,6 @@ class Check_test : public beast::unit_test::suite
                 // a payment to bob cannot exceed that trust line, but cashing
                 // a check can.
 
-                //@@start check-payment-gate
                 // Payment of 20 USD fails, unless recipients are exempt
                 // from their limit, in which case it succeeds and is undone
                 // so the check below still tells the same story.
@@ -857,7 +852,6 @@ class Check_test : public beast::unit_test::suite
                     env(pay(gw, bob, USD(20)), ter(tecPATH_PARTIAL));
                     env.close();
                 }
-                //@@end check-payment-gate
 
                 uint256 const chkId20{getCheckIndex(gw, env.seq(gw))};
                 env(check::create(gw, bob, USD(20)));
@@ -1003,7 +997,6 @@ class Check_test : public beast::unit_test::suite
 
             // bob tries to cash the check again but fails because his trust
             // limit is too low.
-            //@@start check-auth-cash-gate
             bool const exceedsLimit =
                 cashCheckMakesTrustLine || features[featureNoRecipientLimit];
             if (!exceedsLimit)
@@ -1024,7 +1017,6 @@ class Check_test : public beast::unit_test::suite
             //    exceed the trust limit and bob gets the full transfer.
             env(check::cash(bob, chkId, check::DeliverMin(USD(4))));
             STAmount const bobGot = exceedsLimit ? USD(7) : USD(5);
-            //@@end check-auth-cash-gate
             verifyDeliveredAmount(env, bobGot);
             env.require(balance(alice, USD(8) - bobGot));
             env.require(balance(bob, bobGot));
@@ -2719,13 +2711,11 @@ class Check_test : public beast::unit_test::suite
         testEnabled(features);
         testCreateValid(features);
         testCreateDisallowIncoming(features);
-        //@@start check-wiring
         testCreateInvalid(features);
         testCreateInvalid(features - featureNoRecipientLimit);
         testCashXRP(features);
         testCashIOU(features);
         testCashIOU(features - featureNoRecipientLimit);
-        //@@end check-wiring
         testCashXferFee(features);
         testCashQuality(features);
         testCashInvalid(features);

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -960,13 +960,19 @@ struct Flow_test : public beast::unit_test::suite
         env.require(balance(alice, EUR(600)));
         aliceOffers = offersOnAccount(env, alice);
         BEAST_EXPECT(aliceOffers.size() == 1);
+        //@@start self-payment-gate
+        // alice's EUR limit is 606 and she holds 600: the last step, gw2
+        // issuing to alice, is capped at 6 EUR unless recipients are exempt
+        // from their limit, in which case all 60 EUR cross.
+        bool const exempt = features[featureNoRecipientLimit];
         for (auto const& offerPtr : aliceOffers)
         {
             auto const offer = *offerPtr;
             BEAST_EXPECT(offer[sfLedgerEntryType] == ltOFFER);
-            BEAST_EXPECT(offer[sfTakerGets] == EUR(594));
-            BEAST_EXPECT(offer[sfTakerPays] == USD(495));
+            BEAST_EXPECT(offer[sfTakerGets] == (exempt ? EUR(540) : EUR(594)));
+            BEAST_EXPECT(offer[sfTakerPays] == (exempt ? USD(450) : USD(495)));
         }
+        //@@end self-payment-gate
     }
     void
     testSelfFundedXRPEndpoint(bool consumeOffer, FeatureBitset features)
@@ -1401,6 +1407,173 @@ struct Flow_test : public beast::unit_test::suite
     }
 
     void
+    testRecipientLimit(FeatureBitset features)
+    {
+        // A trust line limit governs an account used as an intermediary, not
+        // an account receiving its issuer's token: with
+        // featureNoRecipientLimit the issuer's step into the destination
+        // ignores the destination's limit. Without it, today's behaviour
+        // holds. Funds caps, intermediary caps and a non-issuer rippling into
+        // the destination are unchanged in both regimes.
+        bool const exempt = features[featureNoRecipientLimit];
+        testcase(
+            exempt ? "Recipient limit (exempt)" : "Recipient limit (enforced)");
+
+        using namespace jtx;
+        auto const gw = Account("gw");
+        auto const USD = gw["USD"];
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const carol = Account("carol");
+        auto const dan = Account("dan");
+
+        {
+            // Issuer pays a holder more than the holder's limit.
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, alice);
+            env.trust(USD(100), alice);
+            env(pay(gw, alice, USD(150)),
+                ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_PARTIAL)));
+            env.require(balance(alice, exempt ? USD(150) : USD(0)));
+        }
+        {
+            // A line already at its limit: the dry check in the direct step.
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, alice);
+            env.trust(USD(100), alice);
+            env(pay(gw, alice, USD(100)));
+            env(pay(gw, alice, USD(1)),
+                ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
+            env.require(balance(alice, exempt ? USD(101) : USD(100)));
+        }
+        {
+            // Holder pays holder through the issuer; the recipient's limit is
+            // the last step's limit.
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, alice, bob);
+            env.trust(USD(1000), alice);
+            env.trust(USD(100), bob);
+            env(pay(gw, alice, USD(500)));
+            env(pay(alice, bob, USD(150)),
+                paths(USD),
+                ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_PARTIAL)));
+            env.require(balance(bob, exempt ? USD(150) : USD(0)));
+        }
+        {
+            // Cross-currency: the last direct step follows a book step.
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, alice, bob, carol);
+            env.trust(USD(1000), carol);
+            env.trust(USD(100), bob);
+            env(pay(gw, carol, USD(500)));
+            env(offer(carol, XRP(150), USD(150)));
+            env(pay(alice, bob, USD(150)),
+                sendmax(XRP(150)),
+                ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_PARTIAL)));
+            env.require(balance(bob, exempt ? USD(150) : USD(0)));
+        }
+        {
+            // A partial payment delivers up to the limit today and all of it
+            // when the recipient is exempt.
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, alice, bob);
+            env.trust(USD(1000), alice);
+            env.trust(USD(100), bob);
+            env(pay(gw, alice, USD(500)));
+            env(pay(alice, bob, USD(150)),
+                paths(USD),
+                txflags(tfPartialPayment));
+            env.require(balance(bob, exempt ? USD(150) : USD(100)));
+        }
+        {
+            // Rippling through an intermediary is still capped by the
+            // intermediary's limit in both regimes: bob's limit on alice's
+            // USD is 10, and bob is not the destination.
+            auto const USDA = alice["USD"];
+            auto const USDB = bob["USD"];
+            auto const USDC = carol["USD"];
+            Env env(*this, features);
+            env.fund(XRP(10000), alice, bob, carol, dan);
+            env.trust(USDA(10), bob);
+            env.trust(USDB(1000), carol);
+            env.trust(USDC(1000), dan);
+            env(pay(alice, dan, USDC(15)), paths(USDA), ter(tecPATH_PARTIAL));
+            env.require(balance(dan, USDC(0)));
+            env(pay(alice, dan, USDC(10)), paths(USDA));
+            env.require(
+                balance(bob, USDA(10)),
+                balance(carol, USDB(10)),
+                balance(dan, USDC(10)));
+        }
+        {
+            // A non-issuer crediting the destination is still capped by the
+            // destination's limit on that account in both regimes: the
+            // payment names carol's own USD, so the engine does not route
+            // through an issuer, and the last hop is bob issuing bob's USD to
+            // carol, whose limit on bob is 10.
+            auto const USDA = alice["USD"];
+            auto const USDB = bob["USD"];
+            auto const USDC = carol["USD"];
+            Env env(*this, features);
+            env.fund(XRP(10000), alice, bob, carol);
+            env.trust(USDA(100), bob);
+            env.trust(USDB(10), carol);
+            env(pay(alice, carol, USDC(15)), path(bob), ter(tecPATH_PARTIAL));
+            env.require(balance(carol, USDB(0)));
+            env(pay(alice, carol, USDC(10)), path(bob));
+            env.require(balance(bob, USDA(10)), balance(carol, USDB(10)));
+        }
+        {
+            // The destination can be an intermediary earlier in the same
+            // strand, in another currency: gw pays bob EUR through bob's own
+            // USD line and mike's EUR/bobUSD offer. The USD hop into bob is
+            // not the issuer delivering the named token, so bob's USD limit
+            // (10) still caps it in both regimes.
+            auto const EUR = gw["EUR"];
+            auto const mike = Account("mike");
+            auto const USDB = bob["USD"];
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, bob, mike);
+            env(fset(bob, asfDefaultRipple));
+            env.close();
+            env.trust(USD(10), bob);
+            env.trust(EUR(100), bob);
+            env.trust(USDB(100), mike);
+            env.trust(EUR(100), mike);
+            env(pay(gw, mike, EUR(50)));
+            env(offer(mike, USDB(15), EUR(15)));
+            env.close();
+            env(pay(gw, bob, EUR(15)),
+                sendmax(USD(15)),
+                path(bob, ~EUR),
+                txflags(tfNoRippleDirect),
+                ter(tecPATH_PARTIAL));
+            env.require(balance(bob, USD(0)), balance(bob, EUR(0)));
+            env(pay(gw, bob, EUR(10)),
+                sendmax(USD(10)),
+                path(bob, ~EUR),
+                txflags(tfNoRippleDirect));
+            env.require(
+                balance(bob, USD(10)),
+                balance(bob, EUR(10)),
+                balance(mike, USDB(10)));
+        }
+        {
+            // Redeeming to the issuer is capped by the sender's balance, not
+            // by any limit, in both regimes. Once the balance is spent the
+            // strand would have the sender issue its own USD to the issuer;
+            // the sender is not the issuer named by the payment, so the
+            // issuer's zero limit still refuses that.
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, alice);
+            env.trust(USD(1000), alice);
+            env(pay(gw, alice, USD(50)));
+            env(pay(alice, gw, USD(60)), ter(tecPATH_PARTIAL));
+            env.require(balance(alice, USD(50)));
+        }
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         using namespace jtx;
@@ -1416,13 +1589,20 @@ struct Flow_test : public beast::unit_test::suite
         testBookStep(features | ownerPaysFee);
         testTransferRate(features | ownerPaysFee);
         testSelfPayment1(features);
+        //@@start self-payment-wiring
         testSelfPayment2(features);
+        testSelfPayment2(features - featureNoRecipientLimit);
+        //@@end self-payment-wiring
         testSelfFundedXRPEndpoint(false, features);
         testSelfFundedXRPEndpoint(true, features);
         testUnfundedOffer(features);
         testReexecuteDirectStep(features);
         testSelfPayLowQualityOffer(features);
         testTicketPay(features);
+        //@@start recipient-limit-wiring
+        testRecipientLimit(features);
+        testRecipientLimit(features - featureNoRecipientLimit);
+        //@@end recipient-limit-wiring
     }
 
     void

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -960,7 +960,6 @@ struct Flow_test : public beast::unit_test::suite
         env.require(balance(alice, EUR(600)));
         aliceOffers = offersOnAccount(env, alice);
         BEAST_EXPECT(aliceOffers.size() == 1);
-        //@@start self-payment-gate
         // alice's EUR limit is 606 and she holds 600: the last step, gw2
         // issuing to alice, is capped at 6 EUR unless recipients are exempt
         // from their limit, in which case all 60 EUR cross.
@@ -972,7 +971,6 @@ struct Flow_test : public beast::unit_test::suite
             BEAST_EXPECT(offer[sfTakerGets] == (exempt ? EUR(540) : EUR(594)));
             BEAST_EXPECT(offer[sfTakerPays] == (exempt ? USD(450) : USD(495)));
         }
-        //@@end self-payment-gate
     }
     void
     testSelfFundedXRPEndpoint(bool consumeOffer, FeatureBitset features)
@@ -1589,20 +1587,16 @@ struct Flow_test : public beast::unit_test::suite
         testBookStep(features | ownerPaysFee);
         testTransferRate(features | ownerPaysFee);
         testSelfPayment1(features);
-        //@@start self-payment-wiring
         testSelfPayment2(features);
         testSelfPayment2(features - featureNoRecipientLimit);
-        //@@end self-payment-wiring
         testSelfFundedXRPEndpoint(false, features);
         testSelfFundedXRPEndpoint(true, features);
         testUnfundedOffer(features);
         testReexecuteDirectStep(features);
         testSelfPayLowQualityOffer(features);
         testTicketPay(features);
-        //@@start recipient-limit-wiring
         testRecipientLimit(features);
         testRecipientLimit(features - featureNoRecipientLimit);
-        //@@end recipient-limit-wiring
     }
 
     void

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -81,16 +81,26 @@ class Path_test : public beast::unit_test::suite
     jtx::Env
     pathTestEnv()
     {
+        using namespace jtx;
+        return pathTestEnv(supported_amendments());
+    }
+
+    jtx::Env
+    pathTestEnv(FeatureBitset features)
+    {
         // These tests were originally written with search parameters that are
         // different from the current defaults. This function creates an env
         // with the search parameters that the tests were written for.
         using namespace jtx;
-        return Env(*this, envconfig([](std::unique_ptr<Config> cfg) {
-            cfg->PATH_SEARCH_OLD = 7;
-            cfg->PATH_SEARCH = 7;
-            cfg->PATH_SEARCH_MAX = 10;
-            return cfg;
-        }));
+        return Env(
+            *this,
+            envconfig([](std::unique_ptr<Config> cfg) {
+                cfg->PATH_SEARCH_OLD = 7;
+                cfg->PATH_SEARCH = 7;
+                cfg->PATH_SEARCH_MAX = 10;
+                return cfg;
+            }),
+            features);
     }
 
 public:
@@ -734,11 +744,11 @@ public:
     }
 
     void
-    issues_path_negative_issue()
+    issues_path_negative_issue(FeatureBitset features)
     {
         testcase("path negative: Issue #5");
         using namespace jtx;
-        Env env = pathTestEnv();
+        Env env = pathTestEnv(features);
         env.fund(XRP(10000), "alice", "bob", "carol", "dan");
         env.trust(Account("bob")["USD"](100), "alice", "carol", "dan");
         env.trust(Account("alice")["USD"](100), "dan");
@@ -751,14 +761,21 @@ public:
             find_paths(env, "alice", "bob", Account("bob")["USD"](25));
         BEAST_EXPECT(std::get<0>(result).empty());
 
-        env(pay("alice", "bob", Account("alice")["USD"](25)), ter(tecPATH_DRY));
+        //@@start path-issue5-gate
+        // alice issuing her own USD to bob, who has no limit on her, is
+        // refused; with featureNoRecipientLimit bob's limit does not cap
+        // his issuer and the payment succeeds.
+        bool const exempt = env.enabled(featureNoRecipientLimit);
+        env(pay("alice", "bob", Account("alice")["USD"](25)),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
 
         result = find_paths(env, "alice", "bob", Account("alice")["USD"](25));
         BEAST_EXPECT(std::get<0>(result).empty());
 
-        env.require(balance("alice", Account("bob")["USD"](0)));
+        env.require(balance("alice", Account("bob")["USD"](exempt ? -25 : 0)));
         env.require(balance("alice", Account("dan")["USD"](0)));
-        env.require(balance("bob", Account("alice")["USD"](0)));
+        env.require(balance("bob", Account("alice")["USD"](exempt ? 25 : 0)));
+        //@@end path-issue5-gate
         env.require(balance("bob", Account("carol")["USD"](-75)));
         env.require(balance("bob", Account("dan")["USD"](0)));
         env.require(balance("carol", Account("bob")["USD"](75)));
@@ -1518,7 +1535,11 @@ public:
         alternative_paths_consume_best_transfer();
         alternative_paths_consume_best_transfer_first();
         alternative_paths_limit_returned_paths_to_best_quality();
-        issues_path_negative_issue();
+        //@@start path-wiring
+        issues_path_negative_issue(jtx::supported_amendments());
+        issues_path_negative_issue(
+            jtx::supported_amendments() - featureNoRecipientLimit);
+        //@@end path-wiring
         issues_path_negative_ripple_client_issue_23_smaller();
         issues_path_negative_ripple_client_issue_23_larger();
         via_offers_via_gateway();

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -761,7 +761,6 @@ public:
             find_paths(env, "alice", "bob", Account("bob")["USD"](25));
         BEAST_EXPECT(std::get<0>(result).empty());
 
-        //@@start path-issue5-gate
         // alice issuing her own USD to bob, who has no limit on her, is
         // refused; with featureNoRecipientLimit bob's limit does not cap
         // his issuer and the payment succeeds.
@@ -775,7 +774,6 @@ public:
         env.require(balance("alice", Account("bob")["USD"](exempt ? -25 : 0)));
         env.require(balance("alice", Account("dan")["USD"](0)));
         env.require(balance("bob", Account("alice")["USD"](exempt ? 25 : 0)));
-        //@@end path-issue5-gate
         env.require(balance("bob", Account("carol")["USD"](-75)));
         env.require(balance("bob", Account("dan")["USD"](0)));
         env.require(balance("carol", Account("bob")["USD"](75)));
@@ -1535,11 +1533,9 @@ public:
         alternative_paths_consume_best_transfer();
         alternative_paths_consume_best_transfer_first();
         alternative_paths_limit_returned_paths_to_best_quality();
-        //@@start path-wiring
         issues_path_negative_issue(jtx::supported_amendments());
         issues_path_negative_issue(
             jtx::supported_amendments() - featureNoRecipientLimit);
-        //@@end path-wiring
         issues_path_negative_ripple_client_issue_23_smaller();
         issues_path_negative_ripple_client_issue_23_larger();
         via_offers_via_gateway();

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -4959,10 +4959,15 @@ struct PayChan_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 postLocked ==
                 (t.negative ? (preLocked + delta) : (preLocked - delta)));
-            // src claim fails because trust limit is 0
+            //@@start paychan-ripple-state-gate
+            // src claim fails because trust limit is 0, unless a limit no
+            // longer governs the receiver
             auto const testResult =
-                t.hasTrustline ? ter(tesSUCCESS) : ter(tecPATH_DRY);
+                (t.hasTrustline || features[featureNoRecipientLimit])
+                ? ter(tesSUCCESS)
+                : ter(tecPATH_DRY);
             env(paychan::claim(t.src, chan, authAmt, authAmt), testResult);
+            //@@end paychan-ripple-state-gate
         }
     }
 
@@ -5288,11 +5293,27 @@ struct PayChan_test : public beast::unit_test::suite
             assert(reqBal <= chanAmt);
             auto const preLocked = -lockedAmount(env, alice, gw, USD);
             BEAST_EXPECT(preLocked == USD(1000));
-            // alice cannot claim because bobs amount would be > than limit
-            env(paychan::claim(alice, chan, reqBal, authAmt), ter(tecPATH_DRY));
+            //@@start paychan-limit-gate
+            auto const preBobLimit = limitAmount(env, bob, gw, USD);
+            if (features[featureNoRecipientLimit])
+            {
+                // bob's limit does not govern bob receiving, whoever
+                // finishes the claim
+                env(paychan::claim(alice, chan, reqBal, authAmt));
+                env.close();
+                BEAST_EXPECT(env.balance(bob, USD) == USD(1000) + delta);
+                reqBal = reqBal + delta;
+            }
+            else
+            {
+                // alice cannot claim because bobs amount would be > than
+                // limit
+                env(paychan::claim(alice, chan, reqBal, authAmt),
+                    ter(tecPATH_DRY));
+            }
+            //@@end paychan-limit-gate
 
             // bob can claim, increasing the limit amount
-            auto const preBobLimit = limitAmount(env, bob, gw, USD);
             auto const sig =
                 signClaimIOUAuth(alice.pk(), alice.sk(), chan, authAmt);
             env(paychan::claim(
@@ -5926,10 +5947,14 @@ struct PayChan_test : public beast::unit_test::suite
         testIOUAccountDelete(features);
         testIOUUsingTickets(features);
         testIOUAutoTL(features);
+        //@@start paychan-wiring
         testIOURippleState(features);
+        testIOURippleState(features - featureNoRecipientLimit);
         testIOUGateway(features);
         testIOULockedRate(features);
         testIOUTLLimitAmount(features);
+        testIOUTLLimitAmount(features - featureNoRecipientLimit);
+        //@@end paychan-wiring
         testIOUTLRequireAuth(features);
         testIOUTLFreeze(features);
         testIOUTLINSF(features);

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -4959,7 +4959,6 @@ struct PayChan_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 postLocked ==
                 (t.negative ? (preLocked + delta) : (preLocked - delta)));
-            //@@start paychan-ripple-state-gate
             // src claim fails because trust limit is 0, unless a limit no
             // longer governs the receiver
             auto const testResult =
@@ -4967,7 +4966,6 @@ struct PayChan_test : public beast::unit_test::suite
                 ? ter(tesSUCCESS)
                 : ter(tecPATH_DRY);
             env(paychan::claim(t.src, chan, authAmt, authAmt), testResult);
-            //@@end paychan-ripple-state-gate
         }
     }
 
@@ -5293,7 +5291,6 @@ struct PayChan_test : public beast::unit_test::suite
             assert(reqBal <= chanAmt);
             auto const preLocked = -lockedAmount(env, alice, gw, USD);
             BEAST_EXPECT(preLocked == USD(1000));
-            //@@start paychan-limit-gate
             auto const preBobLimit = limitAmount(env, bob, gw, USD);
             if (features[featureNoRecipientLimit])
             {
@@ -5311,7 +5308,6 @@ struct PayChan_test : public beast::unit_test::suite
                 env(paychan::claim(alice, chan, reqBal, authAmt),
                     ter(tecPATH_DRY));
             }
-            //@@end paychan-limit-gate
 
             // bob can claim, increasing the limit amount
             auto const sig =
@@ -5947,14 +5943,12 @@ struct PayChan_test : public beast::unit_test::suite
         testIOUAccountDelete(features);
         testIOUUsingTickets(features);
         testIOUAutoTL(features);
-        //@@start paychan-wiring
         testIOURippleState(features);
         testIOURippleState(features - featureNoRecipientLimit);
         testIOUGateway(features);
         testIOULockedRate(features);
         testIOUTLLimitAmount(features);
         testIOUTLLimitAmount(features - featureNoRecipientLimit);
-        //@@end paychan-wiring
         testIOUTLRequireAuth(features);
         testIOUTLFreeze(features);
         testIOUTLINSF(features);

--- a/src/test/app/Remit_test.cpp
+++ b/src/test/app/Remit_test.cpp
@@ -3018,10 +3018,8 @@ struct Remit_test : public beast::unit_test::suite
         testURIToken(features);
         testOptionals(features);
         testDestAMM(features);
-        //@@start persist-wiring
         testPersistLine(features);
         testPersistLine(features - featureNoRecipientLimit);
-        //@@end persist-wiring
     }
 
 public:

--- a/src/test/app/Remit_test.cpp
+++ b/src/test/app/Remit_test.cpp
@@ -2925,6 +2925,78 @@ struct Remit_test : public beast::unit_test::suite
     }
 
     void
+    testPersistLine(FeatureBitset features)
+    {
+        using namespace jtx;
+        bool const persisted = features[featureNoRecipientLimit];
+        testcase(
+            std::string("remit-created line ") +
+            (persisted ? "persists" : "is deleted") + " at zero balance");
+
+        Env env{*this, features};
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const gw = Account("gw");
+        auto const USD = gw["USD"];
+
+        env.fund(XRP(1000), alice, bob, gw);
+        env.close();
+        env.trust(USD(100000), alice);
+        env.close();
+        env(pay(gw, alice, USD(10000)));
+        env.close();
+
+        auto const lineKey = keylet::line(bob, gw, USD.currency);
+        auto const persistFlag =
+            bob.id() > gw.id() ? lsfHighPersist : lsfLowPersist;
+        auto const persists = [&]() {
+            auto const sle = env.le(lineKey);
+            return sle && ((*sle)[sfFlags] & persistFlag);
+        };
+
+        // The remit creates bob's line and, under the amendment, marks
+        // bob's side as persisting.
+        env(remit::remit(alice, bob), remit::amts({USD(1)}));
+        env.close();
+        BEAST_EXPECT(env.le(lineKey));
+        BEAST_EXPECT(persists() == persisted);
+        BEAST_EXPECT(env.ownerCount(bob) == 1);
+
+        // A second remit onto the existing line changes nothing about it.
+        env(remit::remit(alice, bob), remit::amts({USD(1)}));
+        env.close();
+        BEAST_EXPECT(persists() == persisted);
+        BEAST_EXPECT(env.ownerCount(bob) == 1);
+        BEAST_EXPECT(env.balance(bob, USD.issue()) == USD(2));
+
+        // bob spends the whole balance back to the issuer. Without the flag
+        // the default line is deleted with it.
+        env(pay(bob, gw, USD(2)));
+        env.close();
+        BEAST_EXPECT(bool(env.le(lineKey)) == persisted);
+        BEAST_EXPECT(env.ownerCount(bob) == (persisted ? 1 : 0));
+
+        if (!persisted)
+            return;
+
+        // bob can still receive on the kept line, and can clear the flag
+        // to let it go once it is empty.
+        env(remit::remit(alice, bob), remit::amts({USD(3)}));
+        env.close();
+        BEAST_EXPECT(env.balance(bob, USD.issue()) == USD(3));
+        BEAST_EXPECT(env.ownerCount(bob) == 1);
+
+        env(trust(bob, USD(0), tfClearPersist));
+        env.close();
+        BEAST_EXPECT(env.le(lineKey) && !persists());
+
+        env(pay(bob, gw, USD(3)));
+        env.close();
+        BEAST_EXPECT(!env.le(lineKey));
+        BEAST_EXPECT(env.ownerCount(bob) == 0);
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnabled(features);
@@ -2946,6 +3018,10 @@ struct Remit_test : public beast::unit_test::suite
         testURIToken(features);
         testOptionals(features);
         testDestAMM(features);
+        //@@start persist-wiring
+        testPersistLine(features);
+        testPersistLine(features - featureNoRecipientLimit);
+        //@@end persist-wiring
     }
 
 public:

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -747,7 +747,6 @@ public:
         testDisallowIncoming(features);
         testTrustLineResetWithAuthFlag();
         testTrustLineDelete();
-        //@@start settrust-wiring
         testExceedTrustLineLimit(features);
         testExceedTrustLineLimit(features - featureNoRecipientLimit);
         testAuthFlagTrustLines();
@@ -755,7 +754,6 @@ public:
         testTrustLineLimitsWithRippling(features - featureNoRecipientLimit);
         testPersist(features);
         testPersist(features - featureNoRecipientLimit);
-        //@@end settrust-wiring
     }
 
 public:

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -342,14 +342,17 @@ public:
     }
 
     void
-    testExceedTrustLineLimit()
+    testExceedTrustLineLimit(FeatureBitset features)
     {
         testcase(
             "Ensure that trust line limits are respected in payment "
             "transactions");
 
         using namespace jtx;
-        Env env{*this};
+        Env env{*this, features};
+        // With featureNoRecipientLimit the issuer's payment into the
+        // holder is not capped by the holder's limit.
+        bool const exempt = features[featureNoRecipientLimit];
 
         auto const gw = Account{"gateway"};
         auto const alice = Account{"alice"};
@@ -360,8 +363,10 @@ public:
         env.close();
 
         // send a payment for a large quantity through the trust line
-        env(pay(gw, alice, gw["USD"](200)), ter(tecPATH_PARTIAL));
+        env(pay(gw, alice, gw["USD"](200)),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_PARTIAL)));
         env.close();
+        env.require(balance(alice, gw["USD"](exempt ? 200 : 0)));
 
         // on the other hand, smaller payments should succeed
         env(pay(gw, alice, gw["USD"](20)));
@@ -398,14 +403,17 @@ public:
     }
 
     void
-    testTrustLineLimitsWithRippling()
+    testTrustLineLimitsWithRippling(FeatureBitset features)
     {
         testcase(
             "Check that trust line limits are respected in conjunction "
             "with rippling feature");
 
         using namespace jtx;
-        Env env{*this};
+        Env env{*this, features};
+        // With featureNoRecipientLimit bob, issuing his own USD to alice,
+        // is not capped by alice's (zero) limit on him.
+        bool const exempt = features[featureNoRecipientLimit];
 
         auto const bob = Account{"bob"};
         auto const alice = Account{"alice"};
@@ -426,9 +434,12 @@ public:
         env.close();
 
         // bob cannot place alice in his debt i.e. alice's balance of the USD
-        // tokens cannot go below zero.
-        env(pay(bob, alice, bob["USD"](11)), ter(tecPATH_PARTIAL));
+        // tokens cannot go below zero, unless recipients are exempt from
+        // their limit: then bob issues 1 USD of his own to alice.
+        env(pay(bob, alice, bob["USD"](11)),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_PARTIAL)));
         env.close();
+        env.require(balance(bob, alice["USD"](exempt ? -1 : 10)));
 
         // payments that respect the trust line limits of alice should succeed
         env(pay(bob, alice, bob["USD"](10)), ter(tesSUCCESS));
@@ -619,6 +630,106 @@ public:
     }
 
     void
+    testPersist(FeatureBitset features)
+    {
+        using namespace jtx;
+        bool const enabled = features[featureNoRecipientLimit];
+        testcase(
+            std::string("Persist flag ") + (enabled ? "enabled" : "disabled"));
+
+        Env env{*this, features};
+        auto const gw = Account{"gateway"};
+        auto const alice = Account{"alice"};
+        auto const USD = gw["USD"];
+        env.fund(XRP(10000), gw, alice);
+        env.close();
+
+        if (!enabled)
+        {
+            env(trust(alice, USD(100), tfSetPersist), ter(temINVALID_FLAG));
+            env(trust(alice, USD(100), tfClearPersist), ter(temINVALID_FLAG));
+            return;
+        }
+
+        auto const lineKey = keylet::line(alice, gw, USD.currency);
+        auto const persistFlag =
+            alice.id() > gw.id() ? lsfHighPersist : lsfLowPersist;
+        auto const persists = [&]() {
+            auto const sle = env.le(lineKey);
+            return sle && ((*sle)[sfFlags] & persistFlag);
+        };
+
+        // Set and clear together is malformed.
+        env(trust(alice, USD(100), tfSetPersist | tfClearPersist),
+            ter(temINVALID_FLAG));
+
+        // Set on a fresh line: the line is created with the flag.
+        env(trust(alice, USD(100), tfSetPersist));
+        env.close();
+        BEAST_EXPECT(persists());
+        BEAST_EXPECT(env.ownerCount(alice) == 1);
+
+        // Dropping the limit to zero leaves a persisting line in place and
+        // alice keeps paying its reserve.
+        env(trust(alice, USD(0)));
+        env.close();
+        BEAST_EXPECT(persists());
+        BEAST_EXPECT(env.ownerCount(alice) == 1);
+
+        // Clearing the flag on an otherwise default line deletes it.
+        env(trust(alice, USD(0), tfClearPersist));
+        env.close();
+        BEAST_EXPECT(!env.le(lineKey));
+        BEAST_EXPECT(env.ownerCount(alice) == 0);
+
+        // Set alone, with a default limit, is not redundant: it creates the
+        // line so a zero-limit holder can keep it.
+        env(trust(alice, USD(0), tfSetPersist));
+        env.close();
+        BEAST_EXPECT(persists());
+        BEAST_EXPECT(env.ownerCount(alice) == 1);
+
+        // A balance that comes and goes does not delete a persisting line.
+        env(pay(gw, alice, USD(10)));
+        env(pay(alice, gw, USD(10)));
+        env.close();
+        BEAST_EXPECT(persists());
+        BEAST_EXPECT(env.balance(alice, USD.issue()) == USD(0));
+
+        // Clearing with no balance and no limit deletes the line.
+        env(trust(alice, USD(0), tfClearPersist));
+        env.close();
+        BEAST_EXPECT(!env.le(lineKey));
+        BEAST_EXPECT(env.ownerCount(alice) == 0);
+
+        // Clearing a line that never persisted is a no-op on the flag but
+        // still a valid, non-redundant request when a limit is set.
+        env(trust(alice, USD(50), tfClearPersist));
+        env.close();
+        BEAST_EXPECT(env.le(lineKey) && !persists());
+
+        // Each side owns its own bit. With both set, clearing one leaves
+        // the other side's claim, and its reserve, in place.
+        auto const gwPersistFlag =
+            persistFlag == lsfHighPersist ? lsfLowPersist : lsfHighPersist;
+        env(trust(alice, USD(0), tfSetPersist));
+        env(trust(gw, alice["USD"](0), tfSetPersist));
+        env.close();
+        BEAST_EXPECT(persists());
+        BEAST_EXPECT(env.ownerCount(gw) == 1);
+        env(trust(alice, USD(0), tfClearPersist));
+        env.close();
+        BEAST_EXPECT(env.le(lineKey) && !persists());
+        BEAST_EXPECT((*env.le(lineKey))[sfFlags] & gwPersistFlag);
+        BEAST_EXPECT(env.ownerCount(alice) == 0);
+        BEAST_EXPECT(env.ownerCount(gw) == 1);
+        env(trust(gw, alice["USD"](0), tfClearPersist));
+        env.close();
+        BEAST_EXPECT(!env.le(lineKey));
+        BEAST_EXPECT(env.ownerCount(gw) == 0);
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testFreeTrustlines(features, true, false);
@@ -636,9 +747,15 @@ public:
         testDisallowIncoming(features);
         testTrustLineResetWithAuthFlag();
         testTrustLineDelete();
-        testExceedTrustLineLimit();
+        //@@start settrust-wiring
+        testExceedTrustLineLimit(features);
+        testExceedTrustLineLimit(features - featureNoRecipientLimit);
         testAuthFlagTrustLines();
-        testTrustLineLimitsWithRippling();
+        testTrustLineLimitsWithRippling(features);
+        testTrustLineLimitsWithRippling(features - featureNoRecipientLimit);
+        testPersist(features);
+        testPersist(features - featureNoRecipientLimit);
+        //@@end settrust-wiring
     }
 
 public:

--- a/src/test/app/TrustAndBalance_test.cpp
+++ b/src/test/app/TrustAndBalance_test.cpp
@@ -176,9 +176,14 @@ class TrustAndBalance_test : public beast::unit_test::suite
         env(pay(bob, alice, bob["USD"](1300)));
         env.require(balance(bob, alice["USD"](-600)));
 
-        // bob sends past limit
-        env(pay(bob, alice, bob["USD"](1)), ter(tecPATH_DRY));
-        env.require(balance(bob, alice["USD"](-600)));
+        //@@start direct-ripple-gate
+        // bob sends past limit; with featureNoRecipientLimit bob is the
+        // issuer of what alice receives and her limit does not cap him
+        bool const exempt = features[featureNoRecipientLimit];
+        env(pay(bob, alice, bob["USD"](1)),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
+        env.require(balance(bob, alice["USD"](exempt ? -601 : -600)));
+        //@@end direct-ripple-gate
     }
 
     void
@@ -466,7 +471,10 @@ public:
 
         auto testWithFeatures = [this](FeatureBitset features) {
             testPayNonexistent(features);
+            //@@start direct-ripple-wiring
             testDirectRipple(features);
+            testDirectRipple(features - featureNoRecipientLimit);
+            //@@end direct-ripple-wiring
             testWithTransferFee(false, false, features);
             testWithTransferFee(false, true, features);
             testWithTransferFee(true, false, features);

--- a/src/test/app/TrustAndBalance_test.cpp
+++ b/src/test/app/TrustAndBalance_test.cpp
@@ -176,14 +176,12 @@ class TrustAndBalance_test : public beast::unit_test::suite
         env(pay(bob, alice, bob["USD"](1300)));
         env.require(balance(bob, alice["USD"](-600)));
 
-        //@@start direct-ripple-gate
         // bob sends past limit; with featureNoRecipientLimit bob is the
         // issuer of what alice receives and her limit does not cap him
         bool const exempt = features[featureNoRecipientLimit];
         env(pay(bob, alice, bob["USD"](1)),
             ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
         env.require(balance(bob, alice["USD"](exempt ? -601 : -600)));
-        //@@end direct-ripple-gate
     }
 
     void
@@ -471,10 +469,8 @@ public:
 
         auto testWithFeatures = [this](FeatureBitset features) {
             testPayNonexistent(features);
-            //@@start direct-ripple-wiring
             testDirectRipple(features);
             testDirectRipple(features - featureNoRecipientLimit);
-            //@@end direct-ripple-wiring
             testWithTransferFee(false, false, features);
             testWithTransferFee(false, true, features);
             testWithTransferFee(true, false, features);

--- a/src/test/app/URIToken_test.cpp
+++ b/src/test/app/URIToken_test.cpp
@@ -2294,7 +2294,13 @@ struct URIToken_test : public beast::unit_test::suite
             env.close();
             auto const postLimit = limitAmount(env, bob, gw, USD);
             BEAST_EXPECT(postLimit == preLimit);
-            env(pay(alice, carol, USD(1)), ter(tecPATH_DRY));
+            //@@start uritoken-limit-gate
+            // carol already holds her 1000 limit; the issuer's step into
+            // her is dry unless recipients are exempt from their limit.
+            env(pay(alice, carol, USD(1)),
+                ter(features[featureNoRecipientLimit] ? TER(tesSUCCESS)
+                                                      : TER(tecPATH_DRY)));
+            //@@end uritoken-limit-gate
         }
     }
 
@@ -2648,7 +2654,10 @@ struct URIToken_test : public beast::unit_test::suite
         testFreeze(features);
         testTransferRate(features);
         testDisallowXRP(features);
+        //@@start uritoken-wiring
         testLimitAmount(features);
+        testLimitAmount(features - featureNoRecipientLimit);
+        //@@end uritoken-wiring
         testURIUTF8(features);
     }
 

--- a/src/test/app/URIToken_test.cpp
+++ b/src/test/app/URIToken_test.cpp
@@ -2294,13 +2294,11 @@ struct URIToken_test : public beast::unit_test::suite
             env.close();
             auto const postLimit = limitAmount(env, bob, gw, USD);
             BEAST_EXPECT(postLimit == preLimit);
-            //@@start uritoken-limit-gate
             // carol already holds her 1000 limit; the issuer's step into
             // her is dry unless recipients are exempt from their limit.
             env(pay(alice, carol, USD(1)),
                 ter(features[featureNoRecipientLimit] ? TER(tesSUCCESS)
                                                       : TER(tecPATH_DRY)));
-            //@@end uritoken-limit-gate
         }
     }
 
@@ -2654,10 +2652,8 @@ struct URIToken_test : public beast::unit_test::suite
         testFreeze(features);
         testTransferRate(features);
         testDisallowXRP(features);
-        //@@start uritoken-wiring
         testLimitAmount(features);
         testLimitAmount(features - featureNoRecipientLimit);
-        //@@end uritoken-wiring
         testURIUTF8(features);
     }
 

--- a/src/test/rpc/DeliveredAmount_test.cpp
+++ b/src/test/rpc/DeliveredAmount_test.cpp
@@ -206,7 +206,6 @@ class DeliveredAmount_test : public beast::unit_test::suite
             env(pay(gw, alice, XRP(50)));
             checkDeliveredAmount.adjCountersSuccess();
 
-            //@@start delivered-rpc-gate
             // Without recipient limits, the partial-payment flag does
             // not prevent the issuer from delivering the full amount.
             bool const exempt = features[featureNoRecipientLimit];
@@ -222,7 +221,6 @@ class DeliveredAmount_test : public beast::unit_test::suite
             else
                 checkDeliveredAmount.adjCountersFail();
             env.require(balance(carol, USD(exempt ? 9999999 : 0)));
-            //@@end delivered-rpc-gate
         }
 
         auto wsc = makeWSClient(env.app().config());
@@ -293,7 +291,6 @@ class DeliveredAmount_test : public beast::unit_test::suite
         env(pay(gw, alice, XRP(50)));
         checkDeliveredAmount.adjCountersSuccess();
 
-        //@@start delivered-subscribe-gate
         // Without recipient limits, the partial-payment flag does
         // not prevent the issuer from delivering the full amount.
         bool const exempt = features[featureNoRecipientLimit];
@@ -309,7 +306,6 @@ class DeliveredAmount_test : public beast::unit_test::suite
         else
             checkDeliveredAmount.adjCountersFail();
         env.require(balance(carol, USD(exempt ? 9999999 : 0)));
-        //@@end delivered-subscribe-gate
 
         env.close();
         std::string index;
@@ -334,10 +330,8 @@ public:
         FeatureBitset const all{supported_amendments() - featureXahauGenesis};
         testTxDeliveredAmountRPC(all);
         testAccountDeliveredAmountSubscribe(all);
-        //@@start delivered-wiring
         testTxDeliveredAmountRPC(all - featureNoRecipientLimit);
         testAccountDeliveredAmountSubscribe(all - featureNoRecipientLimit);
-        //@@end delivered-wiring
     }
 };
 

--- a/src/test/rpc/DeliveredAmount_test.cpp
+++ b/src/test/rpc/DeliveredAmount_test.cpp
@@ -206,15 +206,23 @@ class DeliveredAmount_test : public beast::unit_test::suite
             env(pay(gw, alice, XRP(50)));
             checkDeliveredAmount.adjCountersSuccess();
 
-            // partial payment
+            //@@start delivered-rpc-gate
+            // Without recipient limits, the partial-payment flag does
+            // not prevent the issuer from delivering the full amount.
+            bool const exempt = features[featureNoRecipientLimit];
             env(pay(gw, bob, USD(9999999)), txflags(tfPartialPayment));
             checkDeliveredAmount.adjCountersPartialPayment();
-            env.require(balance(bob, USD(1000)));
+            env.require(balance(bob, USD(exempt ? 9999999 : 1000)));
 
-            // failed payment
-            env(pay(bob, carol, USD(9999999)), ter(tecPATH_PARTIAL));
-            checkDeliveredAmount.adjCountersFail();
-            env.require(balance(carol, USD(0)));
+            // bob is now fully funded only with the amendment enabled.
+            env(pay(bob, carol, USD(9999999)),
+                ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_PARTIAL)));
+            if (exempt)
+                checkDeliveredAmount.adjCountersSuccess();
+            else
+                checkDeliveredAmount.adjCountersFail();
+            env.require(balance(carol, USD(exempt ? 9999999 : 0)));
+            //@@end delivered-rpc-gate
         }
 
         auto wsc = makeWSClient(env.app().config());
@@ -285,15 +293,23 @@ class DeliveredAmount_test : public beast::unit_test::suite
         env(pay(gw, alice, XRP(50)));
         checkDeliveredAmount.adjCountersSuccess();
 
-        // partial payment
+        //@@start delivered-subscribe-gate
+        // Without recipient limits, the partial-payment flag does
+        // not prevent the issuer from delivering the full amount.
+        bool const exempt = features[featureNoRecipientLimit];
         env(pay(gw, bob, USD(9999999)), txflags(tfPartialPayment));
         checkDeliveredAmount.adjCountersPartialPayment();
-        env.require(balance(bob, USD(1000)));
+        env.require(balance(bob, USD(exempt ? 9999999 : 1000)));
 
-        // failed payment
-        env(pay(gw, carol, USD(9999999)), ter(tecPATH_PARTIAL));
-        checkDeliveredAmount.adjCountersFail();
-        env.require(balance(carol, USD(0)));
+        // The issuer is likewise no longer capped by carol's limit.
+        env(pay(gw, carol, USD(9999999)),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_PARTIAL)));
+        if (exempt)
+            checkDeliveredAmount.adjCountersSuccess();
+        else
+            checkDeliveredAmount.adjCountersFail();
+        env.require(balance(carol, USD(exempt ? 9999999 : 0)));
+        //@@end delivered-subscribe-gate
 
         env.close();
         std::string index;
@@ -318,6 +334,10 @@ public:
         FeatureBitset const all{supported_amendments() - featureXahauGenesis};
         testTxDeliveredAmountRPC(all);
         testAccountDeliveredAmountSubscribe(all);
+        //@@start delivered-wiring
+        testTxDeliveredAmountRPC(all - featureNoRecipientLimit);
+        testAccountDeliveredAmountSubscribe(all - featureNoRecipientLimit);
+        //@@end delivered-wiring
     }
 };
 

--- a/src/xrpld/app/paths/Credit.cpp
+++ b/src/xrpld/app/paths/Credit.cpp
@@ -24,6 +24,16 @@
 
 namespace ripple {
 
+//@@start limit-contract
+// Trust line limits are consulted here and in creditLimit2, by the payment
+// engine's direct step, which applies them to intermediary hops and (with
+// featureNoRecipientLimit) not to the issuer's step into the destination.
+// The only other reader is trustTransferLockedBalance, gated the same way.
+// A transactor that credits an account through accountSend or rippleCredit
+// never reads a limit; keep it that way so the invariant "a limit governs an
+// intermediary, never an account receiving its issuer's token" holds for
+// every transaction type without per-transactor exceptions.
+//@@end limit-contract
 STAmount
 creditLimit(
     ReadView const& view,

--- a/src/xrpld/app/paths/Credit.cpp
+++ b/src/xrpld/app/paths/Credit.cpp
@@ -24,7 +24,6 @@
 
 namespace ripple {
 
-//@@start limit-contract
 // Trust line limits are consulted here and in creditLimit2, by the payment
 // engine's direct step, which applies them to intermediary hops and (with
 // featureNoRecipientLimit) not to the issuer's step into the destination.
@@ -33,7 +32,6 @@ namespace ripple {
 // never reads a limit; keep it that way so the invariant "a limit governs an
 // intermediary, never an account receiving its issuer's token" holds for
 // every transaction type without per-transactor exceptions.
-//@@end limit-contract
 STAmount
 creditLimit(
     ReadView const& view,

--- a/src/xrpld/app/paths/detail/DirectStep.cpp
+++ b/src/xrpld/app/paths/detail/DirectStep.cpp
@@ -44,7 +44,6 @@ protected:
     // Charge transfer fees when the prev step redeems
     Step const* const prevStep_ = nullptr;
     bool const isLast_;
-    //@@start issues-to-dst-member
     // This step is the delivered asset's issuer crediting the strand's
     // destination. Not the same as isLast_: the implied issuer-to-destination
     // step after a book or AMM is built without isLast, and isLast_ also
@@ -56,7 +55,6 @@ protected:
     // (its own USD line feeding a USD/EUR book that delivers EUR), and that
     // hop is capped like any intermediary hop.
     bool const issuesToDst_;
-    //@@end issues-to-dst-member
     beast::Journal const j_;
 
     struct Cache
@@ -112,11 +110,9 @@ public:
         , currency_(c)
         , prevStep_(ctx.prevStep)
         , isLast_(ctx.isLast)
-        //@@start issues-to-dst-init
         , issuesToDst_(
               dst == ctx.strandDst && src == ctx.strandDeliver.account &&
               c == ctx.strandDeliver.currency)
-        //@@end issues-to-dst-init
         , j_(ctx.j)
     {
     }
@@ -391,7 +387,6 @@ DirectIOfferCrossingStep::quality(ReadView const&, QualityDirection qDir) const
     return QUALITY_ONE;
 }
 
-//@@start recipient-limit-max-flow
 std::pair<IOUAmount, DebtDirection>
 DirectIPaymentStep::maxFlow(ReadView const& sb, IOUAmount const&) const
 {
@@ -415,9 +410,7 @@ DirectIPaymentStep::maxFlow(ReadView const& sb, IOUAmount const&) const
 
     return {amount, direction};
 }
-//@@end recipient-limit-max-flow
 
-//@@start offer-crossing-precedent
 std::pair<IOUAmount, DebtDirection>
 DirectIOfferCrossingStep::maxFlow(ReadView const& sb, IOUAmount const& desired)
     const
@@ -439,7 +432,6 @@ DirectIOfferCrossingStep::maxFlow(ReadView const& sb, IOUAmount const& desired)
 
     return maxPaymentFlow(sb);
 }
-//@@end offer-crossing-precedent
 
 TER
 DirectIPaymentStep::check(
@@ -481,7 +473,6 @@ DirectIPaymentStep::check(
         }
     }
 
-    //@@start recipient-limit-dry-test
     // The destination's limit does not apply to its issuer's step into it
     // (see maxFlow); a dry test against it would refuse a payment the
     // recipient is allowed to receive.
@@ -499,7 +490,6 @@ DirectIPaymentStep::check(
             }
         }
     }
-    //@@end recipient-limit-dry-test
     return tesSUCCESS;
 }
 
@@ -516,7 +506,6 @@ DirectIOfferCrossingStep::check(
 
 //------------------------------------------------------------------------------
 
-//@@start limit-reader-max-payment-flow
 template <class TDerived>
 std::pair<IOUAmount, DebtDirection>
 DirectStepI<TDerived>::maxPaymentFlow(ReadView const& sb) const
@@ -532,7 +521,6 @@ DirectStepI<TDerived>::maxPaymentFlow(ReadView const& sb) const
         creditLimit2(sb, dst_, src_, currency_) + srcOwed,
         DebtDirection::issues};
 }
-//@@end limit-reader-max-payment-flow
 
 template <class TDerived>
 DebtDirection

--- a/src/xrpld/app/paths/detail/DirectStep.cpp
+++ b/src/xrpld/app/paths/detail/DirectStep.cpp
@@ -44,6 +44,19 @@ protected:
     // Charge transfer fees when the prev step redeems
     Step const* const prevStep_ = nullptr;
     bool const isLast_;
+    //@@start issues-to-dst-member
+    // This step is the delivered asset's issuer crediting the strand's
+    // destination. Not the same as isLast_: the implied issuer-to-destination
+    // step after a book or AMM is built without isLast, and isLast_ also
+    // selects quality semantics. Not any step into the destination either: a
+    // non-issuer crediting the destination is rippling the destination's
+    // acceptance of that account's IOU, which its limit still governs. And
+    // the currency must be the delivered one: the destination can appear
+    // earlier in the same strand as an intermediary in another currency
+    // (its own USD line feeding a USD/EUR book that delivers EUR), and that
+    // hop is capped like any intermediary hop.
+    bool const issuesToDst_;
+    //@@end issues-to-dst-member
     beast::Journal const j_;
 
     struct Cache
@@ -99,6 +112,11 @@ public:
         , currency_(c)
         , prevStep_(ctx.prevStep)
         , isLast_(ctx.isLast)
+        //@@start issues-to-dst-init
+        , issuesToDst_(
+              dst == ctx.strandDst && src == ctx.strandDeliver.account &&
+              c == ctx.strandDeliver.currency)
+        //@@end issues-to-dst-init
         , j_(ctx.j)
     {
     }
@@ -373,12 +391,33 @@ DirectIOfferCrossingStep::quality(ReadView const&, QualityDirection qDir) const
     return QUALITY_ONE;
 }
 
+//@@start recipient-limit-max-flow
 std::pair<IOUAmount, DebtDirection>
 DirectIPaymentStep::maxFlow(ReadView const& sb, IOUAmount const&) const
 {
-    return maxPaymentFlow(sb);
-}
+    auto const [amount, direction] = maxPaymentFlow(sb);
 
+    // A trust line limit governs an account being used as an intermediary,
+    // not an account receiving its issuer's token. The issuer's step into the
+    // strand's destination is not capped by the destination's limit. Only the
+    // issuing direction is capped by a limit; when the source redeems,
+    // `amount` is the source's own balance and stays as the cap.
+    //
+    // The cap is the largest IOU amount rather than `desired`: in the
+    // reverse pass `desired` is the step's output, and a destination
+    // QualityIn below one makes src->dst larger than the output, so an
+    // uncapped step would be reported as limiting and the re-executed
+    // limiting step would never agree with itself.
+    if (issuesToDst_ && issues(direction) &&
+        sb.rules().enabled(featureNoRecipientLimit))
+        return {
+            IOUAmount(STAmount::cMaxValue, STAmount::cMaxOffset), direction};
+
+    return {amount, direction};
+}
+//@@end recipient-limit-max-flow
+
+//@@start offer-crossing-precedent
 std::pair<IOUAmount, DebtDirection>
 DirectIOfferCrossingStep::maxFlow(ReadView const& sb, IOUAmount const& desired)
     const
@@ -400,6 +439,7 @@ DirectIOfferCrossingStep::maxFlow(ReadView const& sb, IOUAmount const& desired)
 
     return maxPaymentFlow(sb);
 }
+//@@end offer-crossing-precedent
 
 TER
 DirectIPaymentStep::check(
@@ -441,6 +481,11 @@ DirectIPaymentStep::check(
         }
     }
 
+    //@@start recipient-limit-dry-test
+    // The destination's limit does not apply to its issuer's step into it
+    // (see maxFlow); a dry test against it would refuse a payment the
+    // recipient is allowed to receive.
+    if (!(issuesToDst_ && ctx.view.rules().enabled(featureNoRecipientLimit)))
     {
         auto const owed = creditBalance(ctx.view, dst_, src_, currency_);
         if (owed <= beast::zero)
@@ -454,6 +499,7 @@ DirectIPaymentStep::check(
             }
         }
     }
+    //@@end recipient-limit-dry-test
     return tesSUCCESS;
 }
 
@@ -470,6 +516,7 @@ DirectIOfferCrossingStep::check(
 
 //------------------------------------------------------------------------------
 
+//@@start limit-reader-max-payment-flow
 template <class TDerived>
 std::pair<IOUAmount, DebtDirection>
 DirectStepI<TDerived>::maxPaymentFlow(ReadView const& sb) const
@@ -485,6 +532,7 @@ DirectStepI<TDerived>::maxPaymentFlow(ReadView const& sb) const
         creditLimit2(sb, dst_, src_, currency_) + srcOwed,
         DebtDirection::issues};
 }
+//@@end limit-reader-max-payment-flow
 
 template <class TDerived>
 DebtDirection

--- a/src/xrpld/app/tx/detail/Remit.cpp
+++ b/src/xrpld/app/tx/detail/Remit.cpp
@@ -562,10 +562,13 @@ Remit::doApply()
             if (availableFunds < srcAmt)
                 return tecUNFUNDED_PAYMENT;
 
+            //@@start remit-persist
             // if the target trustline doesn't exist we need to create it and
             // pay its reserve
-            if (!sb.exists(
-                    keylet::line(dstAccID, issuerAccID, amount.getCurrency())))
+            auto const lineKey =
+                keylet::line(dstAccID, issuerAccID, amount.getCurrency());
+            bool const lineExisted = sb.exists(lineKey);
+            if (!lineExisted)
             {
                 if (nativeRemit + objectReserve < nativeRemit)
                     return tecINTERNAL;
@@ -584,6 +587,23 @@ Remit::doApply()
                     true);
                 !isTesSuccess(result))
                 return result;
+
+            // A line this remit created was never configured by the
+            // destination. Mark the destination's side as persisting so the
+            // line survives a zero balance until the destination clears it.
+            if (!lineExisted && sb.rules().enabled(featureNoRecipientLimit))
+            {
+                if (auto const sleLine = sb.peek(lineKey))
+                {
+                    bool const dstHigh = dstAccID > issuerAccID;
+                    sleLine->setFieldU32(
+                        sfFlags,
+                        sleLine->getFieldU32(sfFlags) |
+                            (dstHigh ? lsfHighPersist : lsfLowPersist));
+                    sb.update(sleLine);
+                }
+            }
+            //@@end remit-persist
         }
     }
 

--- a/src/xrpld/app/tx/detail/Remit.cpp
+++ b/src/xrpld/app/tx/detail/Remit.cpp
@@ -562,7 +562,6 @@ Remit::doApply()
             if (availableFunds < srcAmt)
                 return tecUNFUNDED_PAYMENT;
 
-            //@@start remit-persist
             // if the target trustline doesn't exist we need to create it and
             // pay its reserve
             auto const lineKey =
@@ -603,7 +602,6 @@ Remit::doApply()
                     sb.update(sleLine);
                 }
             }
-            //@@end remit-persist
         }
     }
 

--- a/src/xrpld/app/tx/detail/SetTrust.cpp
+++ b/src/xrpld/app/tx/detail/SetTrust.cpp
@@ -91,6 +91,18 @@ SetTrust::preflight(PreflightContext const& ctx)
         }
     }
 
+    //@@start persist-preflight
+    if (uTxFlags & (tfSetPersist | tfClearPersist))
+    {
+        // Persist flags are valid only under the amendment, and not both.
+        if (!ctx.rules.enabled(featureNoRecipientLimit) ||
+            ((uTxFlags & tfSetPersist) && (uTxFlags & tfClearPersist)))
+        {
+            return temINVALID_FLAG;
+        }
+    }
+    //@@end persist-preflight
+
     STAmount const saLimitAmount(tx.getFieldAmount(sfLimitAmount));
 
     if (!isLegalNet(saLimitAmount))
@@ -342,6 +354,10 @@ SetTrust::doApply()
     bool const bClearFreeze = (uTxFlags & tfClearFreeze);
     bool const bSetDeepFreeze = (uTxFlags & tfSetDeepFreeze);
     bool const bClearDeepFreeze = (uTxFlags & tfClearDeepFreeze);
+    //@@start persist-flags
+    bool const bSetPersist = (uTxFlags & tfSetPersist);
+    bool const bClearPersist = (uTxFlags & tfClearPersist);
+    //@@end persist-flags
 
     auto viewJ = ctx_.app.journal("View");
 
@@ -508,6 +524,13 @@ SetTrust::doApply()
             uFlagsOut &= ~(bHigh ? lsfHighNoRipple : lsfLowNoRipple);
         }
 
+        //@@start persist-set-clear
+        if (bSetPersist)
+            uFlagsOut |= (bHigh ? lsfHighPersist : lsfLowPersist);
+        else if (bClearPersist)
+            uFlagsOut &= ~(bHigh ? lsfHighPersist : lsfLowPersist);
+        //@@end persist-set-clear
+
         // Have to use lsfNoFreeze to maintain pre-deep freeze behavior
         bool const bNoFreeze = sle->isFlag(lsfNoFreeze);
         uFlagsOut = computeFreezeFlags(
@@ -529,19 +552,21 @@ SetTrust::doApply()
         bool const bHighDefRipple =
             sleHighAccount->getFlags() & lsfDefaultRipple;
 
+        //@@start persist-reserve
         bool const bLowReserveSet = uLowQualityIn || uLowQualityOut ||
             ((uFlagsOut & lsfLowNoRipple) == 0) != bLowDefRipple ||
-            (uFlagsOut & lsfLowFreeze) || saLowLimit ||
-            saLowBalance > beast::zero;
+            (uFlagsOut & lsfLowFreeze) || (uFlagsOut & lsfLowPersist) ||
+            saLowLimit || saLowBalance > beast::zero;
         bool const bLowReserveClear = !bLowReserveSet;
 
         bool const bHighReserveSet = uHighQualityIn || uHighQualityOut ||
             ((uFlagsOut & lsfHighNoRipple) == 0) != bHighDefRipple ||
-            (uFlagsOut & lsfHighFreeze) || saHighLimit ||
-            saHighBalance > beast::zero;
+            (uFlagsOut & lsfHighFreeze) || (uFlagsOut & lsfHighPersist) ||
+            saHighLimit || saHighBalance > beast::zero;
         bool const bHighReserveClear = !bHighReserveSet;
 
         bool const bDefault = bLowReserveClear && bHighReserveClear;
+        //@@end persist-reserve
 
         bool const bLowReserved = (uFlagsIn & lsfLowReserve);
         bool const bHighReserved = (uFlagsIn & lsfHighReserve);
@@ -614,6 +639,7 @@ SetTrust::doApply()
             JLOG(j_.trace()) << "Modify ripple line";
         }
     }
+    //@@start persist-not-redundant
     // Line does not exist.
     else if (
         !saLimitAmount &&                  // Setting default limit.
@@ -621,12 +647,13 @@ SetTrust::doApply()
                                            // setting default quality in.
         (!bQualityOut || !uQualityOut) &&  // Not setting quality out or
                                            // setting default quality out.
-        (!bSetAuth))
+        (!bSetAuth) && (!bSetPersist))     // Not asking the line to persist.
     {
         JLOG(j_.trace())
             << "Redundant: Setting non-existent ripple line to defaults.";
         return tecNO_LINE_REDUNDANT;
     }
+    //@@end persist-not-redundant
     else if (mPriorBalance < reserveCreate)  // Reserve is not scaled by load.
     {
         JLOG(j_.trace()) << "Delay transaction: Line does not exist. "
@@ -663,6 +690,20 @@ SetTrust::doApply()
             uQualityIn,
             uQualityOut,
             viewJ);
+
+        //@@start persist-create
+        if (isTesSuccess(terResult) && bSetPersist)
+        {
+            if (auto const sleLine = view().peek(k))
+            {
+                sleLine->setFieldU32(
+                    sfFlags,
+                    sleLine->getFieldU32(sfFlags) |
+                        (bHigh ? lsfHighPersist : lsfLowPersist));
+                view().update(sleLine);
+            }
+        }
+        //@@end persist-create
     }
 
     return terResult;

--- a/src/xrpld/app/tx/detail/SetTrust.cpp
+++ b/src/xrpld/app/tx/detail/SetTrust.cpp
@@ -91,7 +91,6 @@ SetTrust::preflight(PreflightContext const& ctx)
         }
     }
 
-    //@@start persist-preflight
     if (uTxFlags & (tfSetPersist | tfClearPersist))
     {
         // Persist flags are valid only under the amendment, and not both.
@@ -101,7 +100,6 @@ SetTrust::preflight(PreflightContext const& ctx)
             return temINVALID_FLAG;
         }
     }
-    //@@end persist-preflight
 
     STAmount const saLimitAmount(tx.getFieldAmount(sfLimitAmount));
 
@@ -354,10 +352,8 @@ SetTrust::doApply()
     bool const bClearFreeze = (uTxFlags & tfClearFreeze);
     bool const bSetDeepFreeze = (uTxFlags & tfSetDeepFreeze);
     bool const bClearDeepFreeze = (uTxFlags & tfClearDeepFreeze);
-    //@@start persist-flags
     bool const bSetPersist = (uTxFlags & tfSetPersist);
     bool const bClearPersist = (uTxFlags & tfClearPersist);
-    //@@end persist-flags
 
     auto viewJ = ctx_.app.journal("View");
 
@@ -524,12 +520,10 @@ SetTrust::doApply()
             uFlagsOut &= ~(bHigh ? lsfHighNoRipple : lsfLowNoRipple);
         }
 
-        //@@start persist-set-clear
         if (bSetPersist)
             uFlagsOut |= (bHigh ? lsfHighPersist : lsfLowPersist);
         else if (bClearPersist)
             uFlagsOut &= ~(bHigh ? lsfHighPersist : lsfLowPersist);
-        //@@end persist-set-clear
 
         // Have to use lsfNoFreeze to maintain pre-deep freeze behavior
         bool const bNoFreeze = sle->isFlag(lsfNoFreeze);
@@ -552,7 +546,6 @@ SetTrust::doApply()
         bool const bHighDefRipple =
             sleHighAccount->getFlags() & lsfDefaultRipple;
 
-        //@@start persist-reserve
         bool const bLowReserveSet = uLowQualityIn || uLowQualityOut ||
             ((uFlagsOut & lsfLowNoRipple) == 0) != bLowDefRipple ||
             (uFlagsOut & lsfLowFreeze) || (uFlagsOut & lsfLowPersist) ||
@@ -566,7 +559,6 @@ SetTrust::doApply()
         bool const bHighReserveClear = !bHighReserveSet;
 
         bool const bDefault = bLowReserveClear && bHighReserveClear;
-        //@@end persist-reserve
 
         bool const bLowReserved = (uFlagsIn & lsfLowReserve);
         bool const bHighReserved = (uFlagsIn & lsfHighReserve);
@@ -639,7 +631,6 @@ SetTrust::doApply()
             JLOG(j_.trace()) << "Modify ripple line";
         }
     }
-    //@@start persist-not-redundant
     // Line does not exist.
     else if (
         !saLimitAmount &&                  // Setting default limit.
@@ -653,7 +644,6 @@ SetTrust::doApply()
             << "Redundant: Setting non-existent ripple line to defaults.";
         return tecNO_LINE_REDUNDANT;
     }
-    //@@end persist-not-redundant
     else if (mPriorBalance < reserveCreate)  // Reserve is not scaled by load.
     {
         JLOG(j_.trace()) << "Delay transaction: Line does not exist. "
@@ -691,7 +681,6 @@ SetTrust::doApply()
             uQualityOut,
             viewJ);
 
-        //@@start persist-create
         if (isTesSuccess(terResult) && bSetPersist)
         {
             if (auto const sleLine = view().peek(k))
@@ -703,7 +692,6 @@ SetTrust::doApply()
                 view().update(sleLine);
             }
         }
-        //@@end persist-create
     }
 
     return terResult;

--- a/src/xrpld/ledger/View.h
+++ b/src/xrpld/ledger/View.h
@@ -1135,9 +1135,11 @@ trustTransferLockedBalance(
             // dest trust line does exist
             // checked NoRipple and Freeze flags in trustTransferAllowed
 
+            //@@start locked-balance-limit-read
             // check the limit
             STAmount dstLimit = dstHigh ? (*sleDstLine)[sfHighLimit]
                                         : (*sleDstLine)[sfLowLimit];
+            //@@end locked-balance-limit-read
 
             // get prior balance
             STAmount priorBalance = dstHigh ? -((*sleDstLine)[sfBalance])
@@ -1154,15 +1156,19 @@ trustTransferLockedBalance(
                 return tecINTERNAL;
             }
 
+            //@@start locked-balance-limit
             // if final is more than dest limit and tx acct is not dest acct -
-            // fail
-            if (finalBalance > dstLimit && actingAccID != dstAccID)
+            // fail. Under NoRecipientLimit a limit never governs the account
+            // receiving, whoever finishes the instrument.
+            if (finalBalance > dstLimit && actingAccID != dstAccID &&
+                !view.rules().enabled(featureNoRecipientLimit))
             {
                 JLOG(j.trace())
                     << "trustTransferLockedBalance would increase dest "
                        "line above limit without permission";
                 return tecPATH_DRY;
             }
+            //@@end locked-balance-limit
 
             // if there is significant precision loss - fail
             if (!isAddable(priorBalance, dstAmt))

--- a/src/xrpld/ledger/View.h
+++ b/src/xrpld/ledger/View.h
@@ -1135,11 +1135,9 @@ trustTransferLockedBalance(
             // dest trust line does exist
             // checked NoRipple and Freeze flags in trustTransferAllowed
 
-            //@@start locked-balance-limit-read
             // check the limit
             STAmount dstLimit = dstHigh ? (*sleDstLine)[sfHighLimit]
                                         : (*sleDstLine)[sfLowLimit];
-            //@@end locked-balance-limit-read
 
             // get prior balance
             STAmount priorBalance = dstHigh ? -((*sleDstLine)[sfBalance])
@@ -1156,7 +1154,6 @@ trustTransferLockedBalance(
                 return tecINTERNAL;
             }
 
-            //@@start locked-balance-limit
             // if final is more than dest limit and tx acct is not dest acct -
             // fail. Under NoRecipientLimit a limit never governs the account
             // receiving, whoever finishes the instrument.
@@ -1168,7 +1165,6 @@ trustTransferLockedBalance(
                        "line above limit without permission";
                 return tecPATH_DRY;
             }
-            //@@end locked-balance-limit
 
             // if there is significant precision loss - fail
             if (!isAddable(priorBalance, dstAmt))

--- a/src/xrpld/ledger/detail/View.cpp
+++ b/src/xrpld/ledger/detail/View.cpp
@@ -1125,7 +1125,6 @@ isTrustDefault(
 
     uint32_t const acFlags = line->getFieldU32(sfFlags);
 
-    //@@start persist-default
     const auto fNoRipple{high ? lsfHighNoRipple : lsfLowNoRipple};
     const auto fFreeze{high ? lsfHighFreeze : lsfLowFreeze};
     const auto fPersist{high ? lsfHighPersist : lsfLowPersist};
@@ -1136,7 +1135,6 @@ isTrustDefault(
     // A persisting side keeps its claim on the line at zero balance.
     if (tlFlags & fPersist)
         return false;
-    //@@end persist-default
 
     if ((acFlags & lsfDefaultRipple) && (tlFlags & fNoRipple))
         return false;
@@ -1262,7 +1260,6 @@ rippleCreditIOU(
 
         // FIXME This NEEDS to be cleaned up and simplified. It's impossible
         //       for anyone to understand.
-        //@@start persist-credit-delete
         if (saBefore > beast::zero
             // Sender balance was positive.
             && saBalance <= beast::zero
@@ -1287,7 +1284,6 @@ rippleCreditIOU(
             && !sleRippleState->getFieldU32(
                    !bSenderHigh ? sfLowQualityOut : sfHighQualityOut))
         // Sender quality out is 0.
-        //@@end persist-credit-delete
         {
             // Clear the reserve of the sender, possibly delete the line!
             adjustOwnerCount(
@@ -1750,7 +1746,6 @@ updateTrustLine(
         return false;
 
     // YYY Could skip this if rippling in reverse.
-    //@@start persist-update-delete
     if (before > beast::zero
         // Sender balance was positive.
         && after <= beast::zero
@@ -1770,7 +1765,6 @@ updateTrustLine(
         &&
         !state->getFieldU32(!bSenderHigh ? sfLowQualityOut : sfHighQualityOut))
     // Sender quality out is 0.
-    //@@end persist-update-delete
     {
         // VFALCO Where is the line being deleted?
         // Clear the reserve of the sender, possibly delete the line!

--- a/src/xrpld/ledger/detail/View.cpp
+++ b/src/xrpld/ledger/detail/View.cpp
@@ -1125,11 +1125,18 @@ isTrustDefault(
 
     uint32_t const acFlags = line->getFieldU32(sfFlags);
 
+    //@@start persist-default
     const auto fNoRipple{high ? lsfHighNoRipple : lsfLowNoRipple};
     const auto fFreeze{high ? lsfHighFreeze : lsfLowFreeze};
+    const auto fPersist{high ? lsfHighPersist : lsfLowPersist};
 
     if (tlFlags & fFreeze)
         return false;
+
+    // A persisting side keeps its claim on the line at zero balance.
+    if (tlFlags & fPersist)
+        return false;
+    //@@end persist-default
 
     if ((acFlags & lsfDefaultRipple) && (tlFlags & fNoRipple))
         return false;
@@ -1255,6 +1262,7 @@ rippleCreditIOU(
 
         // FIXME This NEEDS to be cleaned up and simplified. It's impossible
         //       for anyone to understand.
+        //@@start persist-credit-delete
         if (saBefore > beast::zero
             // Sender balance was positive.
             && saBalance <= beast::zero
@@ -1268,6 +1276,8 @@ rippleCreditIOU(
                     view.read(keylet::account(uSenderID))->getFlags() &
                     lsfDefaultRipple) &&
             !(uFlags & (!bSenderHigh ? lsfLowFreeze : lsfHighFreeze)) &&
+            // Sender does not persist the line.
+            !(uFlags & (!bSenderHigh ? lsfLowPersist : lsfHighPersist)) &&
             !sleRippleState->getFieldAmount(
                 !bSenderHigh ? sfLowLimit : sfHighLimit)
             // Sender trust limit is 0.
@@ -1277,6 +1287,7 @@ rippleCreditIOU(
             && !sleRippleState->getFieldU32(
                    !bSenderHigh ? sfLowQualityOut : sfHighQualityOut))
         // Sender quality out is 0.
+        //@@end persist-credit-delete
         {
             // Clear the reserve of the sender, possibly delete the line!
             adjustOwnerCount(
@@ -1739,6 +1750,7 @@ updateTrustLine(
         return false;
 
     // YYY Could skip this if rippling in reverse.
+    //@@start persist-update-delete
     if (before > beast::zero
         // Sender balance was positive.
         && after <= beast::zero
@@ -1749,6 +1761,8 @@ updateTrustLine(
                flags & (!bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple)) !=
             static_cast<bool>(sle->getFlags() & lsfDefaultRipple) &&
         !(flags & (!bSenderHigh ? lsfLowFreeze : lsfHighFreeze)) &&
+        // Sender does not persist the line.
+        !(flags & (!bSenderHigh ? lsfLowPersist : lsfHighPersist)) &&
         !state->getFieldAmount(!bSenderHigh ? sfLowLimit : sfHighLimit)
         // Sender trust limit is 0.
         && !state->getFieldU32(!bSenderHigh ? sfLowQualityIn : sfHighQualityIn)
@@ -1756,6 +1770,7 @@ updateTrustLine(
         &&
         !state->getFieldU32(!bSenderHigh ? sfLowQualityOut : sfHighQualityOut))
     // Sender quality out is 0.
+    //@@end persist-update-delete
     {
         // VFALCO Where is the line being deleted?
         // Clear the reserve of the sender, possibly delete the line!


### PR DESCRIPTION
Today a Payment can fail because the recipient has reached its trust-line limit, even though Remit already lets that limit be exceeded.

This change lets an account receive more of the named issuer's token on an existing trust line, whoever pays: the exempt step is the issuer's credit into the destination, and a holder's payment that ripples through the issuer ends with that same step. Limits still apply to accounts used as intermediaries along the payment path. Funds, authorization and freeze checks are unchanged.

A companion change keeps Remit-created trust lines when their balance returns to zero, retaining their owner reserve.

## Scope

Against `c208a40ce`: 125 source lines added, 13 removed, across 11 files; 499 test lines added, 53 removed, across 9 files.

Of the 125 added source lines, **77 are code**, 41 are comments and 7 are blank.

| Area | Files | Lines |
|---|---|---|
| Engine exemption | `DirectStep.cpp`, `Credit.cpp`, `View.h` | +49 / -3 |
| Persist flag | `SetTrust.cpp`, `View.cpp`, `Remit.cpp` | +63 / -7 |
| Protocol: flags, amendment, hook headers | `LedgerFormats.h`, `TxFlags.h`, `features.macro`, `hook/*.h` | +13 / -3 |
| New tests | `Flow_test`, `SetTrust_test`, `Remit_test` | +374 / -11 |
| Gates on existing tests | `Check`, `PayChan`, `Path`, `TrustAndBalance`, `URIToken`, `DeliveredAmount` | +125 / -42 |

## The invariant

A trust-line limit governs an account being used as an intermediary, never an account receiving its issuer's token. The issuer's credit into a transaction's destination ignores the recipient's limit. A hop through a third account inside a payment path obeys that account's limit, because that account is lending its balance sheet to someone else's payment. A non-issuer crediting the destination directly still obeys the destination's limit on that account: the limit is the destination's acceptance of that account's IOU, not a cap on the token it asked for. The same rule keeps a sender from over-redeeming to the issuer by issuing its own IOU on the way out.

Several transfer paths already allow receipt above a trust-line limit: Remit, offer crossing, NFT and URIToken sales, AMM operations, and checks under `CheckCashMakesTrustLine`. This amendment changes the two places still enforcing it: the payment engine's issuer-to-recipient step, and token escrow and payment-channel settlement when someone other than the destination finishes the transfer.

## The one exception

After the amendment, a limit is enforced on a line whose owner is the *recipient* in exactly one case:

| Exception | Example | Why |
|---|---|---|
| The credit is another account's IOU, not the issuer named in the payment | Payment names carol's USD, path ends bob → carol on carol's line with bob: carol's limit on bob still caps it. Same when alice pays gw more USD than she holds: the shortfall would be alice's own IOU onto gw, and gw's limit (0) refuses it. | Your limit on a peer is your acceptance of *that peer's* IOU. You asked for the issuer's token, not theirs. |

Everything else where you are the recipient ignores the limit. Advisory only, not enforcement: `path_find` and `account_currencies` still treat a full line as uncreditable.

## More to think about

- **Clearing the persist bit.** Xaman's remove-token flow sends a TrustSet with limit 0 and the freeze/NoRipple flags ([TokenSettingsOverlay.tsx](https://github.com/XRPL-Labs/Xaman-App/blob/01e2538b08ef/src/screens/Overlay/TokenSettings/TokenSettingsOverlay.tsx#L408-L431)). On a Remit-created line that TrustSet no longer deletes the line, and a persisting line also blocks AccountDelete. One way out: any TrustSet from a side clears that side's persist bit unless it sets `tfSetPersist`, and `tfClearPersist` goes away.
- **Who can reach the exempt step.** Any payer whose strand ends with the issuer's step, which includes a holder rippling through a DefaultRipple gateway. Remit already allows the same. The narrower option is issuer-signed payments only, a one-line predicate change.
- **The name.** `NoRecipientLimit` is a placeholder.
- **Not in this PR.** The pathfinder and `account_currencies` still treat a full destination line as uncreditable, `account_lines` does not report persist, and persist does not veto AMM trust-line teardown.
- **You can't stop your issuer paying you, except by removing the line.** Payment has no "disallow incoming" flag like Remit does. DepositAuth works, but it blocks everything. And if you remove the line, a Remit can put it right back unless you set `DisallowIncomingRemit`.
- **Remit can give you a line; persist makes it stay.** That was already true for the line and its reserve. Now it stays after you spend to zero, until you clear it. The clearing question above decides how easy that is.
- **Payment still doesn't create lines.** Remit already does that job. Payment could too, but it means picking a reserve rule (Remit charges the sender; CashCheck uses the casher's own) and a fair bit more code, so it stays out of this change.
- **One amendment or two?** The engine change and the persist flag could be voted on separately.
- **Wallets won't notice yet.** Xaman checks the recipient's limit itself before sending and pushes you to Remit. Nothing changes for users until the app skips that check for issuer payments.
- **One bit of dead weight later.** `CheckCashMakesTrustLine` raises the casher's limit around the engine. Once this is on, it doesn't need to.

## How Xaman handles this today

When you send a token, Xaman checks the recipient's trust line before it builds anything ([RecipientStep.tsx#L748-L865](https://github.com/XRPL-Labs/Xaman-App/blob/01e2538b08ef/src/screens/Send/Steps/Recipient/RecipientStep.tsx#L748-L865)):

- Skipped when sending a token back to its issuer, e.g. depositing to Bitstamp.
- Otherwise it fetches the recipient's line with the issuer ([LedgerService.ts#L593](https://github.com/XRPL-Labs/Xaman-App/blob/01e2538b08ef/src/services/LedgerService.ts#L593)) and refuses if:
  - there is **no line** (missing, or default 0 limit/balance), or
  - the amount plus the current balance would go over the **limit** ([L775-L778](https://github.com/XRPL-Labs/Xaman-App/blob/01e2538b08ef/src/screens/Send/Steps/Recipient/RecipientStep.tsx#L775-L778)).

On Xahau, the Payment refusal due to a missing or non-supporting line comes with an offer: "Do you want to send your payment as a 'Remit' transaction instead? This will automatically create the Trustline in the recipient's account, but you will pay an extra 0.2 XAH to satisfy their TrustLine reserve" ([en.json#L1219](https://github.com/XRPL-Labs/Xaman-App/blob/01e2538b08ef/src/locale/en.json#L1219)).

Xaman would simply need to update to remove the limit check, as the limit is only applied to intermediaries, not an end recipient. Remit retains its job as the way to pay someone who has no line yet.

## Recipient limit by transaction, before and after

IOU trust-line credits only. "Enforced" means the recipient's limit capped or refused the credit.

| Transaction delivering a token | Before | After |
|---|---|---|
| Payment, issuer's hop into the recipient (direct, holder to holder via the issuer, DEX book then the implied issuer hop) | enforced | ignored |
| Payment, last hop on another account's line (path names the recipient's own currency) | enforced | enforced |
| Payment, recipient used as an intermediary earlier in the same strand | enforced | enforced |
| EscrowFinish / PayChanClaim (IOU), finished by the recipient | ignored | ignored |
| EscrowFinish / PayChanClaim (IOU), finished by anyone else | enforced | ignored |
| CheckCash, `CheckCashMakesTrustLine` on (Xahau today) | ignored | ignored |
| CheckCash, `CheckCashMakesTrustLine` off | enforced | ignored |
| Remit | ignored | ignored |
| NFTokenAcceptOffer (sale, broker fee, issuer transfer fee) | ignored | ignored |
| URIToken buy (sale proceeds to the seller) | ignored | ignored |
| OfferCreate (taker's receipt) | ignored | ignored |
| AMM create / deposit / withdraw / bid, and AMMClawback's withdrawal credit (`AMM` is `Supported::no`) | ignored | ignored |
| XChainBridge IOU claims and commits into a locking door (`Supported::no`) | as Payment | as Payment |
| Clawback / AMMClawback debit; Import, GenesisMint, ClaimReward, MPT | n/a | n/a |
