### PR TITLE
feat: NoRecipientLimit-aware receive_currencies and destination_currencies

### DIFF
--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -1458,6 +1458,22 @@ struct Flow_test : public beast::unit_test::suite
             env.require(balance(bob, exempt ? USD(150) : USD(0)));
         }
         {
+            // Holder pays holder through the issuer while the recipient's
+            // line is exactly full.
+            Env env(*this, features);
+            env.fund(XRP(10000), gw, alice, bob);
+            env.trust(USD(1000), alice);
+            env.trust(USD(100), bob);
+            env(pay(gw, alice, USD(500)));
+            env(pay(gw, bob, USD(100)));
+            env(pay(alice, bob, USD(5)),
+                paths(USD),
+                ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
+            env(pay(alice, bob, USD(5)),
+                ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
+            env.require(balance(bob, exempt ? USD(110) : USD(100)));
+        }
+        {
             // Cross-currency: the last direct step follows a book step.
             Env env(*this, features);
             env.fund(XRP(10000), gw, alice, bob, carol);

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -373,6 +373,48 @@ public:
     }
 
     void
+    path_find_recipient_limit(FeatureBitset features)
+    {
+        // bob's line is at its limit. A payment that names the issuer
+        // reaches bob on the default path (alice -> gw -> bob); the
+        // pathfinder stops at the named issuer and never reads bob's limit,
+        // and the engine's liquidity check decides. So there is nothing to
+        // propose in either regime, and the request that names bob as
+        // issuer (any issuer) stays capped by design.
+        testcase("path find: destination at its limit");
+        using namespace jtx;
+        bool const exempt = features[featureNoRecipientLimit];
+        Env env = pathTestEnv(features);
+        auto const gw = Account("gateway");
+        auto const USD = gw["USD"];
+        env.fund(XRP(10000), "alice", "bob", gw);
+        env.close();
+        env.trust(USD(600), "alice");
+        env.trust(USD(100), "bob");
+        env.close();
+        env(pay(gw, "alice", USD(70)));
+        env(pay(gw, "bob", USD(100)));
+        env.close();
+
+        STPathSet st;
+        STAmount sa;
+        std::tie(st, sa, std::ignore) = find_paths(env, "alice", "bob", USD(5));
+        BEAST_EXPECT(st.empty());
+        std::tie(st, sa, std::ignore) =
+            find_paths(env, "alice", "bob", Account("bob")["USD"](5));
+        BEAST_EXPECT(st.empty());
+        // The payment itself succeeds only with the amendment, on the
+        // default path and with an explicit one.
+        env(pay("alice", "bob", USD(5)),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
+        env(pay("alice", "bob", USD(5)),
+            paths(USD),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
+        env(pay(gw, "bob", USD(5)),
+            ter(exempt ? TER(tesSUCCESS) : TER(tecPATH_DRY)));
+    }
+
+    void
     path_find()
     {
         testcase("path find");
@@ -1535,6 +1577,9 @@ public:
         alternative_paths_limit_returned_paths_to_best_quality();
         issues_path_negative_issue(jtx::supported_amendments());
         issues_path_negative_issue(
+            jtx::supported_amendments() - featureNoRecipientLimit);
+        path_find_recipient_limit(jtx::supported_amendments());
+        path_find_recipient_limit(
             jtx::supported_amendments() - featureNoRecipientLimit);
         issues_path_negative_ripple_client_issue_23_smaller();
         issues_path_negative_ripple_client_issue_23_larger();

--- a/src/test/rpc/AccountCurrencies_test.cpp
+++ b/src/test/rpc/AccountCurrencies_test.cpp
@@ -19,6 +19,7 @@
 
 #include <test/jtx.h>
 #include <xrpl/beast/unit_test.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/jss.h>
 
 namespace ripple {
@@ -138,12 +139,15 @@ class AccountCurrencies_test : public beast::unit_test::suite
     }
 
     void
-    testBasic()
+    testBasic(FeatureBitset features)
     {
         testcase("Basic request for account_currencies");
 
         using namespace test::jtx;
-        Env env{*this};
+        Env env{*this, features};
+        // Under NoRecipientLimit a full line can still receive from its
+        // issuer, so it stays in receive_currencies.
+        bool const exempt = features[featureNoRecipientLimit];
 
         auto const alice = Account{"alice"};
         auto const gw = Account{"gateway"};
@@ -219,7 +223,9 @@ class AccountCurrencies_test : public beast::unit_test::suite
             boost::lexical_cast<std::string>(params))[jss::result];
         decltype(gwCurrencies) gwCurrenciesNoUSA(
             gwCurrencies.begin() + 1, gwCurrencies.end());
-        BEAST_EXPECT(arrayCheck(jss::receive_currencies, gwCurrenciesNoUSA));
+        BEAST_EXPECT(arrayCheck(
+            jss::receive_currencies,
+            exempt ? gwCurrencies : gwCurrenciesNoUSA));
         BEAST_EXPECT(arrayCheck(jss::send_currencies, gwCurrencies));
 
         // add trust from gw to alice and then exhaust that trust line
@@ -238,8 +244,10 @@ public:
     void
     run() override
     {
+        using namespace test::jtx;
         testBadInput();
-        testBasic();
+        testBasic(supported_amendments());
+        testBasic(supported_amendments() - featureNoRecipientLimit);
     }
 };
 

--- a/src/xrpld/app/paths/AccountCurrencies.cpp
+++ b/src/xrpld/app/paths/AccountCurrencies.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <xrpld/app/paths/AccountCurrencies.h>
+#include <xrpl/protocol/Feature.h>
 
 namespace ripple {
 
@@ -69,6 +70,12 @@ accountDestCurrencies(
         currencies.insert(xrpCurrency());
     // Even if account doesn't exist
 
+    // Under NoRecipientLimit the issuer can always pay onto a line, and
+    // redemption was never bound by the limit, so every line's currency is
+    // receivable.
+    bool const noRecipientLimit =
+        lrCache->getLedger()->rules().enabled(featureNoRecipientLimit);
+
     if (auto const lines =
             lrCache->getRippleLines(account, LineDirection::outgoing))
     {
@@ -76,7 +83,8 @@ accountDestCurrencies(
         {
             auto& saBalance = rspEntry.getBalance();
 
-            if (saBalance < rspEntry.getLimit())  // Can take more
+            if (noRecipientLimit ||
+                saBalance < rspEntry.getLimit())  // Can take more
                 currencies.insert(saBalance.getCurrency());
         }
     }

--- a/src/xrpld/rpc/handlers/AccountCurrenciesHandler.cpp
+++ b/src/xrpld/rpc/handlers/AccountCurrenciesHandler.cpp
@@ -23,6 +23,7 @@
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/detail/RPCHelpers.h>
 #include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/RPCErr.h>
 #include <xrpl/protocol/jss.h>
 
@@ -68,12 +69,18 @@ doAccountCurrencies(RPC::JsonContext& context)
     if (!ledger->exists(keylet::account(accountID)))
         return rpcError(rpcACT_NOT_FOUND);
 
+    // Under NoRecipientLimit the issuer can always pay onto a line, and
+    // redemption was never bound by the limit, so every line's currency is
+    // receivable.
+    bool const noRecipientLimit =
+        ledger->rules().enabled(featureNoRecipientLimit);
+
     std::set<Currency> send, receive;
     for (auto const& rspEntry : RPCTrustLine::getItems(accountID, *ledger))
     {
         STAmount const& saBalance = rspEntry.getBalance();
 
-        if (saBalance < rspEntry.getLimit())
+        if (noRecipientLimit || saBalance < rspEntry.getLimit())
             receive.insert(saBalance.getCurrency());
         if ((-saBalance) < rspEntry.getLimitPeer())
             send.insert(saBalance.getCurrency());


### PR DESCRIPTION
Stacked on #806 (base branch `recipient-limit-invariant`); merge that first.

Under `NoRecipientLimit` the issuer can always pay onto a trust line, and redemption was never bound by the limit, so a full line's currency is still receivable. Two RPC-side lists said otherwise:

- `destination_currencies` in `path_find` / `ripple_path_find` (`accountDestCurrencies`)
- `account_currencies` → `receive_currencies` (the handler's own loop)

Both now list every line's currency when the amendment is enabled on the ledger. No consensus change.

The pathfinder itself needs no change: a request that names the issuer stops at the issuer and the engine's liquidity check decides the final hop, so the payment goes on the default path and there is nothing to propose. A request naming the destination as issuer ("any issuer") is the non-issuer last hop that #806 keeps capped, and the pathfinder already agrees.

Tests: `Path_test::path_find_recipient_limit` (nothing proposed in either regime; the payment succeeds only with the amendment, default and explicit path), `AccountCurrencies_test` with the amendment on and off, and a Flow control for a holder paying a holder through the issuer onto a full line.
